### PR TITLE
fsm: rearm child workers on pull in

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2182,8 +2182,11 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 			continue;
 		}
 
-		if (ni_ifworker_array_index(array, child) < 0)
+		if (ni_ifworker_array_index(array, child) < 0) {
+			if (ni_ifworker_complete(child))
+				ni_ifworker_rearm(child);
 			ni_ifworker_array_append(array, child);
+		}
 		__ni_fsm_pull_in_children(child, array);
 	}
 }


### PR DESCRIPTION
This is needed to enable consecutive ifup calls.
