### PR TITLE
socket: handle hangup after input but before output

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -207,13 +207,6 @@ ni_socket_wait(long timeout)
 			goto done_with_this_socket;
 		}
 
-		if (pfd[i].revents & POLLHUP) {
-			if (sock->handle_hangup)
-				sock->handle_hangup(sock);
-			if (sock->__fd < 0)
-				goto done_with_this_socket;
-		}
-
 		if (pfd[i].revents & POLLIN) {
 			if (sock->receive == NULL) {
 				ni_error("socket %d has no receive callback", sock->__fd);
@@ -221,7 +214,16 @@ ni_socket_wait(long timeout)
 			} else {
 				sock->receive(sock);
 			}
+			if (sock->__fd < 0)
+				goto done_with_this_socket;
 		}
+
+		if (pfd[i].revents & POLLHUP) {
+			if (sock->handle_hangup)
+				sock->handle_hangup(sock);
+			if (sock->__fd < 0)
+				goto done_with_this_socket;
+		} else
 
 		if (pfd[i].revents & POLLOUT) {
 			if (sock->transmit == NULL) {


### PR DESCRIPTION
poll may return POLLIN|POLLHUP and wicked didn't read the last data chunk then
