### PR TITLE
fsm: in pull in check empty config on children

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2176,8 +2176,9 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 	for (i = 0; i < w->children.count; i++) {
 		ni_ifworker_t *child = w->children.data[i];
 
-		if (xml_node_is_empty(w->config.node)) {
-			ni_debug_application("%s: ignoring dependent child  - no config", w->name);
+		if (xml_node_is_empty(child->config.node)) {
+			ni_debug_application("%s: ignoring dependent child %s - no config",
+				w->name, child->name);
 			continue;
 		}
 


### PR DESCRIPTION
With the patches we provided the br(vnet0) where vnet0 exists but does not have any config file works fine.
