### PR TITLE
Revert "service: added network-online.target to wants (bnc#883565)"

### DIFF
--- a/etc/systemd/wicked.service.in
+++ b/etc/systemd/wicked.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=wicked managed network interfaces
-Wants=network.target network-online.target
+Wants=network.target
 After=wickedd.service wickedd-nanny.service
 Before=SuSEfirewall2.service network-online.target network.target multi-user.target shutdown.target
 


### PR DESCRIPTION
Reverts openSUSE/wicked#286

See https://bugzilla.novell.com/show_bug.cgi?id=883565#c21.
The network-online.target should be pulled in by consumers of network, not by their providers.
