### PR TITLE
server: no unrequested device-ready events (bnc#871135)

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -402,7 +402,6 @@ handle_interface_event(ni_netdev_t *dev, ni_event_t event)
 		case NI_EVENT_DEVICE_READY:
 			while ((event_uuid = ni_netdev_get_event_uuid(dev, event)) != NULL)
 				ni_objectmodel_send_netif_event(dbus_server, object, event, event_uuid);
-			ni_objectmodel_send_netif_event(dbus_server, object, event, NULL);
 			break;
 
 		case NI_EVENT_LINK_ASSOCIATED:


### PR DESCRIPTION
This bug caused e.g. bridges not going up from device-exists
even they already were in device-ready state before.
