### PR TITLE
FSM: introduce newDevice call ACK; reset timer on each action; change the action logging

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3884,8 +3884,9 @@ ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 
 		ni_fsm_schedule_bind_methods(fsm, w);
 	}
+	else
+		ni_ifworker_set_state(w, action->next_state);
 
-	ni_ifworker_set_state(w, action->next_state);
 	return 0;
 }
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4158,6 +4158,8 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 
 			if (rv >= 0) {
 				made_progress = 1;
+				if (w->fsm.timer)
+					ni_ifworker_set_timeout(w, fsm->worker_timeout);
 				if (w->fsm.state == action->next_state) {
 					/* We should not have transitioned to the next state while
 					 * we were still waiting for some event. */

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3839,6 +3839,9 @@ ni_ifworker_bind_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 static int
 ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transition_t *action)
 {
+	/* Initially, enable waiting for this action */
+	w->fsm.wait_for = action;
+
 	if (!ni_ifworker_device_bound(w)) {
 		struct ni_fsm_transition_binding *bind;
 		const char *relative_path;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4160,7 +4160,7 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 				made_progress = 1;
 				if (w->fsm.timer)
 					ni_ifworker_set_timeout(w, fsm->worker_timeout);
-				if (w->fsm.state == action->next_state) {
+				if (w->fsm.state >= action->next_state) {
 					/* We should not have transitioned to the next state while
 					 * we were still waiting for some event. */
 					ni_assert(w->fsm.wait_for == NULL);


### PR DESCRIPTION
1.
When creating non-existing device, wait for device-create to arrive.

2.
Restarting the timer on every successful action is just a proposal; basically when we start multiple (many ;-)) devices with limited, low high-watermark (a feature to be soon implemented) we may be delaying final requestLease action due to waiting ~1 for generic updater - in order to let all devices successfully finish restarting timer might be a good option.

3.
Action/state transition in the FSM might be doubled before we reach the check (e.g. when device-ready arrives just after device-create event). Consider the following:

<pre>
These are multiplexed logs of state transitions from FSM and async (+waiting) PoV:

DELL:/etc/sysconfig/network # grep -E "changed state|successfully|waiting for event" log_all |grep br0

wicked: br0: changed state device-down -> device-exists
wicked: br0: changed state device-exists -> device-ready
wicked: br0: successfully transitioned from device-down to device-ready
wicked: br0: successfully transitioned from device-ready to device-ready
wicked: br0: changed state device-ready -> device-up
wicked: br0: successfully transitioned from device-ready to device-up
wicked: br0: changed state device-up -> protocols-up
wicked: br0: successfully transitioned from device-up to protocols-up
wicked: br0: changed state protocols-up -> firewall-up
wicked: br0: successfully transitioned from protocols-up to firewall-up
wicked: br0: waiting for event in state firewall-up
wicked: br0: changed state firewall-up -> link-up, resuming activity
wicked: br0: changed state link-up -> link-authenticated
wicked: br0: successfully transitioned from link-up to link-authenticated
wicked: br0: changed state link-authenticated -> lldp-up
wicked: br0: successfully transitioned from link-authenticated to lldp-up
wicked: br0: waiting for event in state lldp-up
wicked: br0: changed state lldp-up -> network-up, resuming activity

These are state transitions (buth FSM + async):

DELL:/etc/sysconfig/network # grep changed log_all |grep br0
wicked: br0: changed state device-down -> device-exists
wicked: br0: changed state device-exists -> device-ready
wicked: br0: changed state device-ready -> device-up
wicked: br0: changed state device-up -> protocols-up
wicked: br0: changed state protocols-up -> firewall-up
wicked: br0: changed state firewall-up -> link-up, resuming activity
wicked: br0: changed state link-up -> link-authenticated
wicked: br0: changed state link-authenticated -> lldp-up
wicked: br0: changed state lldp-up -> network-up, resuming activity

These are action tranistions from FSM PoV:

DELL:/etc/sysconfig/network # grep successfully log_all |grep br0
wicked: br0: successfully transitioned from device-down to device-ready
wicked: br0: successfully transitioned from device-ready to device-ready
wicked: br0: successfully transitioned from device-ready to device-up
wicked: br0: successfully transitioned from device-up to protocols-up
wicked: br0: successfully transitioned from protocols-up to firewall-up
wicked: br0: successfully transitioned from link-up to link-authenticated
wicked: br0: successfully transitioned from link-authenticated to lldp-up

After applying the patches:

DELL:/etc/sysconfig/network # grep -E "action.*successful|waiting for event|changed state" log_all |grep br0
wicked: br0: changed state device-down -> device-exists
wicked: br0: changed state device-exists -> device-ready
wicked: br0: action device-down -> device-exists successful
wicked: br0: action device-exists -> device-ready successful
wicked: br0: changed state device-ready -> device-up
wicked: br0: action device-ready -> device-up successful
wicked: br0: changed state device-up -> protocols-up
wicked: br0: action device-up -> protocols-up successful
wicked: br0: changed state protocols-up -> firewall-up
wicked: br0: action protocols-up -> firewall-up successful
wicked: br0: waiting for event in state firewall-up
wicked: br0: changed state firewall-up -> link-up, resuming activity
wicked: br0: changed state link-up -> link-authenticated
wicked: br0: action link-up -> link-authenticated successful
wicked: br0: changed state link-authenticated -> lldp-up
wicked: br0: action link-authenticated -> lldp-up successful
wicked: br0: waiting for event in state lldp-up
wicked: br0: changed state lldp-up -> network-up, resuming activity

DELL:/etc/sysconfig/network # grep -E "action.*successful|waiting for event" log_all |grep br0
wicked: br0: action device-down -> device-exists successful
wicked: br0: action device-exists -> device-ready successful
wicked: br0: action device-ready -> device-up successful
wicked: br0: action device-up -> protocols-up successful
wicked: br0: action protocols-up -> firewall-up successful
wicked: br0: waiting for event in state firewall-up
wicked: br0: action link-up -> link-authenticated successful
wicked: br0: action link-authenticated -> lldp-up successful
wicked: br0: waiting for event in state lldp-up
</pre>