### PR TITLE
ModemManager: disable modem functionality for now

### DIFF
--- a/schema/wicked.xml
+++ b/schema/wicked.xml
@@ -15,7 +15,7 @@
 <include name="infiniband.xml"/>
 <include name="interface.xml"/>
 <include name="wireless.xml"/>
-<include name="modem.xml"/>
+<!-- <include name="modem.xml"/> -->
 <include name="ppp.xml"/>
 <include name="firewall.xml"/>
 <include name="addrconf.xml"/>

--- a/server/main.c
+++ b/server/main.c
@@ -212,10 +212,13 @@ run_interface_server(void)
 	if (!dbus_server)
 		ni_fatal("Cannot create server, giving up.");
 
+	/* FIXME: ModemManager changed to ModemManager1 - new API*/
+#if 0
 	if (!opt_no_modem_manager) {
 		if (!ni_modem_manager_init(handle_modem_event))
 			ni_error("unable to initialize modem manager client");
 	}
+#endif
 
 	schema = ni_objectmodel_init(dbus_server);
 	if (schema == NULL)


### PR DESCRIPTION
org.freedesktop.ModemManager changed to ModemManager1 as well as
its API.
To be implemented later.
