### PR TITLE
fsm: permit to continue setup without a ready link

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1487,13 +1487,18 @@ __ni_compat_generate_ifcfg(xml_node_t *ifnode, const ni_compat_netdev_t *compat)
 				ni_format_boolean(control->usercontrol));
 		}
 
-		if (control->link_timeout || control->link_priority || control->link_required) {
+		if (control->link_timeout || control->link_priority || ni_tristate_is_set(control->link_required)) {
 			linkdet = xml_node_create(child, "link-detection");
-			if (control->link_timeout)
-				xml_node_new_element("timeout", linkdet,
+			if (linkdet) {
+				if (ni_tristate_is_set(control->link_required)) {
+					xml_node_new_element("require-link", linkdet,
+						ni_format_boolean(ni_tristate_is_enabled(control->link_required)));
+				}
+				if (control->link_timeout) {
+					xml_node_new_element("timeout", linkdet,
 						ni_sprint_timeout(control->link_timeout));
-			if (control->link_required)
-				(void) xml_node_new("require-link", linkdet);
+				}
+			}
 		}
 	}
 

--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -90,8 +90,8 @@ ni_ifcheck_device_link_required(ni_netdev_t *dev)
 
 	if (cs && ni_tristate_is_set(cs->control.require_link))
 		link_required = cs->control.require_link;
-
-	/* TODO: apply device specific magic */
+	else if (dev)
+		link_required = ni_netdev_guess_link_required(dev);
 
 	return !ni_tristate_is_disabled(link_required);
 }
@@ -117,8 +117,14 @@ ni_ifcheck_worker_device_enabled(ni_ifworker_t *w)
 ni_bool_t
 ni_ifcheck_worker_device_link_required(ni_ifworker_t *w)
 {
-	/* TODO: apply device specific magic */
-	return w && !ni_tristate_is_disabled(w->control.link_required);
+	ni_tristate_t link_required = NI_TRISTATE_DEFAULT;
+
+	if (w && ni_tristate_is_set(w->control.link_required))
+		link_required = w->control.link_required;
+	else if (w && w->device)
+		link_required = ni_netdev_guess_link_required(w->device);
+
+	return !ni_tristate_is_disabled(link_required);
 }
 
 ni_bool_t

--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -83,6 +83,20 @@ ni_ifcheck_device_is_persistent(ni_netdev_t *dev)
 }
 
 ni_bool_t
+ni_ifcheck_device_link_required(ni_netdev_t *dev)
+{
+	ni_client_state_t *cs = dev ? dev->client_state : NULL;
+	ni_tristate_t link_required = NI_TRISTATE_DEFAULT;
+
+	if (cs && ni_tristate_is_set(cs->control.require_link))
+		link_required = cs->control.require_link;
+
+	/* TODO: apply device specific magic */
+
+	return !ni_tristate_is_disabled(link_required);
+}
+
+ni_bool_t
 ni_ifcheck_worker_device_exists(ni_ifworker_t *w)
 {
 	return w && w->device;
@@ -103,7 +117,8 @@ ni_ifcheck_worker_device_enabled(ni_ifworker_t *w)
 ni_bool_t
 ni_ifcheck_worker_device_link_required(ni_ifworker_t *w)
 {
-	return w && w->control.link_required;
+	/* TODO: apply device specific magic */
+	return w && !ni_tristate_is_disabled(w->control.link_required);
 }
 
 ni_bool_t

--- a/client/ifcheck.h
+++ b/client/ifcheck.h
@@ -34,6 +34,7 @@ extern ni_bool_t	ni_ifcheck_device_is_up(ni_netdev_t *);
 extern ni_bool_t	ni_ifcheck_device_link_is_up(ni_netdev_t *);
 extern ni_bool_t	ni_ifcheck_device_network_is_up(ni_netdev_t *);
 extern ni_bool_t	ni_ifcheck_device_is_persistent(ni_netdev_t *);
+extern ni_bool_t	ni_ifcheck_device_link_required(ni_netdev_t *);
 
 extern ni_bool_t	ni_ifcheck_worker_device_exists(ni_ifworker_t *);
 extern ni_bool_t	ni_ifcheck_worker_device_enabled(ni_ifworker_t *);

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -283,7 +283,8 @@ __ifstatus_of_device(ni_netdev_t *dev)
 	if (!ni_string_empty(dev->link.masterdev.name))
 		return NI_WICKED_ST_ENSLAVED;
 
-	if (!ni_ifcheck_device_link_is_up(dev))
+	if (!ni_ifcheck_device_link_is_up(dev) &&
+	    ni_ifcheck_device_link_required(dev))
 		return NI_WICKED_ST_IN_PROGRESS;
 
 	__ifstatus_of_device_leases(dev, &st);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -112,7 +112,7 @@ typedef struct ni_ifworker_control {
 	char *			boot_stage;
 	ni_bool_t		persistent;
 	ni_bool_t		usercontrol;
-	ni_bool_t		link_required;
+	ni_tristate_t		link_required;
 	unsigned int		link_priority;
 	unsigned int		link_timeout;
 } ni_ifworker_control_t;

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -285,6 +285,8 @@ extern ni_bool_t	ni_netdev_device_is_ready(ni_netdev_t *);
 extern ni_bool_t	ni_netdev_device_always_ready(ni_netdev_t *);
 extern ni_bool_t	ni_netdev_link_always_ready(ni_linkinfo_t *);
 
+extern ni_tristate_t	ni_netdev_guess_link_required(const ni_netdev_t *);
+
 static inline int
 ni_netdev_device_is_up(const ni_netdev_t *ifp)
 {

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -45,7 +45,8 @@ substitute_vars			= \
 	-e "s|[@]wicked_schemadir[@]|$(wicked_schemadir)|g"	\
 	-e "s|[@]wicked_configdir[@]|$(wicked_configdir)|g"	\
 	-e "s|[@]wicked_supplicantdir[@]|$(wicked_supplicantdir)|g"\
-	-e "s|[@]wicked_extensionsdir[@]|$(wicked_extensionsdir)|g"
+	-e "s|[@]wicked_extensionsdir[@]|$(wicked_extensionsdir)|g"\
+	-e "s|[@]PACKAGE_BUGREPORT[@]|$(PACKAGE_BUGREPORT)|g"
 
 wicked%: wicked%.in $(top_builddir)/config.status
 	@echo "substituting variables in $< > $@"

--- a/man/ifcfg.5.in
+++ b/man/ifcfg.5.in
@@ -225,24 +225,43 @@ valid inside this site.
 .BR MTU
 Set the maximum transfer unit (MTU) for this interface.
 .TP
-.BR IP_OPTIONS [ \fIsuffix\fR ]
-Any other option you may want to give to the
-.B ip add add ...
-command. This string is appended to the command.
-.TP
 .B LLADDR
 Set an individual link layer address (MAC address).
 .TP
-.B LINK_OPTIONS
-Here you may add any option valid with
-.B ip link set up ...
+.B LINK_REQUIRED\ { auto \fR| yes | no\fB }
+While a working and connected link is required for further setup
+steps, such as bridge STP, link authentication, auto configuration
+of the IP address (dhcp, ...) and duplicate IP address detection
+(enabled by default), it is required in some cases to continue
+the setup without to consider the link detection (carrier), e.g.
+in well-known static "router like" setups. You may want to disable
+also the duplicate IP detection (see \fBCHECK_DUPLICATE_IP\fR and
+the \fBifsysctl(5)\fR manual page).
+
+This variable permits to configure the waiting for link-detection.
+When set to \fByes\fR, wicked waits until link has been detected
+before it continues with further steps.
+When set to \fBno\fR, wicked is permitted to continue earlier,
+without to wait for a link in a usable state.
+When set to \fBauto\fR (default), an internal logic is applied
+causing to use a "no" for tun/tap devices (which require a driver
+daemon) and for bridges with enabled STP and without any ports.
+In other cases, it behaves as "yes".
 .TP
-.B INTERFACETYPE
-In case ifup cannot determine the interface type properly, you may
-specify the correct type in this variable to override the behavior
-and force ifup to handle the interface differently than it detected
-from system or config.
-Please always open a bug report when it is required to set the type.
+.B LINK_READY_WAIT
+This variable configures how long to wait for the link detection
+(by the kernel / network card driver) in seconds.
+Default is 0, causing to not wait at all if link is not required
+or wait infinitely when link is required, so nanny can continue
+with the setup when the cable gets connected to the network card
+after a while.
+Otherwise wicked will wait until the specified number of seconds
+and continue with further steps if link is not required or fail
+and stop further steps if nanny is not used (see \fBuse-nanny\fR
+in \fBwicked-config(5)\fR).
+Note, that an ifup call has it's own, independent timeout, which
+is limitting the maximal time ifup waits before it has to report
+(see global network/config \fBWAIT_FOR_INTERFACES\fR variable).
 .TP
 .B ETHTOOL_OPTIONS [ \fIsuffix\fR ]
 If this variable is not empty, wicked will set these options on an
@@ -262,6 +281,21 @@ e.g.:
 
 The NIC driver may reject settings as not supported (e.g. '-K iface lro off')
 or also when the link is not up.
+.TP
+.B CHECK_DUPLICATE_IP\ { yes \fR| no\fB }
+Whether to detect duplicate IPv4 addresses or not. Set to "no" to disable it.
+By default, duplicate IPv4 addresses checks are enabled on ARP capable devices.
+
+The IPv6 duplicate address detection is configured by the accept_dad sysctl
+variable (see \fBifsysctl(5)\fR).
+Note, that duplicate addresses check requires a connected/usable link and
+skipped when it is not (see \fBLINK_REQUIRED\fR).
+.TP
+.B SEND_GRATUITOUS_ARP\ { auto \fR| yes | no\fB }
+When a new IPv4 has been configured on an interface, send a gratuitous ARP
+to inform the receivers about the address (trigger arp cache update).
+Default is to send gratuitous ARP, when also duplicate IPv4 address check
+is enabled and the check were sucessful.
 .TP
 .B TUNNEL, TUNNEL_*
 Using this variable you may set up different tunnels. See
@@ -289,18 +323,42 @@ is used to set the infiniband transport mode of an IB device to one of "connecte
 .B IPOIB_UMCAST
 is used to enable/disable user-multicast for an IB device by setting to "allowed"
 or "disallowed".
+.TP
+.B INTERFACETYPE
+In case ifup cannot determine the interface type properly, you may specify the
+correct type in this variable to override the behavior and force ifup to handle
+the interface differently than it detected from system or config.
+Please always open a bug report when it is required to set the type.
 
 .SH GENERAL VARIABLES
-There are some general settings in the file
+.TP
 .IR /etc/sysconfig/network/config
-and
-.IR /etc/sysconfig/network/dhcp .
-See the
-.B ifup
-.BR (8)
+.TP
+.B WAIT_FOR_INTERFACES
+Specifies how log ifup waits for interfaces in seconds by default before it stops
+processing and reports the status reached until then. This time may be automatically
+increased in case of involved devices which require more time, such as bridge with
+enabled STP (IEEE defaults may need up to 50 seconds additionally).
+
+This setting can be overridden by the \fIwicked ifup --timeout\fR option (see the
+\fBwicked(8)\fR manual page).
+Note: nanny is not affected by this ifup reporting timeout and continues to setup
+in background until ifdown or reboot.
+
+.TP
+See also the \fB/etc/sysconfig/network/config\fR configuration file and the
+\fBnetconfig(8)\fR manual page.
+
+.TP
+.IR /etc/sysconfig/network/dhcp
+.TP
+See the \fB/etc/sysconfig/network/dhcp\fR configuration file and the \fBifcfg-dhcp\fR
 manual page.
 
-.SH Multiple addresses
+
+.SH EXAMPLES
+.TP
+.B Multiple addresses
 
 You can extend the variable name
 .B IPADDR
@@ -324,13 +382,15 @@ Example:
 .PP
 
 .SH COPYRIGHT
-Copyright (C) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+Copyright (C) 2004-2015 SUSE LINUX GmbH, Nuernberg, Germany.
 .SH BUGS
-Please report bugs at <https://bugzilla.novell.com/index.cgi>
+Please report bugs at <@PACKAGE_BUGREPORT@>
 .SH AUTHOR
 .nf
-Michal Ludvig -- tunneling
-Pawel Wieczorkiewicz -- wicked
+Michal Ludvig
+Karol Mroz
+Pawel Wieczorkiewicz
+Marius Tomaschewski
 .fi
 .SH "SEE ALSO"
 .BR ifcfg-dhcp (5),

--- a/man/ifup.8.in
+++ b/man/ifup.8.in
@@ -114,8 +114,8 @@ routes (5) for a detailed description.
 .SH GENERAL VARIABLES
 There are some general settings in the file
 .IR /etc/sysconfig/network/config .
-If needed you can also set every general variable as an individual variable in
-the
+If needed you can also set most of the general variables as an individual variable
+in the
 .B ifcfg-*
 files.
 Please see the description of these variables in

--- a/src/client/client_state.h
+++ b/src/client/client_state.h
@@ -12,26 +12,29 @@
 #include <unistd.h>
 #include <wicked/logging.h>
 
-#define NI_CLIENT_STATE_XML_NODE			"client-state"
+#define NI_CLIENT_STATE_XML_NODE		"client-state"
 
 #define NI_CLIENT_STATE_XML_CONTROL_NODE	"control"
 #define NI_CLIENT_STATE_XML_PERSISTENT_NODE	"persistent"
 #define NI_CLIENT_STATE_XML_USERCONTROL_NODE	"usercontrol"
+#define NI_CLIENT_STATE_XML_REQUIRE_LINK_NODE	"require-link"
 
-#define NI_CLIENT_STATE_XML_CONFIG_NODE	"config"
+#define NI_CLIENT_STATE_XML_CONFIG_NODE		"config"
 #define NI_CLIENT_STATE_XML_CONFIG_UUID_NODE	"uuid"
 #define NI_CLIENT_STATE_XML_CONFIG_ORIGIN_NODE	"origin"
 #define NI_CLIENT_STATE_XML_CONFIG_OWNER_NODE	"owner-uid"
 
 typedef struct ni_client_state_control {
-	ni_bool_t persistent;   /* allowing/disallowing ifdown flag */
-	ni_bool_t usercontrol;  /* allowing/disallowing user to change the config */
+	ni_bool_t	persistent;	/* allowing/disallowing ifdown flag */
+	ni_bool_t	usercontrol;	/* allowing/disallowing user to change the config */
+	ni_tristate_t	require_link;	/* require link-up or ignore link detection results
+					   and consider an administrative UP as sufficient? */
 } ni_client_state_control_t;
 
 typedef struct ni_client_state_config {
-	ni_uuid_t	uuid;   /* Configuration UUID marker of the interface */
-	char *	origin; /* Source of the configuration of the interface */
-	uid_t	owner;  /* User's UID who has initiated the given configuration */
+	ni_uuid_t	uuid;		/* Configuration UUID marker of the interface */
+	char *		origin;		/* Source of the configuration of the interface */
+	uid_t		owner;		/* User's UID who has initiated the given configuration */
 } ni_client_state_config_t;
 #define NI_CLIENT_STATE_CONFIG_INIT { .uuid = NI_UUID_INIT, .origin = NULL, .owner = -1U }
 
@@ -49,7 +52,10 @@ extern void		ni_client_state_config_init(ni_client_state_config_t *);
 extern void		ni_client_state_config_reset(ni_client_state_config_t *);
 extern void		ni_client_state_config_copy(ni_client_state_config_t *,
 						const ni_client_state_config_t *);
-
+extern void		ni_client_state_control_init(ni_client_state_control_t *);
+extern void		ni_client_state_control_reset(ni_client_state_control_t *);
+extern void		ni_client_state_control_copy(ni_client_state_control_t *,
+						const ni_client_state_control_t *);
 extern ni_bool_t	ni_client_state_control_is_valid(const ni_client_state_control_t *);
 extern ni_bool_t	ni_client_state_config_is_valid(const ni_client_state_config_t *);
 extern ni_bool_t	ni_client_state_is_valid(const ni_client_state_t *);

--- a/src/dbus-objects/interface.c
+++ b/src/dbus-objects/interface.c
@@ -1290,6 +1290,13 @@ ni_objectmodel_netif_client_state_control_to_dict(const ni_client_state_control_
 		return FALSE;
 	}
 
+	if (ni_tristate_is_set(ctrl->require_link)) {
+		if (!ni_dbus_dict_add_bool(var, NI_CLIENT_STATE_XML_REQUIRE_LINK_NODE,
+			(dbus_bool_t) ni_tristate_is_disabled(ctrl->require_link))) {
+			return FALSE;
+		}
+	}
+
 	return TRUE;
 }
 
@@ -1368,6 +1375,11 @@ ni_objectmodel_netif_client_state_control_from_dict(ni_client_state_control_t *c
 
 	if (ni_dbus_dict_get_bool(var, NI_CLIENT_STATE_XML_USERCONTROL_NODE, &val))
 		ctrl->usercontrol = val;
+
+	if (ni_dbus_dict_get_bool(var, NI_CLIENT_STATE_XML_REQUIRE_LINK_NODE, &val))
+		ni_tristate_set(&ctrl->require_link, val);
+	else
+		ctrl->require_link = NI_TRISTATE_DEFAULT;
 
 	return TRUE;
 }

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -27,6 +27,7 @@
 #include <wicked/bridge.h>
 
 #include "client/ifconfig.h"
+#include "appconfig.h"
 #include "util_priv.h"
 
 static ni_fsm_user_prompt_fn_t *ni_fsm_user_prompt_fn;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -382,7 +382,7 @@ ni_ifworker_fail(ni_ifworker_t *w, const char *fmt, ...)
 	vsnprintf(errmsg, sizeof(errmsg), fmt, ap);
 	va_end(ap);
 
-	ni_error("device %s failed: %s", w->name, errmsg);
+	ni_error("device %s: %s", w->name, ni_string_empty(errmsg) ? "failed" : errmsg);
 	w->fsm.state = NI_FSM_STATE_NONE;
 	w->failed = TRUE;
 	w->pending = FALSE;
@@ -2661,7 +2661,7 @@ ni_fsm_destroy_worker(ni_fsm_t *fsm, ni_ifworker_t *w)
 	ni_ifworker_cancel_timeout(w);
 
 	if (ni_ifworker_active(w))
-		ni_ifworker_fail(w, "device was deleted");
+		ni_ifworker_fail(w, "device has been deleted");
 
 	ni_fsm_clear_hierarchy(w);
 	ni_ifworker_release(w);
@@ -3968,7 +3968,7 @@ ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 		ni_debug_application("%s: calling device factory", w->name);
 		object_path = ni_call_device_new_xml(bind->service, w->name, bind->config);
 		if (object_path == NULL) {
-			ni_ifworker_fail(w, "failed to create interface");
+			ni_ifworker_fail(w, "failed to create new device");
 			return -1;
 		}
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1941,8 +1941,10 @@ ni_ifworker_link_detection_timeout(const ni_timer_t *timer, ni_fsm_timer_ctx_t *
 		ni_warn("%s: link did not came up in time, proceeding anyway", w->name);
 		ni_ifworker_cancel_callbacks(w, &action->callbacks);
 		ni_ifworker_set_state(w, action->next_state);
+	} else if (ni_config_use_nanny()) {
+		ni_warn("%s: link did not came up in time, proceeding anyway", w->name);
 	} else {
-		ni_ifworker_fail(w, "link did not come up in specified time");
+		ni_ifworker_fail(w, "link did not came up in specified time");
 	}
 }
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1660,8 +1660,14 @@ ni_ifworker_control_from_xml(ni_ifworker_t *w, xml_node_t *ctrlnode)
 	control = &w->control;
 	if ((np = xml_node_get_child(ctrlnode, "mode")) != NULL)
 		ni_string_dup(&control->mode, np->cdata);
+	else if (!ni_string_eq(control->mode, "boot"))
+		ni_string_dup(&control->mode, "boot");
+
 	if ((np = xml_node_get_child(ctrlnode, "boot-stage")) != NULL)
 		ni_string_dup(&control->boot_stage, np->cdata);
+	else if (!ni_string_eq(control->boot_stage, NULL))
+		ni_string_dup(&control->boot_stage, NULL);
+
 	if ((np = xml_node_get_child(ctrlnode, NI_CLIENT_STATE_XML_PERSISTENT_NODE)) &&
 	    !ni_parse_boolean(np->cdata, &val)) {
 		ni_ifworker_control_set_persistent(w, val);
@@ -1670,6 +1676,10 @@ ni_ifworker_control_from_xml(ni_ifworker_t *w, xml_node_t *ctrlnode)
 	    !ni_parse_boolean(np->cdata, &val)) {
 		ni_ifworker_control_set_usercontrol(w, val);
 	}
+
+	control->link_priority = 0;
+	control->link_required = NI_TRISTATE_DEFAULT;
+	control->link_timeout  = NI_IFWORKER_INFINITE_TIMEOUT;
 	if ((linknode = xml_node_get_child(ctrlnode, "link-detection")) != NULL) {
 		if ((np = xml_node_get_child(linknode, "timeout")) != NULL) {
 			if (ni_string_eq(np->cdata, "infinite"))

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3915,7 +3915,8 @@ ni_ifworker_link_detection_call(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 
 	ret = ni_ifworker_do_common_call(fsm, w, action);
 
-	/* TODO: apply device specific link_required=auto magic here */
+	if (!ni_tristate_is_set(w->control.link_required) && w->device)
+		w->control.link_required = ni_netdev_guess_link_required(w->device);
 
 	if (ret >= 0 && w->fsm.wait_for) {
 		if (w->control.link_timeout != NI_IFWORKER_INFINITE_TIMEOUT) {

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2709,15 +2709,6 @@ ni_ifworker_start(ni_fsm_t *fsm, ni_ifworker_t *w, unsigned long timeout)
 		return -NI_ERROR_GENERAL_FAILURE;
 	}
 
-	for (j = 0; j < w->children.count; ++j) {
-		ni_ifworker_t *child = w->children.data[j];
-
-		if (w->control.link_required)
-			child->control.link_required = TRUE;
-		if (w->control.link_timeout < child->control.link_timeout)
-			child->control.link_timeout = w->control.link_timeout;
-	}
-
 	ni_debug_application("%s: current state=%s target state=%s",
 				w->name,
 				ni_ifworker_state_name(w->fsm.state),

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4562,8 +4562,8 @@ interface_state_change_signal(ni_dbus_connection_t *conn, ni_dbus_message_t *msg
 	if (event_type == NI_EVENT_ADDRESS_ACQUIRED)
 		fsm->last_event_seq[NI_EVENT_ADDRESS_ACQUIRED] = fsm->event_seq;
 
-	if (event_type == NI_EVENT_DEVICE_READY) {
-		/* Refresh device on create */
+	if (event_type == NI_EVENT_DEVICE_READY || event_type == NI_EVENT_DEVICE_UP) {
+		/* Refresh device on ready & device-up */
 		if (!(w = ni_fsm_recv_new_netif_path(fsm, object_path))) {
 			ni_error("%s: Cannot find corresponding worker for %s",
 				__func__, object_path);

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -169,6 +169,28 @@ ni_netdev_device_is_ready(ni_netdev_t *dev)
 	return dev ? dev->link.ifflags & NI_IFF_DEVICE_READY : FALSE;
 }
 
+ni_tristate_t
+ni_netdev_guess_link_required(const ni_netdev_t *dev)
+{
+	ni_tristate_t link_required = NI_TRISTATE_DEFAULT;
+
+	switch (dev->link.type) {
+	case NI_IFTYPE_TUN:
+	case NI_IFTYPE_TAP:
+		ni_tristate_set(&link_required, FALSE);
+		break;
+
+	case NI_IFTYPE_BRIDGE:
+		if (dev->bridge && dev->bridge->stp && !dev->bridge->ports.count)
+			ni_tristate_set(&link_required, FALSE);
+		break;
+
+	default:
+		break;
+	}
+	return link_required;
+}
+
 /*
  * This is a convenience function for adding addresses to an interface.
  */


### PR DESCRIPTION
Initial handing of control/link-detection require-link and timeout flags
to continue setup without ready link (bsc#911562,bsc#914792).