### PR TITLE
ifup/reload: use default timeout if 0 (bnc#892486)

### DIFF
--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -218,6 +218,12 @@ usage:
 
 	fsm->worker_timeout = ni_fsm_find_max_timeout(fsm, timeout);
 
+	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+		ni_debug_application("wait for interfaces infinitely");
+	else
+		ni_debug_application("wait %u seconds for interfaces",
+					fsm->worker_timeout/1000);
+
 	if (!ni_fsm_create_client(fsm)) {
 		/* Severe error we always explicitly return */
 		return NI_WICKED_RC_ERROR;

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -146,6 +146,8 @@ usage:
 				"      Enable transient interface return codes\n"
 				"  --ifconfig <filename>\n"
 				"      Read interface configuration(s) from file\n"
+				"  --timeout <sec>\n"
+				"      Timeout after <sec> seconds\n"
 #ifdef NI_TEST_HACKS
 				"  --ignore-prio\n"
 				"      Ignore checking the config origin priorities\n"
@@ -200,12 +202,23 @@ usage:
 		goto cleanup;
 	}
 
-	if (opt_timeout)
+	/* Set timeout how long the action is allowed to wait */
+	if (opt_timeout) {
 		fsm->worker_timeout = opt_timeout; /* One set by user */
-	else {
+	} else
+	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-			ni_wait_for_interfaces*1000);
+					ni_wait_for_interfaces*1000);
+	} else {
+		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
+					NI_IFWORKER_DEFAULT_TIMEOUT);
 	}
+
+	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+		ni_debug_application("wait for interfaces infinitely");
+	else
+		ni_debug_application("wait %u seconds for interfaces",
+					fsm->worker_timeout/1000);
 
 	/* Build the up tree */
 	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
@@ -449,6 +462,8 @@ usage:
 				"      Enable transient interface return codes\n"
 				"  --ifconfig <filename>\n"
 				"      Read interface configuration(s) from file\n"
+				"  --timeout <sec>\n"
+				"      Timeout after <sec> seconds\n"
 #ifdef NI_TEST_HACKS
 				"  --ignore-prio\n"
 				"      Ignore checking the config origin priorities\n"
@@ -503,12 +518,23 @@ usage:
 		goto cleanup;
 	}
 
-	if (opt_timeout)
+	/* Set timeout how long the action is allowed to wait */
+	if (opt_timeout) {
 		fsm->worker_timeout = opt_timeout; /* One set by user */
-	else {
+	} else
+	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-			ni_wait_for_interfaces*1000);
+					ni_wait_for_interfaces*1000);
+	} else {
+		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
+					NI_IFWORKER_DEFAULT_TIMEOUT);
 	}
+
+	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+		ni_debug_application("wait for interfaces infinitely");
+	else
+		ni_debug_application("wait %u seconds for interfaces",
+					fsm->worker_timeout/1000);
 
 	/* Build the up tree */
 	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -520,8 +520,8 @@ usage:
 				"      Skip interfaces that have a configuration origin of <name>\n"
 				"      Usually, you would use this with the name \"firmware\" to avoid\n"
 				"      touching interfaces that have been set up via firmware (like iBFT) previously\n"
-				"  --timeout <nsec>\n"
-				"      Timeout after <nsec> seconds\n"
+				"  --timeout <sec>\n"
+				"      Timeout after <sec> seconds\n"
 #ifdef NI_TEST_HACKS
 				"  --ignore-prio\n"
 				"      Ignore checking the config origin priorities\n"
@@ -564,14 +564,24 @@ usage:
 		goto cleanup;
 	}
 
-	/* Client waits for device-up events for WAIT_FOR_INTERFACES */
-	/* Client waits for device-up events for WAIT_FOR_INTERFACES */
-	if (timeout)
+	/* Set timeout how long the action is allowed to wait */
+	if (timeout) {
 		fsm->worker_timeout = timeout; /* One set by user */
-	else {
+	} else
+	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-			ni_wait_for_interfaces*1000);
+				ni_wait_for_interfaces*1000);
+	} else {
+		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
+				NI_IFWORKER_DEFAULT_TIMEOUT);
 	}
+
+	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+		ni_debug_application("wait for interfaces infinitely");
+	else
+		ni_debug_application("wait %u seconds for interfaces",
+					fsm->worker_timeout/1000);
+
 	ni_nanny_fsm_monitor_arm(monitor, fsm->worker_timeout);
 
 	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
@@ -777,8 +787,8 @@ usage:
 				"      Skip interfaces that have a configuration origin of <name>\n"
 				"      Usually, you would use this with the name \"firmware\" to avoid\n"
 				"      touching interfaces that have been set up via firmware (like iBFT) previously\n"
-				"  --timeout <nsec>\n"
-				"      Timeout after <nsec> seconds\n"
+				"  --timeout <sec>\n"
+				"      Timeout after <sec> seconds\n"
 #ifdef NI_TEST_HACKS
 				"  --ignore-prio\n"
 				"      Ignore checking the config origin priorities\n"
@@ -827,13 +837,23 @@ usage:
 		goto cleanup;
 	}
 
-	/* Client waits for device-up events for WAIT_FOR_INTERFACES */
-	if (timeout)
+	/* Set timeout how long the action is allowed to wait */
+	if (timeout) {
 		fsm->worker_timeout = timeout; /* One set by user */
-	else {
+	} else
+	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-			ni_wait_for_interfaces*1000);
+				ni_wait_for_interfaces*1000);
+	} else {
+		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
+				NI_IFWORKER_DEFAULT_TIMEOUT);
 	}
+
+	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+		ni_debug_application("wait for interfaces infinitely");
+	else
+		ni_debug_application("wait %u seconds for interfaces",
+					fsm->worker_timeout/1000);
 
 	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
 		ni_error("ifup: unable to build device hierarchy");


### PR DESCRIPTION
ni_wait_for_interfaces may not set when no compat config is used
