### PR TITLE
Documentation change to clarify the difference between services

### DIFF
--- a/README
+++ b/README
@@ -220,11 +220,11 @@ debugging mode, printing trace information to syslog:
         /usr/lib/wicked/bin/wickedd-auto4 --foreground
         /usr/lib/wicked/bin/wickedd-dhcp6 --foreground
 
-You may also bring up the network using:
+You may then bring up the network using:
 
         systemctl start wicked.service
 
-or via the network.service alias also:
+or using the network.service alias:
 
         systemctl start network.service
 
@@ -234,7 +234,7 @@ defined in the /etc/wicked/client.xml file.
 To enable debugging, you can currently set the WICKED_DEBUG_PARAM
 variable in /etc/sysconfig/network/config file, e.g.:
         WICKED_DEBUG_PARAM="--debug most"
-Note: this is a subject that may change in the furure.
+Note: this may change in the furure.
 
 
 Showing interface status


### PR DESCRIPTION
This "also" was very misleading: I thought that restarting wickedd.service
and wicked.service were the same. In reality, one is the server and the other
is the client, and you need both.
