### PR TITLE
Update client-info only on final state (bnc#876848)

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2002,6 +2002,13 @@ ni_fsm_mark_matching_workers(ni_fsm_t *fsm, ni_ifworker_array_t *marked, const n
 		ni_client_state_t *cs = &w->client_state;
 
 		w->target_range = marker->target_range;
+
+		/* Clean client-info origin and UUID on ifdown */
+		if (marker->target_range.max < NI_FSM_STATE_DEVICE_UP) {
+			ni_string_free(&w->config.origin);
+			memset(&w->config.uuid, 0, sizeof(w->config.uuid));
+		}
+
 		NI_CLIENT_STATE_SET_CONTROL_FLAG(cs->persistent,
 			marker->persistent == TRUE, TRUE);
 	}


### PR DESCRIPTION
Solution to: Bug 876848 - [Upgrade] Network configuration 'dhcp' has no effect
- change final state of physical devices to DEVICE_READY
- Resolve workers dependencies before marking (in order to apply changes on children too)
- clean origin and UUID on ifdown
