### PR TITLE
client: Improve initialization of client-state structure

### DIFF
--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -191,6 +191,10 @@ usage:
 			if (ni_ifcheck_worker_config_matches(w))
 				continue;
 
+			/* Mark persistend when requested */
+			if (opt_persistent)
+				w->client_state.persistent = TRUE;
+
 			/* Remember all changed devices */
 			ni_ifworker_array_append(&marked, w);
 
@@ -246,9 +250,6 @@ usage:
 			status = NI_WICKED_RC_ERROR;
 			goto cleanup;
 		}
-
-		/* Mark persistend when requested */
-		ni_fsm_set_client_state(fsm, opt_persistent);
 
 		/* Execute the up run */
 		if (ni_fsm_schedule(fsm) != 0)

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -231,6 +231,10 @@ typedef struct ni_ifmatcher {
 				skip_active        : 1;
 } ni_ifmatcher_t;
 
+typedef struct ni_ifmarker {
+	ni_uint_range_t	target_range;
+	unsigned int	persistent	: 1;
+} ni_ifmarker_t;
 
 extern ni_fsm_t *		ni_fsm_new(void);
 extern void			ni_fsm_free(ni_fsm_t *);
@@ -245,14 +249,13 @@ extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
 extern xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);
 extern ni_bool_t		ni_fsm_policies_changed_since(const ni_fsm_t *, unsigned int *tstamp);
 
-extern void			ni_fsm_set_client_state(ni_fsm_t *, ni_bool_t);
 extern ni_dbus_client_t *	ni_fsm_create_client(ni_fsm_t *);
 extern void			ni_fsm_refresh_state(ni_fsm_t *);
 extern unsigned int		ni_fsm_schedule(ni_fsm_t *);
 extern ni_bool_t		ni_fsm_do(ni_fsm_t *fsm, long *timeout_p);
 extern void			ni_fsm_mainloop(ni_fsm_t *);
 extern unsigned int		ni_fsm_get_matching_workers(ni_fsm_t *, ni_ifmatcher_t *, ni_ifworker_array_t *);
-extern unsigned int		ni_fsm_mark_matching_workers(ni_fsm_t *, ni_ifmatcher_t *, const ni_uint_range_t *);
+extern unsigned int		ni_fsm_mark_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, const ni_ifmarker_t *);
 extern unsigned int		ni_fsm_start_matching_workers(ni_fsm_t *, ni_ifworker_array_t *);
 extern void			ni_fsm_reset_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, const ni_uint_range_t *, ni_bool_t);
 extern int			ni_fsm_build_hierarchy(ni_fsm_t *);

--- a/src/client/client_state.h
+++ b/src/client/client_state.h
@@ -67,4 +67,19 @@ ni_client_state_print_timeval(const struct timeval *tv, char **str)
 			(unsigned long)tv->tv_usec);
 }
 
+#define NI_CLIENT_STATE_SET_CONTROL_FLAG(flag, cond, value) \
+	do { \
+		if (!(cond)) \
+			break; \
+		if (value) {\
+			flag = TRUE; \
+			ni_debug_application("%s: set %s control flag to TRUE", \
+				__func__, #flag); \
+		} \
+		else if (flag) {\
+			ni_fatal("%s: attempt to switch off %s control flag", \
+				__func__, #flag); \
+		} \
+	} while(0)
+
 #endif


### PR DESCRIPTION
- Split ni_fsm_get_matching_workers() and ni_fsm_mark_matching_workers()
- Introduce new type ni_ifmarker_t to mark specific attributes of
  ifworkers (target_range, persistent)
- get rid of ni_fsm_set_client_state() and move the functionality to
  ni_ifworker_start() - possible due to the above split
- Introduce macro to carefully set control flags like persistent and
  usercontrol
