### PR TITLE
Remove EEXIST handling from __ni_nl_talk

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -498,8 +498,6 @@ __ni_nl_talk(ni_netlink_t *nl, struct nl_msg *msg,
 	do {
 		if ((err = nl_recvmsgs(handle, cb)) < 0) {
 			ni_error("%s: recv failed: %s", __func__, nl_geterror());
-			if (err == -EEXIST)
-				err = 0;
 			break;
 		}
 	} while (ack == 0);


### PR DESCRIPTION
It was supposed to surpress an error if an ipv6 loopback route was set again, the ipv4 code already set also the ipv6 route.
Leave the handling of nl_recvmsgs errors to callers.
