### PR TITLE
Pad DHCP4 packet to correct len (bnc#882561)

### DIFF
--- a/dhcp4/protocol.h
+++ b/dhcp4/protocol.h
@@ -139,7 +139,7 @@ enum FQQN {
 #define SERVERNAME_LEN          64
 #define BOOTFILE_LEN            128
 
-#define BOOTP_MESSAGE_LENGTH_MIN 300
+#define BOOTP_MESSAGE_LENGTH_MIN (20 + 8 + 300)
 
 struct ni_dhcp4_message {
 	unsigned char		op;		/* message type */


### PR DESCRIPTION
The buffer length includes also the IP and UDP header, which makes it already 315 byte.
bootpd-DD2 has a length check, it rejects short packets.

Signed-off-by: Olaf Hering olaf@aepfle.de
