### PR TITLE
fsm: Add autocreated flag to the worker

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -137,6 +137,7 @@ struct ni_ifworker {
 				done		: 1,
 				kickstarted	: 1,
 				pending		: 1,
+				autocreated	: 1,
 				readonly	: 1;
 
 	ni_ifworker_control_t	control;

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -417,8 +417,13 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, const 
 	if (!w->kickstarted) {
 		if (ni_ifworker_is_factory_device(w))
 			ni_nanny_schedule_recheck(&mgr->recheck, w);
-		else if (schedule && w->device)
-			ni_nanny_schedule_recheck(&mgr->recheck, w);
+		else if (w->device) {
+			/* If device exists and we are discovereing and applying old policies, we should reschedule.
+			 * Same if device exists and is automatically created by the kernel
+			 */
+			if (schedule || w->autocreated)
+				ni_nanny_schedule_recheck(&mgr->recheck, w);
+		}
 	}
 
 	/* Register the policy */

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1716,6 +1716,28 @@ ni_ifworker_extra_waittime_from_xml(ni_ifworker_t *w)
 	w->extra_waittime = (extra_timeout*1000);
 }
 
+static void
+ni_ifworker_set_autocreated(ni_ifworker_t *w)
+{
+	if (!w)
+		return;
+
+	switch (w->iftype) {
+	case NI_IFTYPE_LOOPBACK:
+		w->autocreated = TRUE;
+		break;
+	case NI_IFTYPE_DUMMY:
+		if (ni_string_eq(w->name, "dummy0")) {
+			w->autocreated = TRUE;
+			break;
+		}
+		/* Fall through */
+	default:
+		w->autocreated = FALSE;
+		break;
+	}
+}
+
 static ni_iftype_t
 ni_ifworker_iftype_from_xml(xml_node_t *config)
 {
@@ -1808,6 +1830,7 @@ ni_fsm_workers_from_xml(ni_fsm_t *fsm, xml_node_t *ifnode, const char *origin)
 	}
 
 	ni_ifworker_set_config(w, ifnode, origin);
+	ni_ifworker_set_autocreated(w);
 
 	return TRUE;
 }


### PR DESCRIPTION
Autocreated devices should be started by nanny,
whenver new policy for them arrives and device
already exists.