### PR TITLE
nanny: Enable nanny by default

### DIFF
--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -13,6 +13,6 @@ ExecStart=@wicked_sbindir@/wickedd-nanny $WICKED_DEBUG_PARAM --foreground
 StandardError=null
 
 [Install]
-#WantedBy=wickedd.service
+WantedBy=wickedd.service
 Alias=dbus-org.opensuse.Network.Nanny.service
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -13,6 +13,7 @@ StandardError=null
 
 [Install]
 WantedBy=wicked.service
+Also=wickedd-nanny.service
 Also=wickedd-auto4.service
 Also=wickedd-dhcp4.service
 Also=wickedd-dhcp6.service


### PR DESCRIPTION
Let's have nanny enable by default

Side note:
I am currently working on a patch fixing, tweaking nanny's way of handling client-state and client-info. Without it nanny interference a bit into what client sees. Patch is almost ready ;-).
