### PR TITLE
DHCP4 changes

### DIFF
--- a/dhcp4/fsm.c
+++ b/dhcp4/fsm.c
@@ -53,7 +53,7 @@ ni_dhcp4_defer_timeout(void *user_data, const ni_timer_t *timer)
 		ni_warn("%s: bad timer handle", __func__);
 		return;
 	}
-	ni_note("%s: DHCLIENT_WAIT_AT_BOOT=%u reached (fsm.state %u)", dev->ifname, dev->config->defer_timeout, dev->fsm.state);
+	ni_note("%s: DHCLIENT_WAIT_AT_BOOT=%u reached (state %s)", dev->ifname, dev->config->defer_timeout, ni_dhcp4_fsm_state_name(dev->fsm.state));
 	ni_dhcp4_send_event(NI_DHCP4_EVENT_DEFERRED, dev, NULL);
 }
 


### PR DESCRIPTION
Restart DHCP4 fsm in case of timeout in reboot state
Retry DHCP4 rebind until lease_time is reached
Restore config check in ni_dhcp4_fsm_release
