### PR TITLE
sit,ipip: Unload module when ifdown on sit0 or tunl0

### DIFF
--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -264,7 +264,7 @@ main(int argc, char **argv)
 	ni_srandom();
 
 	/* load af_packet module we need for capturing */
-	ni_modprobe(AFPACKET_MODULE_NAME, AFPACKET_MODULE_OPTS);
+	ni_modprobe(NI_MODPROBE_LOAD_OPT, AFPACKET_MODULE_NAME, AFPACKET_MODULE_OPTS);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/src/bonding.c
+++ b/src/bonding.c
@@ -143,7 +143,7 @@ ni_bonding_load(const char *options)
 	if (options == NULL)
 		options = BONDING_MODULE_OPTS;
 
-	return ni_modprobe(BONDING_MODULE_NAME, options);
+	return ni_modprobe(NI_MODPROBE_LOAD_OPT, BONDING_MODULE_NAME, options);
 }
 
 /*

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -881,7 +881,7 @@ ni_system_dummy_create(ni_netconfig_t *nc, const ni_netdev_t *cfg,
 		return -NI_ERROR_DEVICE_EXISTS;
 	}
 
-	if (ni_modprobe(DUMMY_MODULE_NAME, DUMMY_MODULE_OPTS) < 0)
+	if (ni_modprobe(NI_MODPROBE_LOAD_OPT, DUMMY_MODULE_NAME, DUMMY_MODULE_OPTS) < 0)
 		ni_warn("failed to load %s network driver module", DUMMY_MODULE_NAME);
 
 	ni_debug_ifconfig("%s: creating dummy interface", cfg->name);
@@ -1685,7 +1685,7 @@ __ni_system_tunnel_load_modules(unsigned int type)
 	 */
 	switch (type) {
 	case NI_IFTYPE_GRE:
-		if (ni_modprobe(GRE_TUNNEL_MODULE_NAME, NULL) < 0) {
+		if (ni_modprobe(NI_MODPROBE_LOAD_OPT, GRE_TUNNEL_MODULE_NAME, NULL) < 0) {
 			ni_error("failed to load %s module",
 				GRE_TUNNEL_MODULE_NAME);
 			mod_load_ret = -1;
@@ -1693,12 +1693,12 @@ __ni_system_tunnel_load_modules(unsigned int type)
 		break;
 
 	case NI_IFTYPE_SIT:
-		if (ni_modprobe(TUNNEL4_MODULE_NAME, NULL) < 0) {
+		if (ni_modprobe(NI_MODPROBE_LOAD_OPT, TUNNEL4_MODULE_NAME, NULL) < 0) {
 			ni_error("failed to load %s module",
 				TUNNEL4_MODULE_NAME);
 			mod_load_ret = -1;
 		}
-		if (ni_modprobe(SIT_TUNNEL_MODULE_NAME, NULL) < 0) {
+		if (ni_modprobe(NI_MODPROBE_LOAD_OPT, SIT_TUNNEL_MODULE_NAME, NULL) < 0) {
 			ni_error("failed to load %s module",
 				SIT_TUNNEL_MODULE_NAME);
 			mod_load_ret = -1;
@@ -1706,12 +1706,12 @@ __ni_system_tunnel_load_modules(unsigned int type)
 		break;
 
 	case NI_IFTYPE_IPIP:
-		if (ni_modprobe(TUNNEL4_MODULE_NAME, NULL) < 0) {
+		if (ni_modprobe(NI_MODPROBE_LOAD_OPT, TUNNEL4_MODULE_NAME, NULL) < 0) {
 			ni_error("failed to load %s module",
 				TUNNEL4_MODULE_NAME);
 			mod_load_ret = -1;
 		}
-		if (ni_modprobe(IPIP_TUNNEL_MODULE_NAME, NULL) < 0) {
+		if (ni_modprobe(NI_MODPROBE_LOAD_OPT, IPIP_TUNNEL_MODULE_NAME, NULL) < 0) {
 			ni_error("failed to load %s module",
 				IPIP_TUNNEL_MODULE_NAME);
 			mod_load_ret = -1;

--- a/src/modprobe.c
+++ b/src/modprobe.c
@@ -9,31 +9,25 @@
 
 #include <wicked/util.h>
 #include "process.h"
-
-#ifndef NI_MODPROBE_BIN
-#define NI_MODPROBE_BIN "/sbin/modprobe"
-#endif
-#ifndef NI_MODPROBE_OPT
-#define NI_MODPROBE_OPT "-qs"
-#endif
+#include "modprobe.h"
 
 int
-ni_modprobe(const char *module, const char *options)
+ni_modprobe(const char *options, const char *module, const char *moptions)
 {
 	ni_string_array_t argv;
 	ni_shellcmd_t *cmd;
 	ni_process_t *pi;
 	int rv;
 
-	if (ni_string_len(module) == 0)
+	if (ni_string_empty(options) || ni_string_empty(module))
 		return -1;
 
 	ni_string_array_init(&argv);
 	if (ni_string_array_append(&argv, NI_MODPROBE_BIN) < 0 ||
-	    ni_string_array_append(&argv, NI_MODPROBE_OPT) < 0 ||
+	    ni_string_array_append(&argv, options) < 0 ||
 	    ni_string_array_append(&argv, "--") < 0 ||
 	    ni_string_array_append(&argv, module) < 0 ||
-	    (options && ni_string_split(&argv, options, " \t", 0) == 0)) {
+	    (!ni_string_empty(moptions) && ni_string_split(&argv, moptions, " \t", 0) == 0)) {
 		ni_string_array_destroy(&argv);
 		return -1;
 	}

--- a/src/modprobe.h
+++ b/src/modprobe.h
@@ -7,6 +7,16 @@
 #ifndef __WICKED_MODPROBE_H__
 #define __WICKED_MODPROBE_H__
 
-extern int	ni_modprobe(const char *module, const char *options);
+#ifndef NI_MODPROBE_BIN
+#define NI_MODPROBE_BIN "/sbin/modprobe"
+#endif
+#ifndef NI_MODPROBE_LOAD_OPT
+#define NI_MODPROBE_LOAD_OPT "-qs"
+#endif
+#ifndef NI_MODPROBE_REMOVE_OPT
+#define NI_MODPROBE_REMOVE_OPT "-rqs"
+#endif
+
+extern int	ni_modprobe(const char *options, const char *module, const char *moptions);
 
 #endif /* __WICKED_MODPROBE_H__ */


### PR DESCRIPTION
Since we are loading sit/gre/ipip modules on ifup, it _might_ make sense to unload it and therefore allow for graceful ifdown of sit0 or tunl0. Otherwise kernel does not let to remove them and ifdown (especially one with --delete aka --force device-delete) waits 30s to timeout.