### PR TITLE
ipv6: wait for addresses to become usable (bnc#882259)

### DIFF
--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -139,7 +139,8 @@ __ifstatus_of_device_leases(ni_netdev_t *dev, unsigned int *st)
 		if (lease->state == NI_ADDRCONF_STATE_NONE)
 			continue;
 
-		if (lease->state == NI_ADDRCONF_STATE_RELEASING ||
+		if (lease->state == NI_ADDRCONF_STATE_APPLYING ||
+		    lease->state == NI_ADDRCONF_STATE_RELEASING ||
 		    lease->state == NI_ADDRCONF_STATE_REQUESTING) {
 			if (!__is_peer_lease_up(dev, lease)) {
 				*st = NI_WICKED_ST_IN_PROGRESS;

--- a/include/wicked/addrconf.h
+++ b/include/wicked/addrconf.h
@@ -51,6 +51,7 @@ enum {
 enum {
 	NI_ADDRCONF_STATE_NONE,
 	NI_ADDRCONF_STATE_REQUESTING,
+	NI_ADDRCONF_STATE_APPLYING,
 	NI_ADDRCONF_STATE_GRANTED,
 	NI_ADDRCONF_STATE_RELEASING,
 	NI_ADDRCONF_STATE_RELEASED,
@@ -79,8 +80,13 @@ typedef enum ni_dhcp6_mode {
 struct ni_dhcp6_status;
 struct ni_dhcp6_ia;
 
+typedef struct ni_addrconf_updater	ni_addrconf_updater_t;
+
 struct ni_addrconf_lease {
 	ni_addrconf_lease_t *	next;
+
+	ni_addrconf_updater_t *	updater;	/* update actions	*/
+	ni_addrconf_lease_t *	old;		/* replaced old lease	*/
 
 	unsigned int		seqno;		/* globally unique sequence # */
 	ni_addrconf_mode_t	type;

--- a/src/dbus-objects/addrconf.c
+++ b/src/dbus-objects/addrconf.c
@@ -266,8 +266,11 @@ ni_objectmodel_addrconf_signal_handler(ni_dbus_connection_t *conn, ni_dbus_messa
 	 *
 	 * Note, lease may be NULL after this, as the interface object
 	 * takes ownership of it.
+	 *
+	 * Return code 0 is success, < 0 error where we do not emit events.
 	 */
-	__ni_system_interface_update_lease(ifp, &lease);
+	if (__ni_system_interface_update_lease(ifp, &lease) < 0)
+		goto done;
 
 	/* Potentially, there's a client somewhere waiting for that event.
 	 * We use the UUID that's passed back and forth to make sure we

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4175,6 +4175,7 @@ address_acquired_callback_handler(ni_ifworker_t *w, const ni_objectmodel_callbac
 						ni_stringbuf_destroy(&buf);
 
 					if (other->state == NI_ADDRCONF_STATE_GRANTED ||
+					    other->state == NI_ADDRCONF_STATE_APPLYING ||
 					    other->state == NI_ADDRCONF_STATE_REQUESTING)
 						return TRUE;
 				}

--- a/src/names.c
+++ b/src/names.c
@@ -159,6 +159,7 @@ ni_addrconf_type_to_name(unsigned int type)
 static const ni_intmap_t	__addrconf_states[] = {
 	{ "none",		NI_ADDRCONF_STATE_NONE },
 	{ "requesting",		NI_ADDRCONF_STATE_REQUESTING },
+	{ "applying",		NI_ADDRCONF_STATE_APPLYING },
 	{ "granted",		NI_ADDRCONF_STATE_GRANTED },
 	{ "releasing",		NI_ADDRCONF_STATE_RELEASING },
 	{ "released",		NI_ADDRCONF_STATE_RELEASED },

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -33,6 +33,8 @@
 #include "dhcp6/options.h"
 #include <gcrypt.h>
 
+extern void		ni_addrconf_updater_free(ni_addrconf_updater_t **);
+
 struct ni_netconfig {
 	ni_netdev_t *		interfaces;
 	ni_modem_t *		modems;
@@ -788,6 +790,12 @@ ni_addrconf_lease_dhcp6_destroy(struct ni_addrconf_lease_dhcp6 *dhcp6)
 void
 ni_addrconf_lease_destroy(ni_addrconf_lease_t *lease)
 {
+	ni_addrconf_updater_free(&lease->updater);
+	if (lease->old) {
+		ni_addrconf_lease_free(lease->old);
+		lease->old = NULL;
+	}
+
 	ni_string_free(&lease->owner);
 	ni_string_free(&lease->hostname);
 


### PR DESCRIPTION
Added a temporary applying lease state, which is used while
applying a new granted lease to the system.

When a granted ipv6 lease arrives and the addresses are set,
we've to wait unti the kernel verifyed them for duplicates
and removes the tentative flag before we continue to apply
the rest of the lease and finally inform the client about.

When the kernel detects duplicates, the state changes either
to failed and we do not set further settings or to requesting
state for dhcpv6 leases as it automatically declines.
