### PR TITLE
debug: init debug and log level from environment

### DIFF
--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -79,6 +79,7 @@ main(int argc, char **argv)
 {
 	int c;
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
 
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {

--- a/client/main.c
+++ b/client/main.c
@@ -111,7 +111,9 @@ main(int argc, char **argv)
 
 	mtrace();
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
+
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_HELP:

--- a/client/suse/scripts/ifup.in
+++ b/client/suse/scripts/ifup.in
@@ -80,7 +80,7 @@ mesg()
 
 debug()
 {
-	test "$DEBUG" = "yes" && mesg -p debug "$*"
+	test "X${DEBUG:-no}" != "Xno" && mesg -p debug "$*"
 }
 
 systemd_running()
@@ -141,13 +141,12 @@ case $1 in
 	-o)		shift					;;
 esac
 OPTIONS=$@
-opt_debug=""
 opt_quiet=""
 opt_force=""
 while [ $# -gt 0 ]; do
 	case $1 in
-	debug)		DEBUG="yes" ; opt_debug="most"		;;
-	debug=*)	DEBUG="yes" ; opt_debug="${1#debug=}"	;;
+	debug)		DEBUG="yes"				;;
+	debug=*)	DEBUG="${1#debug=}"			;;
 	quiet)		opt_quiet="--quiet"			;;
 	force)          opt_force="--force device-exists"	;;
 	*)		debug "unknown option \"$1\""		;;
@@ -231,13 +230,11 @@ wicked_client="@wicked_sbindir@/wicked"
 case $SCRIPTNAME in
 	ifup)
 		$wicked_client \
-			${opt_debug:+--debug $opt_debug} \
 			ifup "$INTERFACE"
 		rc=$(rc_map_return "$?")
 	;;
 	ifdown)
 		$wicked_client \
-			${opt_debug:+--debug $opt_debug} \
 			ifdown \
 			  ${opt_force} \
 			  "$INTERFACE"
@@ -245,7 +242,6 @@ case $SCRIPTNAME in
 	;;
 	ifstatus)
 		$wicked_client \
-			${opt_debug:+--debug $opt_debug} \
 			ifstatus \
 			  ${opt_quiet} \
 			  "$INTERFACE"
@@ -253,7 +249,6 @@ case $SCRIPTNAME in
 	;;
 	ifprobe)
 		$wicked_client \
-			${opt_debug:+--debug $opt_debug} \
 			ifcheck \
 			  --changed \
 			  ${opt_quiet} \

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -108,6 +108,7 @@ main(int argc, char **argv)
 	const char * opt_test_ifname = NULL;
 	int c;
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
 
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -115,6 +115,7 @@ main(int argc, char **argv)
 	const char * opt_test_ifname = NULL;
 	int c;
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
 
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {

--- a/etc/systemd/wicked.service.in
+++ b/etc/systemd/wicked.service.in
@@ -9,9 +9,9 @@ Type=oneshot
 RemainAfterExit=yes
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_sbindir@/wicked $WICKED_DEBUG_PARAM --systemd ifup all
-ExecStop=@wicked_sbindir@/wicked $WICKED_DEBUG_PARAM --systemd ifdown all
-ExecReload=@wicked_sbindir@/wicked $WICKED_DEBUG_PARAM --systemd ifreload all
+ExecStart=@wicked_sbindir@/wicked --systemd ifup all
+ExecStop=@wicked_sbindir@/wicked --systemd ifdown all
+ExecReload=@wicked_sbindir@/wicked --systemd ifreload all
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/systemd/wicked@.service.in
+++ b/etc/systemd/wicked@.service.in
@@ -13,8 +13,8 @@ Type=oneshot
 RemainAfterExit=yes
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_sbindir@/wicked $WICKED_DEBUG_PARAM ifup --boot-stage %i -- all
-ExecStop=@wicked_sbindir@/wicked $WICKED_DEBUG_PARAM ifdown --boot-stage %i -- all
+ExecStart=@wicked_sbindir@/wicked ifup --boot-stage %i -- all
+ExecStop=@wicked_sbindir@/wicked ifdown --boot-stage %i -- all
 
 [Install]
 Also=wickedd.service

--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -9,7 +9,7 @@ Type=dbus
 BusName=org.opensuse.Network.AUTO4
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_supplicantdir@/wickedd-auto4 $WICKED_DEBUG_PARAM --systemd --foreground
+ExecStart=@wicked_supplicantdir@/wickedd-auto4 --systemd --foreground
 StandardError=null
 Restart=on-abort
 

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -9,7 +9,7 @@ Type=dbus
 BusName=org.opensuse.Network.DHCP4
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_supplicantdir@/wickedd-dhcp4 $WICKED_DEBUG_PARAM --systemd --foreground
+ExecStart=@wicked_supplicantdir@/wickedd-dhcp4 --systemd --foreground
 StandardError=null
 Restart=on-abort
 

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -9,7 +9,7 @@ Type=dbus
 BusName=org.opensuse.Network.DHCP6
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_supplicantdir@/wickedd-dhcp6 $WICKED_DEBUG_PARAM --systemd --foreground
+ExecStart=@wicked_supplicantdir@/wickedd-dhcp6 --systemd --foreground
 StandardError=null
 Restart=on-abort
 

--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -9,7 +9,7 @@ Type=dbus
 BusName=org.opensuse.Network.Nanny
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_sbindir@/wickedd-nanny $WICKED_DEBUG_PARAM --systemd --foreground
+ExecStart=@wicked_sbindir@/wickedd-nanny --systemd --foreground
 StandardError=null
 Restart=on-abort
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -8,7 +8,7 @@ Type=dbus
 BusName=org.opensuse.Network
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStart=@wicked_sbindir@/wickedd $WICKED_DEBUG_PARAM --systemd --foreground
+ExecStart=@wicked_sbindir@/wickedd --systemd --foreground
 StandardError=null
 Restart=on-abort
 

--- a/etc/systemv/network.in
+++ b/etc/systemv/network.in
@@ -110,10 +110,6 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-if [ "$DEBUG" = "yes" ]; then
-	WICKED_DEBUG="--debug ${WICKED_DEBUG_LEVEL:-most}"
-fi
-
 case $ACTION in
 start)
 	IFUP_ARGS=""
@@ -127,13 +123,13 @@ start)
 	# FIXME: remove it
 	ulimit -c unlimited
 
-	$FAKE $WICKED_CLIENT_BIN $WICKED_DEBUG ifup $IFUP_ARGS all
+	$FAKE $WICKED_CLIENT_BIN ifup $IFUP_ARGS all
 
 	rc_status -v
 	;;
 
 stop)
-	$FAKE $WICKED_CLIENT_BIN $WICKED_DEBUG ifdown all
+	$FAKE $WICKED_CLIENT_BIN ifdown all
 	rc_status -v
 	;;
 
@@ -160,13 +156,13 @@ force-reload)
 	;;
 
 reload)
-	$FAKE $WICKED_CLIENT_BIN $WICKED_DEBUG ifreload all
+	$FAKE $WICKED_CLIENT_BIN ifreload all
 	rc_status -v
 	;;
 
 status)
 	echo "Checking for service network:"
-	$FAKE $WICKED_CLIENT_BIN $WICKED_DEBUG ifstatus --brief all
+	$FAKE $WICKED_CLIENT_BIN ifstatus --brief all
 	echo -n "Status of service network "
 	rc_status -v
 	;;
@@ -175,7 +171,7 @@ probe)
 	## Optional / not part of LSB: Probe for the necessity of a reload,
 	## print out the argument to this init script which is required for
 	## a reload (or restart when reload not supported).
-	$FAKE $WICKED_CLIENT_BIN $WICKED_DEBUG ifcheck --changed --quiet all \
+	$FAKE $WICKED_CLIENT_BIN ifcheck --changed --quiet all \
 		&>/dev/null || echo reload
 	;;
 

--- a/etc/systemv/wickedd.in
+++ b/etc/systemv/wickedd.in
@@ -36,7 +36,7 @@ wicked_CONFIG=@wicked_configdir@/server.xml
 wicked_DAEMON_BIN=@wicked_sbindir@/wickedd
 wicked_PIDFILE=@wicked_piddir@/wicked.pid
 
-# for WICKED_DEBUG_LEVEL only
+# for WICKED_DEBUG and WICKED_LOG_LEVEL and DEBUG (sysconfig compat)
 test -f /etc/sysconfig/network/config && \
       . /etc/sysconfig/network/config
 
@@ -115,9 +115,6 @@ esac
 case $ACTION in
     start)
 	COMMON_ARGS=""
-	if [ -n "$WICKED_DEBUG_LEVEL" ]; then
-		COMMON_ARGS+=" --debug $WICKED_DEBUG_LEVEL"
-	fi
 
 	echo -n "Starting"
 

--- a/include/wicked/logging.h
+++ b/include/wicked/logging.h
@@ -31,6 +31,7 @@ extern const char * 	ni_debug_facility_to_name(unsigned int);
 extern int		ni_debug_name_to_facility(const char *, unsigned int *);
 extern const char *	ni_debug_facility_to_description(unsigned int);
 
+extern void		ni_log_init(void);
 extern ni_bool_t	ni_log_level_set(const char *);
 extern unsigned int	ni_log_level_get(void);
 

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -81,6 +81,7 @@ main(int argc, char **argv)
 {
 	int c;
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
 
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {

--- a/server/main.c
+++ b/server/main.c
@@ -86,6 +86,7 @@ main(int argc, char **argv)
 {
 	int c;
 
+	ni_log_init();
 	program_name = ni_basename(argv[0]);
 
 	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -27,7 +27,7 @@
 #define NI_TRACE_MOST	~(NI_TRACE_XPATH | NI_TRACE_WICKED_XML | NI_TRACE_DBUS)
 #define NI_TRACE_ALL	~0U
 
-unsigned int		ni_debug;
+unsigned int		ni_debug = 0;
 unsigned int		ni_log_level = NI_LOG_NOTICE;
 static unsigned int	ni_log_syslog;
 static const char *	ni_log_ident;
@@ -167,7 +167,7 @@ ni_enable_debug(const char *fac)
 	char *copy, *s;
 	int rv = 0;
 
-	copy = xstrdup(fac);
+	copy = xstrdup(fac ? fac : "");
 	for (s = strtok(copy, ","); s; s = strtok(NULL, ",")) {
 		unsigned int flags = 0;
 		int not = 0;
@@ -205,6 +205,25 @@ ni_debug_help(void)
 		printf("  %-10s\t%s\n",
 				ni_debug_facility_to_name(__debug_flags_descriptions[i].value),
 				__debug_flags_descriptions[i].name);
+	}
+}
+
+void
+ni_log_init(void)
+{
+	const char *var = getenv("WICKED_DEBUG");
+
+	if (ni_string_empty(var) && (var = getenv("DEBUG"))) {
+		if (ni_string_eq(var, "no"))
+			var = "";
+		else
+		if (ni_string_eq(var, "yes"))
+			var = "most";
+	}
+	ni_enable_debug(var);
+
+	if ((var = getenv("WICKED_LOG_LEVEL"))) {
+		ni_log_level_set(var);
 	}
 }
 


### PR DESCRIPTION
The environment variable WICKED_DEBUG=<mask> initialize the
debug mask and WICKED_LOG_LEVEL=<level> the level in similar
way as the --debug and --log-level option do.
For compatibility, the DEBUG variable is used if WICKED_DEBUG
is empty and is allowed to contain also the yes/no values.
