### PR TITLE
dummy: fix handling of automatically created dummy0

### DIFF
--- a/src/kernel.h
+++ b/src/kernel.h
@@ -66,6 +66,7 @@ extern int		__ni_tuntap_create(const ni_netdev_t *);
 extern char *		__ni_ppp_create_device(ni_ppp_t *, const char *);
 
 extern int		__ni_netdev_rename(const char *old_name, const char *new_name);
+extern int		__ni_rtnl_link_rename(unsigned int ifindex, const char *oldname, const char *newname);
 
 extern const void *	__ni_nla_get_data(size_t, const struct nlattr *);
 extern int		__ni_nla_get_addr(int, ni_sockaddr_t *, const struct nlattr *);


### PR DESCRIPTION
Initial dummy0[0] = if_nametoindex("dummy0") was not there
as it should be.