### PR TITLE
events: do not delete dbus object immediately

### DIFF
--- a/src/dbus-objects/bonding.c
+++ b/src/dbus-objects/bonding.c
@@ -194,7 +194,6 @@ __ni_objectmodel_delete_bond(ni_dbus_object_t *object, const ni_dbus_method_t *m
 	}
 
 	ni_client_state_drop(dev->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/bridge.c
+++ b/src/dbus-objects/bridge.c
@@ -198,7 +198,6 @@ ni_objectmodel_delete_bridge(ni_dbus_object_t *object, const ni_dbus_method_t *m
 	}
 
 	ni_client_state_drop(dev->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/dummy.c
+++ b/src/dbus-objects/dummy.c
@@ -198,8 +198,7 @@ ni_objectmodel_dummy_delete(ni_dbus_object_t *object, const ni_dbus_method_t *me
 		return FALSE;
 	}
 
-	ni_dbus_object_free(object);
-
+	ni_client_state_drop(dev->link.ifindex);
 	return TRUE;
 }
 

--- a/src/dbus-objects/infiniband.c
+++ b/src/dbus-objects/infiniband.c
@@ -145,7 +145,6 @@ ni_objectmodel_ib_delete(ni_dbus_object_t *object, const ni_dbus_method_t *metho
 	}
 
 	ni_client_state_drop(ifp->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/macvlan.c
+++ b/src/dbus-objects/macvlan.c
@@ -374,7 +374,7 @@ __ni_objectmodel_macvlan_delete(ni_dbus_object_t *object, const ni_dbus_method_t
 		return FALSE;
 	}
 
-	ni_dbus_object_free(object);
+	ni_client_state_drop(dev->link.ifindex);
 	return TRUE;
 }
 

--- a/src/dbus-objects/ppp.c
+++ b/src/dbus-objects/ppp.c
@@ -128,7 +128,6 @@ ni_objectmodel_ppp_delete(ni_dbus_object_t *object, const ni_dbus_method_t *meth
 	}
 
 	ni_client_state_drop(dev->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/tun.c
+++ b/src/dbus-objects/tun.c
@@ -148,7 +148,6 @@ ni_objectmodel_tun_delete(ni_dbus_object_t *object, const ni_dbus_method_t *meth
 	}
 
 	ni_client_state_drop(dev->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/tuntap.c
+++ b/src/dbus-objects/tuntap.c
@@ -269,7 +269,6 @@ ni_objectmodel_tuntap_delete(ni_dbus_object_t *object, const ni_dbus_method_t *m
 	}
 
 	ni_client_state_drop(dev->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 

--- a/src/dbus-objects/vlan.c
+++ b/src/dbus-objects/vlan.c
@@ -259,7 +259,6 @@ ni_objectmodel_vlan_delete(ni_dbus_object_t *object, const ni_dbus_method_t *met
 	}
 
 	ni_client_state_drop(ifp->link.ifindex);
-	ni_dbus_object_free(object);
 	return TRUE;
 }
 


### PR DESCRIPTION
When a device deletion was successfull, we still have to send out
a dbus event about, so do not delete the object immediatelly, but
wait until the next netlink event arrives where we send them.
