### PR TITLE
client: move FSM state generator to common place

### DIFF
--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -40,7 +40,6 @@
 #include <wicked/fsm.h>
 
 #include "wicked-client.h"
-#include "ifup.h"
 #include "ifcheck.h"
 
 static ni_bool_t opt_quiet;
@@ -274,7 +273,7 @@ ni_do_ifcheck(int argc, char **argv)
 			status = NI_WICKED_RC_SUCCESS;
 		default:
 		usage:
-			ni_fsm_fill_state_string(&sb, NULL);
+			ni_client_get_state_strings(&sb, NULL);
 			fprintf(stderr,
 				"wicked [options] ifcheck [ifcheck-options] <ifname ...>|all\n"
 				"\nSupported ifcheck-options:\n"

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -36,7 +36,6 @@
 #include <wicked/fsm.h>
 
 #include "wicked-client.h"
-#include "ifup.h"
 #include "ifdown.h"
 
 
@@ -121,7 +120,7 @@ ni_do_ifdown(int argc, char **argv)
 		default:
 		case OPT_HELP:
 usage:
-			ni_fsm_fill_state_string(&sb, &ifmarker.target_range);
+			ni_client_get_state_strings(&sb, &ifmarker.target_range);
 			fprintf(stderr,
 				"wicked [options] ifdown [ifdown-options] <ifname ...>|all\n"
 				"\nSupported ifdown-options:\n"

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -40,7 +40,6 @@
 #include <wicked/fsm.h>
 
 #include "wicked-client.h"
-#include "ifup.h"
 #include "ifcheck.h"
 
 int

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -48,7 +48,6 @@
 #include <wicked/fsm.h>
 
 #include "wicked-client.h"
-#include "ifup.h"
 #include "ifcheck.h"
 
 /*

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -42,21 +42,6 @@
 #include "wicked-client.h"
 #include "ifup.h"
 
-void
-ni_fsm_fill_state_string(ni_stringbuf_t *sb, const ni_uint_range_t *range)
-{
-	unsigned int state;
-
-	if (!sb)
-		return;
-
-	for (state = (range ? range->min : NI_FSM_STATE_NONE);
-	     state <= (range ? range->max : __NI_FSM_STATE_MAX - 1);
-	     state++) {
-		ni_stringbuf_printf(sb, "%s ", ni_ifworker_state_name(state));
-	}
-}
-
 int
 ni_do_ifup(int argc, char **argv)
 {

--- a/client/ifup.h
+++ b/client/ifup.h
@@ -29,6 +29,4 @@
 
 extern int		ni_do_ifup(int argc, char **argv);
 
-extern void		ni_fsm_fill_state_string(ni_stringbuf_t *, const ni_uint_range_t *);
-
 #endif /* __WICKED_CLIENT_IFUP_H__ */

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -121,4 +121,18 @@ extern ni_device_clientinfo_t *	ni_ifconfig_get_client_info(xml_document_t *);
 extern void			ni_ifconfig_add_client_info(xml_document_t *, ni_device_clientinfo_t *,     char *);
 extern void			ni_ifconfig_del_client_info(xml_document_t *, const char *);
 
+static inline void
+ni_client_get_state_strings(ni_stringbuf_t *sb, const ni_uint_range_t *range)
+{
+	if (sb) {
+		unsigned int state;
+
+		for (state = (range ? range->min : NI_FSM_STATE_NONE);
+		     state <= (range ? range->max : __NI_FSM_STATE_MAX - 1);
+		     state++) {
+			ni_stringbuf_printf(sb, "%s ", ni_ifworker_state_name(state));
+		}
+	}
+}
+
 #endif /* WICKED_CLIENT_H */


### PR DESCRIPTION
Instead of ifup.c it should be provided by common client header file as a static inline routine.

wicked-client.h is a subject of a cleanup, but at the moment it is the common header file of client.
