### PR TITLE
use HEADERS instead of EXTRA_DIST to fix TAGS

### DIFF
--- a/autoip4/Makefile.am
+++ b/autoip4/Makefile.am
@@ -20,7 +20,7 @@ wickedd_auto4_SOURCES	= \
 	fsm.c		\
 	main.c
 
-EXTRA_DIST			= \
+noinst_HEADERS		= \
 	autoip.h
 
 # vim: ai

--- a/dhcp4/Makefile.am
+++ b/dhcp4/Makefile.am
@@ -21,7 +21,7 @@ wickedd_dhcp4_SOURCES	= \
 	main.c		\
 	protocol.c
 
-EXTRA_DIST			= \
+noinst_HEADERS		= \
 	dhcp.h		\
 	protocol.h
 

--- a/dhcp6/Makefile.am
+++ b/dhcp6/Makefile.am
@@ -22,7 +22,7 @@ wickedd_dhcp6_SOURCES	= \
 	protocol.c	\
 	state.c
 
-EXTRA_DIST			= \
+noinst_HEADERS		= \
 	dbus-api.h	\
 	device.h	\
 	dhcp6.h		\

--- a/nanny/Makefile.am
+++ b/nanny/Makefile.am
@@ -22,7 +22,7 @@ wickedd_nanny_SOURCES		= \
 	nanny.c		\
 	policy.c
 
-EXTRA_DIST			= \
+noinst_HEADERS		= \
 	nanny.h
 
 # vim: ai

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,10 +140,12 @@ libwicked_client_la_SOURCES		= \
 	client/client_state.c
 
 noinst_HEADERS			= \
+	dhcp4/lease.h		\
+	dhcp6/lease.h		\
 	linux/if_link.h		\
 	linux/dcbnl.h
 
-EXTRA_DIST			= \
+wicked_include_HEADERS		= \
 	appconfig.h		\
 	buffer.h		\
 	client/client_state.h	\
@@ -155,8 +157,6 @@ EXTRA_DIST			= \
 	dbus-objects/model.h	\
 	dbus-server.h		\
 	debug.h			\
-	dhcp4/lease.h		\
-	dhcp6/lease.h		\
 	dhcp6/options.h		\
 	duid.h			\
 	ipv6_priv.h		\


### PR DESCRIPTION
Quick fix to include all headers in TAGS.
wicked-devel.rpm is likely incomplete, and this does not matter at this point anyway.
