### PR TITLE
dhcp4: handle user-class option in config (bsc#909307)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -116,6 +116,7 @@ ni_compat_netdev_new(const char *ifname)
 	compat->dhcp4.update = ni_config_addrconf_update_mask(NI_ADDRCONF_DHCP, AF_INET);
 	compat->dhcp4.recover_lease = TRUE;
 	compat->dhcp4.release_lease = FALSE;
+	compat->dhcp4.user_class.format = -1U;
 
 	compat->dhcp6.update = ni_config_addrconf_update_mask(NI_ADDRCONF_DHCP, AF_INET6);
 	compat->dhcp6.mode = NI_DHCP6_MODE_AUTO;
@@ -169,6 +170,7 @@ ni_compat_netdev_free(ni_compat_netdev_t *compat)
 		ni_string_free(&compat->dhcp4.hostname);
 		ni_string_free(&compat->dhcp4.client_id);
 		ni_string_free(&compat->dhcp4.vendor_class);
+		ni_string_array_destroy(&compat->dhcp4.user_class.class_id);
 
 		ni_string_free(&compat->dhcp6.hostname);
 		ni_string_free(&compat->dhcp6.client_id);
@@ -1245,6 +1247,29 @@ __ni_compat_generate_dynamic_addrconf(xml_node_t *ifnode, const char *name, unsi
 	return aconf;
 }
 
+/*
+ * Generate XML for user-class data. We want to support both rfc3004 and non-standardized
+ * string case and allow for specification of formatting.
+ */
+static void
+__ni_compat_generate_dhcp4_user_class(xml_node_t *ifnode, const ni_dhcp4_user_class_t *user_class)
+{
+	xml_node_t *user_class_node;
+	const char *ptr;
+	unsigned int i;
+
+	if ((ptr = ni_dhcp4_user_class_format_type_to_name(user_class->format))) {
+		user_class_node = xml_node_new("user-class", ifnode);
+		xml_node_dict_set(user_class_node, "format", ptr);
+		for (i = 0; i < user_class->class_id.count; ++i) {
+			xml_node_new_element("identifier", user_class_node, user_class->class_id.data[i]);
+			if (user_class->format ==  NI_DHCP4_USER_CLASS_STRING)
+				break;
+		}
+	}
+}
+
+
 static xml_node_t *
 __ni_compat_generate_dhcp4_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t *compat)
 {
@@ -1289,6 +1314,10 @@ __ni_compat_generate_dhcp4_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 		xml_node_dict_set(dhcp, "client-id", compat->dhcp4.client_id);
 	if (compat->dhcp4.vendor_class)
 		xml_node_dict_set(dhcp, "vendor-class", compat->dhcp4.vendor_class);
+
+	if (compat->dhcp4.user_class.class_id.count) {
+		__ni_compat_generate_dhcp4_user_class(dhcp, &compat->dhcp4.user_class);
+	}
 
 	return dhcp;
 }

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -29,6 +29,7 @@
 
 #include <wicked/client.h>
 #include <wicked/objectmodel.h>
+#include <wicked/addrconf.h>
 #include <wicked/fsm.h>
 
 extern int			opt_global_dryrun;
@@ -54,6 +55,7 @@ typedef struct ni_compat_netdev {
 		char *		hostname;
 		char *		client_id;
 		char *		vendor_class;
+		ni_dhcp4_user_class_t user_class;
 
 		unsigned int	start_delay;
 		unsigned int	defer_timeout;

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -271,6 +271,7 @@ ni_dhcp4_request_free(ni_dhcp4_request_t *req)
 	ni_string_free(&req->hostname);
 	ni_string_free(&req->clientid);
 	ni_string_free(&req->vendor_class);
+	ni_string_array_destroy(&req->user_class.class_id);
 	free(req);
 }
 

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -315,12 +315,112 @@ ni_objectmodel_get_dhcp4_request(const ni_dbus_object_t *object, ni_bool_t write
 	return __ni_objectmodel_get_dhcp4_request(object, error);
 }
 
+static dbus_bool_t
+__dhcp4_request_set_user_class(ni_dbus_object_t *object,
+			const ni_dbus_property_t *property,
+			const ni_dbus_variant_t *argument,
+			DBusError *error)
+{
+	ni_dhcp4_request_t *req = NULL;
+	ni_dhcp4_user_class_t *uc = NULL;
+	ni_dbus_variant_t *var = NULL;
+	uint32_t format;
+	size_t total_len = 0;
+	size_t len;
+
+	if (!(req = __ni_objectmodel_get_dhcp4_request(object, error)))
+		return FALSE;
+
+	uc = &req->user_class;
+
+	if (!ni_dbus_dict_get_uint32(argument, "format", &format))
+		return FALSE;
+
+	if (format != NI_DHCP4_USER_CLASS_RFC3004 && format != NI_DHCP4_USER_CLASS_STRING) {
+		ni_warn("Invalid user class format (%u) obtained", format);
+		return FALSE;
+	}
+	uc->format = format;
+
+	while ((var = ni_dbus_dict_get_next(argument, "identifier", var))) {
+		if (!(len = ni_string_len(var->string_value))) {
+			ni_warn("Empty user class identifier found");
+			return FALSE;
+		}
+
+		if (format == NI_DHCP4_USER_CLASS_STRING && uc->class_id.count)
+			break; /* only one user class identifier for this format type */
+
+		if (!ni_check_domain_name(var->string_value, len, 0)) {
+			ni_warn("Suspect user class id string: '%s' obtained. Skipping.",
+				ni_print_suspect(var->string_value, len));
+			return FALSE;
+		}
+
+		if(uc->format == NI_DHCP4_USER_CLASS_RFC3004)
+			total_len += len + 1;
+		else
+			total_len += len;
+
+		if (len >= 255 || total_len >= 255) {
+			ni_warn("User class data exceeds maximum allowed length.");
+			ni_string_array_destroy(&uc->class_id);
+			return FALSE;
+		}
+
+		ni_string_array_append(&uc->class_id, var->string_value);
+	}
+
+	return TRUE;
+}
+
+static dbus_bool_t
+__dhcp4_request_get_user_class(const ni_dbus_object_t *object,
+			const ni_dbus_property_t *property,
+			ni_dbus_variant_t *result,
+			DBusError *error)
+{
+	ni_dhcp4_request_t *req = NULL;
+	ni_dhcp4_user_class_t *uc = NULL;
+	unsigned int i;
+	size_t len;
+
+	if (!(req = __ni_objectmodel_get_dhcp4_request(object, error)))
+		return FALSE;
+
+	uc = &req->user_class;
+
+	if (uc->format != NI_DHCP4_USER_CLASS_RFC3004 && uc->format != NI_DHCP4_USER_CLASS_STRING) {
+		ni_warn("Invalid user class format (%u) found", uc->format);
+		return FALSE;
+	}
+
+	if (!uc->class_id.count)
+		return FALSE;
+
+	ni_dbus_dict_add_uint32(result, "format", uc->format);
+
+	for (i = 0; i < uc->class_id.count; ++i) {
+		len = ni_string_empty(uc->class_id.data[i]);
+		if (!ni_check_domain_name(uc->class_id.data[i], len, 0))
+			ni_warn("Suspect user class id string: '%s' found. Skipping.",
+				ni_print_suspect(uc->class_id.data[i], len));
+		else
+			ni_dbus_dict_add_string(result, "identifier", uc->class_id.data[i]);
+		if (uc->format == NI_DHCP4_USER_CLASS_STRING)
+			break; /* a single string */
+	}
+
+	return TRUE;
+}
+
 static ni_dbus_property_t	dhcp4_request_properties[] = {
 	DHCP4REQ_BOOL_PROPERTY(enabled, enabled, RO),
 	DHCP4REQ_UUID_PROPERTY(uuid, uuid, RO),
 	DHCP4REQ_UINT_PROPERTY(flags, flags, RO),
 	DHCP4REQ_STRING_PROPERTY(client-id, clientid, RO),
 	DHCP4REQ_STRING_PROPERTY(vendor-class, vendor_class, RO),
+	___NI_DBUS_PROPERTY(NI_DBUS_DICT_SIGNATURE, user-class, user_class, __dhcp4_request, RO),
 	DHCP4REQ_UINT_PROPERTY(start-delay, start_delay, RO),
 	DHCP4REQ_UINT_PROPERTY(defer-timeout, defer_timeout, RO),
 	DHCP4REQ_UINT_PROPERTY(acquire-timeout, acquire_timeout, RO),

--- a/dhcp4/dhcp.h
+++ b/dhcp4/dhcp.h
@@ -148,6 +148,7 @@ struct ni_dhcp4_request {
 	/* Options controlling what to put into the lease request */
 	char *			clientid;
 	char *			vendor_class;
+	ni_dhcp4_user_class_t	user_class;
 
 	char *			hostname;
 	unsigned int		route_priority;
@@ -173,7 +174,7 @@ struct ni_dhcp4_config {
 	int			fqdn;
 
 	ni_opaque_t		client_id;
-	ni_opaque_t		userclass;
+	ni_dhcp4_user_class_t	user_class;
 
 	unsigned int		start_delay;
 	unsigned int		defer_timeout;

--- a/include/wicked/addrconf.h
+++ b/include/wicked/addrconf.h
@@ -83,6 +83,19 @@ typedef enum ni_dhcp6_mode {
 struct ni_dhcp6_status;
 struct ni_dhcp6_ia;
 
+/*
+ * DHCPv4 user class structure
+ */
+typedef enum {
+	NI_DHCP4_USER_CLASS_RFC3004 = 0U,
+	NI_DHCP4_USER_CLASS_STRING,
+} ni_dhcp4_user_class_format_t;
+
+typedef struct ni_dhcp4_user_class {
+	ni_dhcp4_user_class_format_t    format;
+	ni_string_array_t               class_id;
+} ni_dhcp4_user_class_t;
+
 typedef struct ni_addrconf_updater	ni_addrconf_updater_t;
 
 struct ni_addrconf_lease {

--- a/include/wicked/addrconf.h
+++ b/include/wicked/addrconf.h
@@ -222,6 +222,9 @@ extern const char *	ni_addrconf_update_flags_format(ni_stringbuf_t *, unsigned i
 extern const char *	ni_dhcp6_mode_type_to_name(unsigned int);
 extern int		ni_dhcp6_mode_name_to_type(const char *, unsigned int *);
 
+extern const char *	ni_dhcp4_user_class_format_type_to_name(unsigned int);
+extern int		ni_dhcp4_user_class_format_name_to_type(const char *, unsigned int *);
+
 extern const char *	ni_netbios_node_type_to_name(unsigned int);
 extern ni_bool_t	ni_netbios_node_type_to_code(const char *, unsigned int *);
 

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -54,6 +54,19 @@ hardware address of the network interface is sent as client identifier.
 Specifies the vendor class identifier string. The default is DHCP client
 specific.
 .TP
+.BR DHCLIENT_USER_CLASS_FORMAT\ { string* | rfc3004 }
+Specifies the format of the DHCLIENT_USER_CLASS_ID variable.
+The DHCPv4 option and it's format is specified by RFC3004 as an array
+of class identifiers, but most DHCP clients/servers aren't compliant
+with the specification and send/expect a single string without proper
+RFC3004 length-value tuple format instead.
+When set to "rfc3004" DHCLIENT_USER_CLASS_ID[SUFFIX] permit an RFC
+compliant array, otherwise DHCLIENT_USER_CLASS_ID is used as string.
+.TP
+.BR DHCLIENT_USER_CLASS_ID[SUFFIX]
+Specifies the user class identifier [array] to send in dhcp requests.
+The DHCLIENT_USER_CLASS_FORMAT variable specified how to interpret it.
+.TP
 .BR DHCLIENT_LEASE_TIME
 Specifies the lease time (in seconds), that is suggested to the server. Default
 is unset which means to use the lease time offered by the server.

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -177,6 +177,13 @@
 
     <client-id type="string" />
     <vendor-class type="string" />
+    <user-class class="dict">
+      <format type="uint32" constraint="enum">
+	<rfc3004 value="0"/>
+	<string value="1"/>
+      </format>
+      <identifier type="string"/>
+    </user-class>
 
     <start-delay type="uint32" />
     <defer-timeout type="uint32" />

--- a/src/names.c
+++ b/src/names.c
@@ -337,6 +337,26 @@ ni_dhcp6_mode_name_to_type(const char *name, unsigned int *type)
 	return ni_parse_uint_mapped(name, __dhcp6_modes, type);
 }
 
+/* Map DHCP4 user-class formats */
+static const ni_intmap_t	__dhcp4_user_class_formats[] = {
+	{ "rfc3004",		NI_DHCP4_USER_CLASS_RFC3004	},
+	{ "string",		NI_DHCP4_USER_CLASS_STRING	},
+
+	{ NULL,			-1U				}
+};
+
+const char *
+ni_dhcp4_user_class_format_type_to_name(unsigned int type)
+{
+	return ni_format_uint_mapped(type, __dhcp4_user_class_formats);
+}
+
+int
+ni_dhcp4_user_class_format_name_to_type(const char *name, unsigned int *type)
+{
+	return ni_parse_uint_mapped(name, __dhcp4_user_class_formats, type);
+}
+
 /*
  * Map ARPHRD_* constants to string
  */


### PR DESCRIPTION
Handles parsing of rfc3004 formatted user-class
as well as non-standard but common string type.