### PR TITLE
Making use of STARTMODE='off' and STARTMODE='manual'

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -1047,15 +1047,15 @@ __ni_suse_startmode(const char *mode)
 		ni_ifworker_control_t	control;
 	} __ni_suse_control_params[] = {
 		/* manual is the default in ifcfg */
-		{ "manual",	{ NULL,		NULL,		TRUE,	FALSE,	FALSE,	30	} },
+		{ "manual",	{ "manual",	NULL,		TRUE,	FALSE,	FALSE,	30	} },
 
 		{ "auto",	{ "boot",	NULL,		FALSE,	TRUE,	FALSE,	30	} },
 		{ "boot",	{ "boot",	NULL,		FALSE,	TRUE,	FALSE,	30	} },
 		{ "onboot",	{ "boot",	NULL,		FALSE,	TRUE,	FALSE,	30	} },
 		{ "on",		{ "boot",	NULL,		FALSE,	TRUE,	FALSE,	30	} },
 
-		{ "hotplug",	{ "boot",	NULL,		FALSE,	FALSE,	FALSE,	30	} },
-		{ "ifplugd",	{ "ignore",	NULL,		FALSE,	FALSE,	FALSE,	30	} },
+		{ "hotplug",	{ "hotplug",	NULL,		FALSE,	FALSE,	FALSE,	30	} },
+		{ "ifplugd",	{ "hotplug",	NULL,		FALSE,	FALSE,	FALSE,	30	} },
 
 		{ "nfsroot",	{ "boot",	"localfs",	TRUE,	TRUE,	TRUE,	NI_IFWORKER_INFINITE_TIMEOUT	} },
 		{ "off",	{ "off",	NULL,		FALSE,	FALSE,	FALSE,	0	} },

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1583,6 +1583,9 @@ ni_fsm_get_matching_workers(ni_fsm_t *fsm, ni_ifmatcher_t *match, ni_ifworker_ar
 		if (ni_string_eq_nocase(w->control.mode, "off"))
 			continue;
 
+		if (!match->name && ni_string_eq_nocase(w->control.mode, "manual"))
+			continue;
+
 		if (match->name && !ni_string_eq(match->name, w->name))
 			continue;
 


### PR DESCRIPTION
ifup/ifreload ignore ifworkers where "off" or "manual" (in case of "manual" for ifup/ifreload all only) are set.
ifdown does not read configs so it does not ignore anything.

Open questions is the link_required and mandatory control fields changes. Please review.
