### PR TITLE
dhcp6: do not break ifdown if release fails (bnc#884012)

### DIFF
--- a/dhcp6/device.c
+++ b/dhcp6/device.c
@@ -1160,7 +1160,6 @@ ni_dhcp6_release(ni_dhcp6_device_t *dev, const ni_uuid_t *lease_uuid)
 {
 	char *rel_uuid = NULL;
 	char *our_uuid = NULL;
-	int rv;
 
 	if (dev->lease == NULL) {
 		ni_error("%s: no lease set", dev->ifname);
@@ -1183,9 +1182,7 @@ ni_dhcp6_release(ni_dhcp6_device_t *dev, const ni_uuid_t *lease_uuid)
 		rel_uuid ? " with UUID " : "", rel_uuid ? rel_uuid : "");
 	ni_string_free(&rel_uuid);
 
-	if ((rv = ni_dhcp6_fsm_release(dev)) < 0)
-		return rv;
-
+	ni_dhcp6_fsm_release(dev);
 	return 0;
 }
 

--- a/dhcp6/fsm.c
+++ b/dhcp6/fsm.c
@@ -1448,12 +1448,14 @@ ni_dhcp6_fsm_release(ni_dhcp6_device_t *dev)
 
 	/* When all IA's are expired, just commit a release */
 	if (ni_dhcp6_lease_with_active_address(dev->lease)) {
-		return __ni_dhcp6_fsm_release(dev, 0);
+		__ni_dhcp6_fsm_release(dev, 0);
+		return ni_dhcp6_fsm_commit_lease(dev, NULL);
 	}
 
 	if (dev->config->mode == NI_DHCP6_MODE_INFO) {
 		ni_dhcp6_device_drop_lease(dev);
-		return ni_dhcp6_fsm_restart(dev);
+		ni_dhcp6_fsm_restart(dev);
+		return 0;
 	} else {
 		return ni_dhcp6_fsm_commit_lease(dev, NULL);
 	}


### PR DESCRIPTION
When the interface is not ready to send out a lease release,
commit the lease drop and notify wickedd, so ifdown goes on.
