### PR TITLE
Fsm: Introduce ni_fsm_ifworker_find() to looks for workers (bsc#918662)

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -283,6 +283,7 @@ extern void			ni_fsm_reset_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, c
 extern int			ni_fsm_build_hierarchy(ni_fsm_t *, ni_bool_t);
 extern ni_bool_t		ni_fsm_workers_from_xml(ni_fsm_t *, xml_node_t *, const char *);
 extern unsigned int		ni_fsm_fail_count(ni_fsm_t *);
+extern ni_ifworker_t *		ni_fsm_ifworker_find(ni_fsm_t *, ni_netdev_t *, unsigned int, const char *);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_object_path(ni_fsm_t *, const char *);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_ifindex(ni_fsm_t *, unsigned int);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_netdev(ni_fsm_t *, const ni_netdev_t *);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -581,7 +581,6 @@ ni_nanny_unregister_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 	ni_objectmodel_unregister_managed_device(mdev);
 	ni_nanny_unschedule(&mgr->recheck, w);
 	ni_nanny_policy_drop(w->name);
-	ni_fsm_destroy_worker(mgr->fsm, w);
 }
 
 /*

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -813,7 +813,7 @@ ni_nanny_netif_state_change_signal_receive(ni_dbus_connection_t *conn, ni_dbus_m
 	const char *object_path = dbus_message_get_path(msg);
 	ni_event_t event;
 	ni_managed_device_t *mdev;
-	ni_ifworker_t *w;
+	ni_ifworker_t *w = NULL;
 
 	if (ni_objectmodel_signal_to_event(signal_name, &event) < 0) {
 		ni_debug_nanny("received unknown signal \"%s\" from object \"%s\"",
@@ -829,7 +829,9 @@ ni_nanny_netif_state_change_signal_receive(ni_dbus_connection_t *conn, ni_dbus_m
 			ni_nanny_register_device(mgr, w);
 	}
 
-	w = ni_fsm_ifworker_by_object_path(mgr->fsm, object_path);
+	if (!w)
+		w = ni_fsm_ifworker_find(mgr->fsm, NULL, 0, object_path);
+
 	if (!w) {
 		ni_warn("received signal \"%s\" from unknown object \"%s\"",
 				signal_name, object_path);

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3998,6 +3998,7 @@ ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 
 		ni_debug_application("created device %s (path=%s)", w->name, object_path);
 		ni_string_dup(&w->object_path, object_path);
+		w->ifindex = __ni_fsm_dbus_objectpath_to_ifindex(object_path);
 
 		relative_path = ni_string_strip_prefix(NI_OBJECTMODEL_OBJECT_PATH "/", object_path);
 		if (relative_path == NULL) {

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -735,6 +735,10 @@ done:
 	return ifindex;
 }
 
+/* Since we cannot trust the ifname, before device is ready (has been renamed),
+ * usage of this function should be avoided
+ */
+#if 0
 /*
  * __ni_dbus_objectpath_to_name() allocates a string and return interface name
  */
@@ -757,6 +761,7 @@ __ni_fsm_dbus_objectpath_to_name(const char *object_path)
 	ni_string_dup(&ifname, buf);
 	return ifname;
 }
+#endif
 
 ni_ifworker_t *
 ni_fsm_ifworker_by_name(ni_fsm_t *fsm, ni_ifworker_type_t type, const char *ifname)
@@ -794,13 +799,13 @@ ni_fsm_ifworker_by_object_path(ni_fsm_t *fsm, const char *object_path)
 {
 	unsigned int i;
 
-	if (!object_path)
+	if (ni_string_empty(object_path))
 		return NULL;
 
 	for (i = 0; i < fsm->workers.count; ++i) {
 		ni_ifworker_t *w = fsm->workers.data[i];
 
-		if (w->object_path && !strcmp(w->object_path, object_path))
+		if (ni_string_eq(w->object_path, object_path))
 			return w;
 	}
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -792,29 +792,19 @@ ni_fsm_ifworker_by_policy_name(ni_fsm_t *fsm, ni_ifworker_type_t type, const cha
 ni_ifworker_t *
 ni_fsm_ifworker_by_object_path(ni_fsm_t *fsm, const char *object_path)
 {
-	ni_ifworker_t *w;
-	char *ifname;
 	unsigned int i;
 
-	if (ni_string_empty(object_path))
+	if (!object_path)
 		return NULL;
 
 	for (i = 0; i < fsm->workers.count; ++i) {
-		w = fsm->workers.data[i];
+		ni_ifworker_t *w = fsm->workers.data[i];
 
 		if (w->object_path && !strcmp(w->object_path, object_path))
 			return w;
 	}
 
-	/* ifworker may not be refreshed (no object_path set nor ifindex) */
-	ifname = __ni_fsm_dbus_objectpath_to_name(object_path);
-	if (ni_string_empty(ifname))
-		return NULL;
-
-	w = ni_fsm_ifworker_by_name(fsm, NI_IFWORKER_TYPE_NETDEV, ifname);
-	ni_string_free(&ifname);
-
-	return w;
+	return NULL;
 }
 
 ni_ifworker_t *

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -838,8 +838,6 @@ ni_fsm_ifworker_by_netdev(ni_fsm_t *fsm, const ni_netdev_t *dev)
 
 		if (w->device == dev)
 			return w;
-		if (w->ifindex && w->ifindex == dev->link.ifindex)
-			return w;
 	}
 
 	return NULL;


### PR DESCRIPTION
Also additional fixes:
- do not destroy worker from nanny event handler, but only from fsm event handler
- assign w->ifindex on createDevice() call (calculate from object_path)