### PR TITLE
FSM: introduce newDevice call ACK; reset timer on each action; change the action logging

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3884,8 +3884,9 @@ ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 
 		ni_fsm_schedule_bind_methods(fsm, w);
 	}
+	else
+		ni_ifworker_set_state(w, action->next_state);
 
-	ni_ifworker_set_state(w, action->next_state);
 	return 0;
 }
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3839,6 +3839,9 @@ ni_ifworker_bind_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 static int
 ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transition_t *action)
 {
+	/* Initially, enable waiting for this action */
+	w->fsm.wait_for = action;
+
 	if (!ni_ifworker_device_bound(w)) {
 		struct ni_fsm_transition_binding *bind;
 		const char *relative_path;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4094,7 +4094,6 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 		for (i = 0; i < fsm->workers.count; ++i) {
 			ni_ifworker_t *w = fsm->workers.data[i];
 			ni_fsm_transition_t *action;
-			unsigned int prev_state;
 			int rv;
 
 			ni_ifworker_get(w);
@@ -4153,34 +4152,22 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 
 			ni_ifworker_set_secondary_timeout(w, 0, NULL);
 
-			prev_state = w->fsm.state;
 			rv = action->func(fsm, w, action);
 			w->fsm.next_action++;
 
 			if (rv >= 0) {
 				made_progress = 1;
-				if (w->fsm.state == action->next_state) {
-					/* We should not have transitioned to the next state while
-					 * we were still waiting for some event. */
-					ni_assert(w->fsm.wait_for == NULL);
-					ni_debug_application("%s: successfully transitioned from %s to %s",
-						w->name,
-						ni_ifworker_state_name(prev_state),
-						ni_ifworker_state_name(w->fsm.state));
-				} else {
+				if (w->fsm.wait_for != NULL) {
 					ni_debug_application("%s: waiting for event in state %s",
-						w->name,
-						ni_ifworker_state_name(w->fsm.state));
-					w->fsm.wait_for = action;
+						w->name, ni_ifworker_state_name(w->fsm.state));
 				}
 			} else
 			if (!w->failed) {
 				/* The fsm action should really have marked this
 				 * as a failure. shame on the lazy programmer. */
-				ni_ifworker_fail(w, "%s: failed to transition from %s to %s",
-						w->name,
-						ni_ifworker_state_name(prev_state),
-						ni_ifworker_state_name(action->next_state));
+				ni_ifworker_fail(w, "%s: action %s -> %s failed", w->name,
+					ni_ifworker_state_name(action->from_state),
+					ni_ifworker_state_name(action->next_state));
 			}
 
 			ni_ifworker_release(w);


### PR DESCRIPTION
1. When creating non-existing device, wait for device-create ACK to arrive before moving on to next action.

2. Restarting the timer on every successful action is just a proposal; basically when we start multiple (many ;-)) devices with limited, low high-watermark (a feature to be soon implemented) we may be delaying final requestLease action due to waiting ~1 for generic updater - in order to let all devices successfully finish restarting timer might be a good option.
Therefore ifworker timer will expire when no action has been taken successfully within timeout value (WAIT_FOR_INTERFACES).

3. Action/state transition in the FSM might be doubled before we reach the check (e.g. when device-ready arrives just after device-create event). Consider the following:

<pre>
These are multiplexed logs of state transitions from FSM and async (+waiting) PoV:

DELL:/etc/sysconfig/network # grep -E "changed state|successfully|waiting for event" log_all |grep br0

wicked: br0: changed state device-down -> device-exists
wicked: br0: changed state device-exists -> device-ready
wicked: br0: successfully transitioned from device-down to device-ready
wicked: br0: successfully transitioned from device-ready to device-ready
wicked: br0: changed state device-ready -> device-up
wicked: br0: successfully transitioned from device-ready to device-up
wicked: br0: changed state device-up -> protocols-up
wicked: br0: successfully transitioned from device-up to protocols-up
wicked: br0: changed state protocols-up -> firewall-up
wicked: br0: successfully transitioned from protocols-up to firewall-up
wicked: br0: waiting for event in state firewall-up
wicked: br0: changed state firewall-up -> link-up, resuming activity
wicked: br0: changed state link-up -> link-authenticated
wicked: br0: successfully transitioned from link-up to link-authenticated
wicked: br0: changed state link-authenticated -> lldp-up
wicked: br0: successfully transitioned from link-authenticated to lldp-up
wicked: br0: waiting for event in state lldp-up
wicked: br0: changed state lldp-up -> network-up, resuming activity

These are state transitions (both FSM + async):

DELL:/etc/sysconfig/network # grep changed log_all |grep br0
wicked: br0: changed state device-down -> device-exists
wicked: br0: changed state device-exists -> device-ready
wicked: br0: changed state device-ready -> device-up
wicked: br0: changed state device-up -> protocols-up
wicked: br0: changed state protocols-up -> firewall-up
wicked: br0: changed state firewall-up -> link-up, resuming activity
wicked: br0: changed state link-up -> link-authenticated
wicked: br0: changed state link-authenticated -> lldp-up
wicked: br0: changed state lldp-up -> network-up, resuming activity

These are action transitions from FSM PoV:

DELL:/etc/sysconfig/network # grep successfully log_all |grep br0
wicked: br0: successfully transitioned from device-down to device-ready
wicked: br0: successfully transitioned from device-ready to device-ready
wicked: br0: successfully transitioned from device-ready to device-up
wicked: br0: successfully transitioned from device-up to protocols-up
wicked: br0: successfully transitioned from protocols-up to firewall-up
wicked: br0: successfully transitioned from link-up to link-authenticated
wicked: br0: successfully transitioned from link-authenticated to lldp-up
</pre>

Therefore we should distinguish (ignore) action transition and focus on state transitions as more meaningful.
