### PR TITLE
Do not close stderr on daemon() when in log-target

### DIFF
--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -411,7 +411,13 @@ autoip4_supplicant(void)
 		ni_fatal("unable to initialize netlink listener");
 
 	if (!opt_foreground) {
-		if (ni_server_background(program_name) < 0)
+		ni_daemon_close_t close_flags = NI_DAEMON_CLOSE_IN |
+			NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR;
+
+		if (ni_string_startswith(opt_log_target, "stderr"))
+			close_flags &= ~NI_DAEMON_CLOSE_ERR;
+
+		if (ni_server_background(program_name, close_flags) < 0)
 			ni_fatal("unable to background server");
 	}
 

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -497,7 +497,13 @@ dhcp4_supplicant(void)
 		ni_fatal("unable to initialize netlink listener");
 
 	if (!opt_foreground) {
-		if (ni_server_background(program_name) < 0)
+		ni_daemon_close_t close_flags = NI_DAEMON_CLOSE_IN |
+			NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR;
+
+		if (ni_string_startswith(opt_log_target, "stderr"))
+			close_flags &= ~NI_DAEMON_CLOSE_ERR;
+
+		if (ni_server_background(program_name, close_flags) < 0)
 			ni_fatal("unable to background server");
 	}
 

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -448,7 +448,13 @@ dhcp6_supplicant(void)
 		ni_fatal("Unable to initialize netlink prefix event listener");
 
 	if (!opt_foreground) {
-		if (ni_server_background(program_name) < 0)
+		ni_daemon_close_t close_flags = NI_DAEMON_CLOSE_IN |
+			NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR;
+
+		if (ni_string_startswith(opt_log_target, "stderr"))
+			close_flags &= ~NI_DAEMON_CLOSE_ERR;
+
+		if (ni_server_background(program_name, close_flags) < 0)
 			ni_fatal("Unable to background server");
 	}
 

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -118,7 +118,7 @@ extern int		ni_init(const char *appname);
 typedef ni_bool_t	ni_init_appdata_callback_t(void *, const xml_node_t *);
 extern int		ni_init_ex(const char *appname, ni_init_appdata_callback_t *, void *);
 
-extern int		ni_server_background(const char *);
+extern int		ni_server_background(const char *, ni_daemon_close_t);
 extern int		ni_server_listen_interface_events(void (*handler)(ni_netdev_t *, ni_event_t));
 extern int		ni_server_enable_interface_addr_events(void (*handler)(ni_netdev_t *, ni_event_t, const ni_address_t *));
 extern int		ni_server_enable_interface_prefix_events(void (*handler)(ni_netdev_t *, ni_event_t, const ni_ipv6_ra_pinfo_t *));

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -71,6 +71,14 @@ typedef struct ni_bitfield {
 
 #define NI_BITFIELD_INIT { 0, NULL }
 
+typedef enum ni_daemon_close {
+	NI_DAEMON_CLOSE_NONE	= 0,
+	NI_DAEMON_CLOSE_IN	= 1,
+	NI_DAEMON_CLOSE_OUT	= 2,
+	NI_DAEMON_CLOSE_ERR	= 4,
+	NI_DAEMON_CLOSE_ALL	= -1U,
+} ni_daemon_close_t;
+
 extern void		ni_bitfield_init(ni_bitfield_t *);
 extern void		ni_bitfield_destroy(ni_bitfield_t *);
 extern void		ni_bitfield_setbit(ni_bitfield_t *, unsigned int);
@@ -153,7 +161,7 @@ extern const char *	ni_realpath(const char *path, char **resolved);
 extern const char *	ni_sibling_path(const char *path, const char *file);
 extern const char *	ni_sibling_path_printf(const char *path, const char *fmt, ...);
 extern int		ni_scandir(const char *, const char *, ni_string_array_t *);
-extern int		ni_daemonize(const char *, unsigned int);
+extern int		ni_daemonize(const char *, unsigned int, ni_daemon_close_t);
 extern pid_t		ni_pidfile_check(const char *);
 extern int		ni_pidfile_write(const char *, unsigned int, pid_t);
 

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -216,7 +216,13 @@ babysit(void)
 	fsm->readonly = TRUE;
 
 	if (!opt_foreground) {
-		if (ni_server_background(program_name) < 0)
+		ni_daemon_close_t close_flags = NI_DAEMON_CLOSE_IN |
+			NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR;
+
+		if (ni_string_startswith(opt_log_target, "stderr"))
+			close_flags &= ~NI_DAEMON_CLOSE_ERR;
+
+		if (ni_server_background(program_name, close_flags) < 0)
 			ni_fatal("unable to background server");
 	}
 

--- a/server/main.c
+++ b/server/main.c
@@ -246,7 +246,13 @@ run_interface_server(void)
 	ni_server_listen_other_events(handle_other_event);
 
 	if (!opt_foreground) {
-		if (ni_server_background(program_name) < 0)
+		ni_daemon_close_t close_flags = NI_DAEMON_CLOSE_IN |
+			NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR;
+
+		if (ni_string_startswith(opt_log_target, "stderr"))
+			close_flags &= ~NI_DAEMON_CLOSE_ERR;
+
+		if (ni_server_background(program_name, close_flags) < 0)
 			ni_fatal("unable to background server");
 	}
 

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -342,14 +342,14 @@ ni_extension_statedir(const char *ex_name)
  * and for connecting to it
  */
 int
-ni_server_background(const char *appname)
+ni_server_background(const char *appname, ni_daemon_close_t close_flags)
 {
 	const char *piddir = ni_config_piddir();
 	char pidfilepath[PATH_MAX];
 
 	ni_assert(appname != NULL);
 	snprintf(pidfilepath, sizeof(pidfilepath), "%s/%s.pid", piddir, appname);
-	return ni_daemonize(pidfilepath, 0644);
+	return ni_daemonize(pidfilepath, 0644, close_flags);
 }
 
 void

--- a/src/util.c
+++ b/src/util.c
@@ -1555,9 +1555,10 @@ ni_stringbuf_trim_empty_lines(ni_stringbuf_t *sb)
  * background the current process
  */
 int
-ni_daemonize(const char *pidfile, unsigned int permissions)
+ni_daemonize(const char *pidfile, unsigned int permissions, ni_daemon_close_t close_flags)
 {
 	pid_t pid;
+	FILE *rv;
 
 	if (pidfile) {
 		/* check if service is already running */
@@ -1583,13 +1584,29 @@ ni_daemonize(const char *pidfile, unsigned int permissions)
 	if (pidfile && ni_pidfile_write(pidfile, permissions, getpid()) < 0)
 		return -1;
 
+	if (close_flags & NI_DAEMON_CLOSE_IN)
+		rv = freopen("/dev/null", "r", stdin);
+	if (close_flags & NI_DAEMON_CLOSE_OUT)
+		rv = freopen("/dev/null", "w", stdout);
+	if (close_flags & NI_DAEMON_CLOSE_ERR)
+		rv = freopen("/dev/null", "w", stderr);
+	close_flags |=
+		(NI_DAEMON_CLOSE_IN | NI_DAEMON_CLOSE_OUT | NI_DAEMON_CLOSE_ERR);
+
+	if (close_flags == NI_DAEMON_CLOSE_ALL) {
+		int fd, maxfd = getdtablesize();
+		for (fd = 3; fd < maxfd; ++fd)
+			close(fd);
+	}
+
 	/* fork, chdir to root and close fds */
-	if (daemon(0, 0) < 0)
+	if (daemon(0, TRUE) < 0)
 		ni_fatal("unable to background process! daemon() failed: %m");
 
 	if (pidfile)
 		__ni_pidfile_write(pidfile, permissions, getpid(), 0);
 
+	(void) rv;
 	return 0;
 }
 


### PR DESCRIPTION
Introduce a new ni_daemon_close_t bitmask to mark stdin, stdout, stderr and all fds to be closed, instead of using default closing of daemon().
In case of --log-target stderr is used, do not close that fd.
