### PR TITLE
Do not fail on timeout when at least one lease is granted (bnc#884012, bnc#876845)

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3864,23 +3864,21 @@ __find_corresponding_lease(ni_netdev_t *dev, sa_family_t family, unsigned int ty
 static ni_bool_t
 address_acquired_callback_handler(ni_ifworker_t *w, const ni_objectmodel_callback_info_t *cb, ni_event_t event, ni_fsm_t *fsm, const char *object_path)
 {
-	ni_netdev_t *dev = w && cb ? w->device : NULL;
+	ni_netdev_t *dev;
 	ni_addrconf_lease_t *lease;
 	ni_addrconf_lease_t *other;
 	ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
-	if (!dev) {
-		w = ni_fsm_recv_new_netif_path(fsm, object_path);
-		if (w && cb) {
-			dev = w->device;
+	w = ni_fsm_recv_new_netif_path(fsm, object_path);
+	if (w && cb) {
+		dev = w->device;
 
-			/* Rebuild hierarchy */
-			ni_fsm_refresh_master_dev(fsm, w);
-			ni_fsm_refresh_lower_dev(fsm, w);
-		}
-		else
-			return FALSE;
+		/* Rebuild hierarchy */
+		ni_fsm_refresh_master_dev(fsm, w);
+		ni_fsm_refresh_lower_dev(fsm, w);
 	}
+	else
+		return FALSE;
 
 	switch (event) {
 	case NI_EVENT_ADDRESS_ACQUIRED:


### PR DESCRIPTION
- Perform refresh on existing devices when requested
- Always perform refresh on address acquire callback (factory devices needs whole workers, physical needs w->device->leases)
- On timeout check for optional dhcp leases and fail if non-optional lease is missing.
