### PR TITLE
dbus: Fix crashes when dbus instance is not running

### DIFF
--- a/src/dbus-client.c
+++ b/src/dbus-client.c
@@ -75,8 +75,13 @@ ni_dbus_client_free(ni_dbus_client_t *dbc)
 {
 	NI_TRACE_ENTER();
 
-	ni_dbus_connection_free(dbc->connection);
+	if (!dbc)
+		return;
+
+	if (dbc->connection)
+		ni_dbus_connection_free(dbc->connection);
 	dbc->connection = NULL;
+
 	ni_string_free(&dbc->bus_name);
 	free(dbc);
 }

--- a/src/dbus-connection.c
+++ b/src/dbus-connection.c
@@ -214,6 +214,9 @@ ni_dbus_connection_free(ni_dbus_connection_t *dbc)
 {
 	ni_dbus_sigaction_t *sig;
 
+	if (!dbc)
+		return;
+
 	NI_TRACE_ENTER();
 
 	while (dbc->async_client_calls) {

--- a/src/dbus-server.c
+++ b/src/dbus-server.c
@@ -75,7 +75,8 @@ ni_dbus_server_free(ni_dbus_server_t *server)
 		__ni_dbus_object_free(server->root_object);
 	server->root_object = NULL;
 
-	ni_dbus_connection_free(server->connection);
+	if (server->connection)
+		ni_dbus_connection_free(server->connection);
 	server->connection = NULL;
 
 	free(server);


### PR DESCRIPTION
Fix not to crash when called directly /usr/lib/wicked/bin/wickedd-dhcp4 while dbus is not started (i.e. dracut).
