### PR TITLE
dhcp6: changed --test to request in auto mode

### DIFF
--- a/dhcp6/device.c
+++ b/dhcp6/device.c
@@ -518,7 +518,7 @@ ni_dhcp6_device_netdev(const ni_dhcp6_device_t *dev)
 	return ifp;
 }
 
-static void
+void
 ni_dhcp6_device_update_mode(ni_dhcp6_device_t *dev, const ni_netdev_t *ifp)
 {
 	if (!ifp && !(ifp = ni_dhcp6_device_netdev(dev)))

--- a/dhcp6/device.h
+++ b/dhcp6/device.h
@@ -32,6 +32,7 @@ extern int		ni_dhcp6_device_retransmit(ni_dhcp6_device_t *);
 extern void		ni_dhcp6_device_retransmit_disarm(ni_dhcp6_device_t *);
 
 extern ni_bool_t	ni_dhcp6_device_is_ready(const ni_dhcp6_device_t *, const ni_netdev_t *);
+extern void		ni_dhcp6_device_update_mode(ni_dhcp6_device_t *, const ni_netdev_t *);
 extern const ni_ipv6_ra_info_t  *ni_dhcp6_device_ra_info(const ni_dhcp6_device_t *, const ni_netdev_t *);
 extern const ni_ipv6_ra_pinfo_t *ni_dhcp6_device_ra_pinfo(const ni_dhcp6_device_t *, const ni_netdev_t *);
 extern int		ni_dhcp6_device_start(ni_dhcp6_device_t *);

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -58,6 +58,7 @@ enum {
 	OPT_RECOVER,
 
 	OPT_TEST,
+	OPT_TEST_MODE,
 	OPT_TEST_TIMEOUT,
 	OPT_TEST_REQUEST,
 	OPT_TEST_OUTPUT,
@@ -82,6 +83,7 @@ static struct option		options[] = {
 
 	/* test run */
 	{ "test",		no_argument,		NULL,	OPT_TEST         },
+	{ "test-mode",		required_argument,	NULL,	OPT_TEST_MODE    },
 	{ "test-request",	required_argument,	NULL,	OPT_TEST_REQUEST },
 	{ "test-timeout",	required_argument,	NULL,	OPT_TEST_TIMEOUT },
 	{ "test-output",	required_argument,	NULL,	OPT_TEST_OUTPUT  },
@@ -144,6 +146,7 @@ main(int argc, char **argv)
 				"\n"
 				"  --test [test-options] <ifname>\n"
 				"    test-options:\n"
+				"       --test-mode    <auto|info|managed>\n"
 				"       --test-request <request.xml>\n"
 				"       --test-timeout <timeout in sec> (default: 20+10)\n"
 				"       --test-output  <output file name>\n"
@@ -205,6 +208,13 @@ main(int argc, char **argv)
 		case OPT_TEST:
 			opt_foreground = TRUE;
 			tester = dhcp6_tester_init();
+			break;
+
+		case OPT_TEST_MODE:
+			if (!tester || ni_string_empty(optarg))
+				goto usage;
+			if (ni_dhcp6_mode_name_to_type(optarg, &tester->mode) < 0)
+				goto usage;
 			break;
 
 		case OPT_TEST_REQUEST:

--- a/dhcp6/tester.h
+++ b/dhcp6/tester.h
@@ -36,6 +36,7 @@ typedef struct dhcp6_tester {
 	const char *	request;
 	const char *	output;
 	unsigned int	outfmt;
+	ni_dhcp6_mode_t	mode;
 } dhcp6_tester_t;
 
 extern dhcp6_tester_t *	dhcp6_tester_init(void);


### PR DESCRIPTION
A new --test-mode <auto|info|managed> parameter allows
to set the mode as needed and thus override RA without
the need to provide a request.xml (bnc#889981 fix set).
