### PR TITLE
client: Do not display transient return codes by default

### DIFF
--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -187,7 +187,7 @@ usage:
 		 * or whatever not ready in time) -- returning an error may
 		 * cause to stop the network completely.
 		 */
-		if (opt_systemd)
+		if (!opt_transient)
 			status = NI_LSB_RC_SUCCESS;
 	}
 

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -270,7 +270,7 @@ usage:
 		 * or whatever not ready in time) -- returning an error may
 		 * cause to stop the network completely.
 		 */
-		if (opt_systemd)
+		if (!opt_transient)
 			status = NI_LSB_RC_SUCCESS;
 	}
 

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -470,20 +470,18 @@ int
 ni_do_ifstatus(int argc, char **argv)
 {
 	enum  { OPT_QUIET, OPT_BRIEF, OPT_NORMAL, OPT_VERBOSE,
-		OPT_HELP, OPT_SHOW, OPT_IFCONFIG, OPT_NOTRANSIENT };
+		OPT_HELP, OPT_SHOW, OPT_IFCONFIG };
 	static struct option ifcheck_options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
 		{ "quiet",        no_argument,       NULL, OPT_QUIET       },
 		{ "brief",        no_argument,       NULL, OPT_BRIEF       },
 		{ "verbose",      no_argument,       NULL, OPT_VERBOSE     },
 		{ "ifconfig",     required_argument, NULL, OPT_IFCONFIG    },
-		{ "no-transient", no_argument,       NULL, OPT_NOTRANSIENT },
 
 		{ NULL,           no_argument,       NULL, 0               }
 	};
 	ni_string_array_t opt_ifconfig = NI_STRING_ARRAY_INIT;
 	unsigned int      opt_verbose  = OPT_NORMAL;
-	ni_bool_t         opt_transient = TRUE;
 	int               c, status = NI_WICKED_ST_USAGE;
 	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
 	ni_uint_array_t   stcodes = NI_UINT_ARRAY_INIT;
@@ -532,8 +530,6 @@ ni_do_ifstatus(int argc, char **argv)
 				"\n"
 				"  --ifconfig <filename>\n"
 				"      Read interface configuration(s) from file\n"
-				"  --no-transient\n"
-				"      Discard transient interface status codes\n"
 				, argv[0]
 			);
 			goto cleanup;
@@ -546,10 +542,6 @@ ni_do_ifstatus(int argc, char **argv)
 
 		case OPT_IFCONFIG:
 			ni_string_array_append(&opt_ifconfig, optarg);
-			break;
-
-		case OPT_NOTRANSIENT:
-			opt_transient = FALSE;
 			break;
 		}
 	}

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -269,7 +269,7 @@ usage:
 		 * or whatever not ready in time) -- returning an error may
 		 * cause to stop the network completely.
 		 */
-		if (opt_systemd)
+		if (!opt_transient)
 			status = NI_LSB_RC_SUCCESS;
 	}
 

--- a/client/main.c
+++ b/client/main.c
@@ -65,6 +65,7 @@ enum {
 	OPT_LOG_LEVEL,
 	OPT_LOG_TARGET,
 	OPT_SYSTEMD,
+	OPT_TRANSIENT,
 
 	OPT_DRYRUN,
 	OPT_ROOTDIR,
@@ -80,6 +81,7 @@ static struct option	options[] = {
 	{ "log-level",		required_argument,	NULL,	OPT_LOG_LEVEL },
 	{ "log-target",		required_argument,	NULL,	OPT_LOG_TARGET },
 	{ "systemd", 		no_argument,		NULL,	OPT_SYSTEMD },
+	{ "transient", 		no_argument,		NULL,	OPT_TRANSIENT },
 
 	/* specific */
 	{ "dryrun",		no_argument,		NULL,	OPT_DRYRUN },
@@ -94,6 +96,7 @@ static const char *	opt_log_target;
 int			opt_global_dryrun;
 char *			opt_global_rootdir;
 ni_bool_t		opt_systemd;
+ni_bool_t		opt_transient;
 
 static int		do_show_xml(int, char **);
 static int		do_show_config(int, char **, const char *);
@@ -140,6 +143,8 @@ main(int argc, char **argv)
 				"        Search all config files below this directory.\n"
 				"  --systemd\n"
 				"        Enables behavior required by systemd service\n"
+				"  --transient\n"
+				"        Enable transient interface return codes\n"
 				"\n"
 				"Supported commands:\n"
 				"  ifup        [options] <ifname ...>|all\n"
@@ -207,6 +212,10 @@ main(int argc, char **argv)
 
 		case OPT_SYSTEMD:
 			opt_systemd = TRUE;
+			break;
+
+		case OPT_TRANSIENT:
+			opt_transient = TRUE;
 			break;
 		}
 	}

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -34,6 +34,7 @@
 extern int			opt_global_dryrun;
 extern char *			opt_global_rootdir;
 extern ni_bool_t		opt_systemd;
+extern ni_bool_t		opt_transient;
 
 /* We may want to move this into the library. */
 extern int			ni_resolve_hostname_timed(const char *, int, ni_sockaddr_t *, unsigned int);


### PR DESCRIPTION
New option flag --transient is to enable transient
return codes (dhcp timeout).
By default ERROR is reported only on a severe errors.
