### PR TITLE
dhcp6: fixed to accept low preference server offers

### DIFF
--- a/dhcp6/dhcp6.h
+++ b/dhcp6/dhcp6.h
@@ -169,7 +169,6 @@ struct ni_dhcp6_device {
 
 	struct {
 	    uint32_t		xid;
-	    unsigned int	accept_any_offer : 1;
 	} dhcp6;
 	ni_buffer_t		message;
 


### PR DESCRIPTION
We wait until retransmit timeout before we accept
offers from low preference servers.
We may make it configurable how long to wait later.
