### PR TITLE
capture: lower to debug on reconfig changes device type (bnc#880700)

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -566,7 +566,7 @@ ni_capture_devinfo_refresh(ni_capture_devinfo_t *devinfo, const char *ifname, co
 	devinfo->hwaddr = link->hwaddr;
 
 	if (devinfo->iftype != link->type) {
-		ni_error("%s: reconfig changes device type! d%u l%u", devinfo->ifname, devinfo->iftype, link->type);
+		ni_debug_socket("%s: reconfig changes device type! d%u l%u", devinfo->ifname, devinfo->iftype, link->type);
 		return -1;
 	}
 	if (devinfo->ifindex != link->ifindex) {


### PR DESCRIPTION
This is typical situation on s390 machines.
Usually this is not an error, but debug information.
