### PR TITLE
gcrypt: do not fail on version mismatch (bsc#906217)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,15 +203,13 @@ AC_CHECK_LIB([anl], [getaddrinfo_a], [LIBANL_LIBS="-lanl"],[
 ])
 AC_SUBST(LIBANL_LIBS)
 
-AC_MSG_CHECKING([for libgcrypt])
-if ! test -x /usr/bin/libgcrypt-config; then
-	AC_MSG_ERROR([libgcrypt-config not found])
-fi
-LIBGCRYPT_CFLAGS=`/usr/bin/libgcrypt-config --cflags`
-LIBGCRYPT_LIBS=`/usr/bin/libgcrypt-config --libs`
-AC_SUBST(LIBGCRYPT_CFLAGS)
-AC_SUBST(LIBGCRYPT_LIBS)
-AC_MSG_RESULT([found.])
+# Checks for libgcrypt and it's minimal version;
+# libgcrypt-1.5.0 as on SLE-11-SP3 is sufficient.
+REQUIRE_LIBGCRYPT="1.5.0"
+AM_PATH_LIBGCRYPT([$REQUIRE_LIBGCRYPT],,[
+	AC_MSG_ERROR([Unable to find sufficient libgcrypt version])
+])
+AC_SUBST(REQUIRE_LIBGCRYPT)
 
 # Checks for pkg-config modules.
 PKG_CHECK_MODULES(LIBNL, [libnl-3.0 libnl-route-3.0])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,8 @@ libwicked_la_CPPFLAGS		= -DWICKED_CONFIGDIR=\"$(wicked_configdir)\" \
 				  -DWICKED_STOREDIR=\"$(wicked_storedir)\" \
 				  -DWICKED_STATEDIR=\"$(wicked_statedir)\" \
 				  -DWICKED_PIDDIR=\"$(wicked_piddir)\" \
-				  -DWICKED_SBINDIR=\"$(wicked_sbindir)\"
+				  -DWICKED_SBINDIR=\"$(wicked_sbindir)\" \
+				  -DREQUIRE_LIBGCRYPT=\"$(REQUIRE_LIBGCRYPT)\"
 
 libwicked_la_CFLAGS		= -I$(top_srcdir)		\
 				  -I$(top_srcdir)/include	\

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -60,8 +60,24 @@ ni_init(const char *appname)
 static int
 __ni_init_gcrypt(void)
 {
-	if (!gcry_check_version(GCRYPT_VERSION)) {
-		ni_error("libgcrypt version mismatch");
+/*
+ * gcry_check_version checks for minmum version
+ * we want consider sufficient and returns NULL
+ * on failures.
+ *
+ * configure.ac checks and defines the minimum;
+ * when our requirements change, adjust there.
+ *
+ * With NULL, we don't require a minimum version
+ * but call the function to initialize libgcrypt
+ * and trust the linker and library soname.
+ */
+#ifndef REQUIRE_LIBGCRYPT
+#define REQUIRE_LIBGCRYPT NULL
+#endif
+	if (!gcry_check_version(REQUIRE_LIBGCRYPT)) {
+		ni_error("libgcrypt version mismatch: built %s, required >= %s",
+			GCRYPT_VERSION, REQUIRE_LIBGCRYPT);
 		return -1;
 	}
 


### PR DESCRIPTION
Do not fail on libgcrypt exact version check but complain and
hope the library is compatible as the soname version indicates.
