### PR TITLE
compat: warn about missed global configs (bnc#887910)

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -380,6 +380,8 @@ __ni_suse_read_globals(const char *root, const char *path)
 			ni_error("unable to parse %s", pathbuf);
 			return FALSE;
 		}
+	} else {
+		ni_warn("unable to find global config '%s': %m", pathbuf);
 	}
 
 	snprintf(pathbuf, sizeof(pathbuf), "%s/%s", path, __NI_SUSE_CONFIG_DHCP);
@@ -389,6 +391,8 @@ __ni_suse_read_globals(const char *root, const char *path)
 			ni_error("unable to parse %s", pathbuf);
 			return FALSE;
 		}
+	} else {
+		ni_warn("unable to find global config '%s': %m", pathbuf);
 	}
 
 	snprintf(pathbuf, sizeof(pathbuf), "%s/%s", path, __NI_SUSE_ROUTES_GLOBAL);


### PR DESCRIPTION
This will cause to show a warning while --ifconfig compat:/tmp when the global config
files  /tmp/config or /tmp/dhcp are missed.

Further, /etc/HOSTNAME is a compatibility link to /etc/hostname on >= 13.2 || sle12.
