### PR TITLE
netlink: recover from netlink event socket errors

### DIFF
--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -66,6 +66,14 @@ typedef struct ni_server_preference {
 	int			weight;
 } ni_server_preference_t;
 
+typedef struct ni_config_rtnl_event {
+	/*
+	 * rtnetlink event related tunables
+	 */
+	unsigned int	recv_buff_length;
+	unsigned int	mesg_buff_length;
+} ni_config_rtnl_event_t;
+
 typedef struct ni_config {
 	ni_config_fslocation_t	piddir;
 	ni_config_fslocation_t	storedir;
@@ -119,6 +127,9 @@ typedef struct ni_config {
 
 	char *			dbus_name;
 	char *			dbus_type;
+
+	ni_config_rtnl_event_t	rtnl_event;
+
 } ni_config_t;
 
 extern ni_config_t *	ni_config_new();

--- a/src/ifevent.c
+++ b/src/ifevent.c
@@ -724,11 +724,23 @@ __ni_rtevent_sock_release_data(void *user_data)
 	__ni_rtevent_handle_free(user_data);
 }
 
+static unsigned int
+__ni_rtevent_config_recv_buff_len(void)
+{
+	return ni_global.config ? ni_global.config->rtnl_event.recv_buff_length : 0;
+}
+
+static unsigned int
+__ni_rtevent_config_mesg_buff_len(void)
+{
+	return ni_global.config ? ni_global.config->rtnl_event.mesg_buff_length : 0;
+}
+
 static ni_socket_t *
 __ni_rtevent_sock_open(void)
 {
-	unsigned int recv_buff_len = 1024 * 1024;
-	unsigned int mesg_buff_len = 0;
+	unsigned int recv_buff_len = __ni_rtevent_config_recv_buff_len();
+	unsigned int mesg_buff_len = __ni_rtevent_config_mesg_buff_len();
 	ni_rtevent_handle_t *handle;
 	ni_socket_t *sock;
 	int fd, ret;


### PR DESCRIPTION
Reopen netlink event socket on errors and  make the buffer sizes configurable.
