### PR TITLE
nanny: Remove statedir when nanny is not in use

### DIFF
--- a/nanny/main.c
+++ b/nanny/main.c
@@ -282,6 +282,8 @@ babysit(void)
 	ni_nanny_discover_state(mgr);
 	if (ni_config_use_nanny())
 		ni_nanny_policy_load(mgr);
+	else
+		ni_file_remove_recursively(ni_nanny_statedir());
 
 	while (!ni_caught_terminal_signal()) {
 		long timeout;


### PR DESCRIPTION
In order to purge policies which may be obsolete after period of time when nanny was configured to be "not in use", nanny should remove all saved policies when restarted and configured "not in use".
