### PR TITLE
addrconf: fix to correctly fetch lease info flags

### DIFF
--- a/src/dbus-objects/misc.c
+++ b/src/dbus-objects/misc.c
@@ -1667,23 +1667,20 @@ __ni_objectmodel_return_callback_info(ni_dbus_message_t *reply, ni_event_t event
 static dbus_bool_t
 __ni_objectmodel_lease_info_to_dict(const ni_addrconf_lease_t *lease, ni_dbus_variant_t *dict)
 {
-	ni_dbus_variant_t *lease_dict;
-
 	if (!lease ||
 	    !ni_addrconf_type_to_name(lease->type) ||
 	    !ni_addrfamily_type_to_name(lease->family) ||
 	    !ni_addrconf_state_to_name(lease->state))
 		return FALSE;
 
-	lease_dict = ni_dbus_dict_add(dict, "lease");
-	ni_dbus_variant_init_dict(lease_dict);
-	ni_dbus_dict_add_uint32(lease_dict, "family", lease->family);
-	ni_dbus_dict_add_uint32(lease_dict, "type",   lease->type);
-	ni_dbus_dict_add_uint32(lease_dict, "state",  lease->state);
-	if (lease->flags)
-		ni_dbus_dict_add_uint32(lease_dict, "flags", lease->flags);
+	dict = ni_dbus_dict_add(dict, "lease");
+	ni_dbus_variant_init_dict(dict);
+	ni_dbus_dict_add_uint32(dict, "family", lease->family);
+	ni_dbus_dict_add_uint32(dict, "type",   lease->type);
+	ni_dbus_dict_add_uint32(dict, "state",  lease->state);
+	ni_dbus_dict_add_uint32(dict, "flags",  lease->flags);
 	if (!ni_uuid_is_null(&lease->uuid))
-		ni_dbus_dict_add_uuid(lease_dict,   "uuid", &lease->uuid);
+		ni_dbus_dict_add_uuid(dict, "uuid", &lease->uuid);
 	return TRUE;
 }
 
@@ -1730,23 +1727,22 @@ __ni_objectmodel_callback_info_to_dict(const ni_objectmodel_callback_info_t *cb,
 static ni_addrconf_lease_t *
 __ni_objectmodel_lease_info_from_dict(const ni_dbus_variant_t *dict)
 {
-	ni_dbus_variant_t *lease_dict;
-	ni_addrconf_lease_t *lease;
 	unsigned int type, family, state;
+	ni_addrconf_lease_t *lease;
 
-	lease_dict = ni_dbus_dict_get(dict, "lease");
-	if (!lease_dict || !ni_dbus_variant_is_dict(lease_dict))
+	dict = ni_dbus_dict_get(dict, "lease");
+	if (!dict || !ni_dbus_variant_is_dict(dict))
 		return NULL;
 
-	if (!ni_dbus_dict_get_uint32(lease_dict, "family", &family) ||
+	if (!ni_dbus_dict_get_uint32(dict, "family", &family) ||
 	    !ni_addrfamily_type_to_name(family))
 		return NULL;
 
-	if (!ni_dbus_dict_get_uint32(lease_dict, "type", &type) ||
+	if (!ni_dbus_dict_get_uint32(dict, "type", &type) ||
 	    !ni_addrconf_type_to_name(type))
 		return NULL;
 
-	if (!ni_dbus_dict_get_uint32(lease_dict, "state", &state) ||
+	if (!ni_dbus_dict_get_uint32(dict, "state", &state) ||
 	    !ni_addrconf_state_to_name(state))
 		return NULL;
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3482,15 +3482,16 @@ ni_ifworker_print_device_leases(ni_ifworker_t *w)
 		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_EVENTS,
 				"%s: worker device leases:", w->name);
 		for (lease = w->device->leases; lease; lease = lease->next) {
-			ni_bool_t optional = ni_addrconf_flag_bit_is_set(lease->flags,
-							NI_ADDRCONF_FLAGS_GROUP);
+			ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
+			ni_addrconf_flags_format(&buf, lease->flags, "|");
 			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_EVENTS,
-					"        %s:%s in state %s, uuid %s%s",
+					"        %s:%s in state %s, uuid %s, flags %s",
 					ni_addrfamily_type_to_name(lease->family),
 					ni_addrconf_type_to_name(lease->type),
 					ni_addrconf_state_to_name(lease->state),
 					ni_uuid_print(&lease->uuid),
-					optional ? ", optional" : "");
+					buf.string ? buf.string : "none");
+			ni_stringbuf_destroy(&buf);
 		}
 	}
 }
@@ -4241,11 +4242,12 @@ address_acquired_callback_handler(ni_ifworker_t *w, const ni_objectmodel_callbac
 		return TRUE;
 	}
 	ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_EVENTS,
-			"%s: adjusted %s:%s lease to state: %s",
+			"%s: adjusted %s:%s lease to state: %s, flags: 0x%02x",
 			w->name,
 			ni_addrfamily_type_to_name(lease->family),
 			ni_addrconf_type_to_name(lease->type),
-			ni_addrconf_state_to_name(lease->state));
+			ni_addrconf_state_to_name(lease->state),
+			lease->flags);
 	ni_ifworker_print_device_leases(w);
 
 	/* if there are still pending leases -- wait for them	*/
@@ -4263,15 +4265,17 @@ address_acquired_callback_handler(ni_ifworker_t *w, const ni_objectmodel_callbac
 			return FALSE;
 
 		/* optional type-goup peer lease -> check peer lease */
-		if ((other = __find_corresponding_lease(dev, lease->family, lease->type))) {
+		other = __find_corresponding_lease(dev, lease->family, lease->type);
+		if (other) {
+			ni_addrconf_flags_format(&buf, other->flags, "|");
 			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_EVENTS,
-					"%s: %s:%s peer lease in state %s [%s]",
+					"%s: %s:%s peer lease in state %s, flags %s",
 					w->name,
 					ni_addrfamily_type_to_name(other->family),
 					ni_addrconf_type_to_name(other->type),
 					ni_addrconf_state_to_name(other->state),
-					ni_addrconf_flags_format(&buf, other->flags, "|"));
-					ni_stringbuf_destroy(&buf);
+					buf.string ? buf.string : "none");
+			ni_stringbuf_destroy(&buf);
 
 			if (other->state != NI_ADDRCONF_STATE_GRANTED)
 				return FALSE;


### PR DESCRIPTION
While reading lease info flags and uuid from dbus the code were using wrong [callback]
dict instead of the lease info dict inside the callback dict. Show the flags in debug1 log.
