### PR TITLE
fsm: fixes to use only ready devices by name and event races

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -223,6 +223,7 @@ struct ni_fsm_require {
 };
 
 struct ni_fsm {
+	ni_ifworker_array_t	pending;
 	ni_ifworker_array_t	workers;
 	unsigned int		worker_timeout;
 	ni_bool_t		readonly;

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -452,7 +452,7 @@ static inline ni_bool_t
 ni_ifworker_complete(const ni_ifworker_t *w)
 {
 	return 	w->failed || w->done || w->target_state == NI_FSM_STATE_NONE ||
-		w->target_state == w->fsm.state;
+		(w->target_state == w->fsm.state && ni_ifworker_is_valid_state(w->target_state));
 }
 
 static inline ni_bool_t

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -223,6 +223,19 @@ struct ni_fsm_require {
 	void *			user_data;
 };
 
+struct ni_fsm_event {
+	ni_fsm_event_t *	next;
+
+	char *			object_path;
+	char *			signal_name;
+
+	ni_event_t		event_type;
+	ni_uuid_t		event_uuid;
+
+	ni_ifworker_type_t	worker_type;
+	unsigned int		ifindex;
+};
+
 struct ni_fsm {
 	ni_ifworker_array_t	pending;
 	ni_ifworker_array_t	workers;
@@ -233,6 +246,10 @@ struct ni_fsm {
 	unsigned int		event_seq;
 	unsigned int		last_event_seq[__NI_EVENT_MAX];
 	ni_fsm_event_t *	events;
+	struct {
+		void            (*callback)(ni_fsm_t *, ni_ifworker_t *, ni_fsm_event_t *);
+		void *          user_data;
+	} process_event;
 
 	ni_fsm_policy_t *	policies;
 
@@ -279,6 +296,7 @@ extern ni_bool_t		ni_fsm_refresh_state(ni_fsm_t *);
 extern unsigned int		ni_fsm_schedule(ni_fsm_t *);
 extern ni_bool_t		ni_fsm_do(ni_fsm_t *fsm, long *timeout_p);
 extern void			ni_fsm_mainloop(ni_fsm_t *);
+extern void			ni_fsm_set_process_event_callback(ni_fsm_t *, void (*)(ni_fsm_t *, ni_ifworker_t *, ni_fsm_event_t *), void *);
 extern unsigned int		ni_fsm_get_matching_workers(ni_fsm_t *, ni_ifmatcher_t *, ni_ifworker_array_t *);
 extern unsigned int		ni_fsm_mark_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, const ni_ifmarker_t *);
 extern unsigned int		ni_fsm_start_matching_workers(ni_fsm_t *, ni_ifworker_array_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -64,8 +64,8 @@ typedef struct ni_fsm_transition ni_fsm_transition_t;
 
 typedef int			ni_fsm_transition_fn_t(ni_fsm_t *, ni_ifworker_t *, ni_fsm_transition_t *);
 struct ni_fsm_transition {
-	unsigned int		from_state;
-	unsigned int		next_state;
+	ni_fsm_state_t		from_state;
+	ni_fsm_state_t		next_state;
 	ni_fsm_transition_fn_t *bind_func;
 	ni_fsm_transition_fn_t *call_func;
 	ni_fsm_timer_fn_t *	timeout_fn;

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -300,6 +300,7 @@ extern void			ni_fsm_wait_tentative_addrs(ni_fsm_t *);
 
 extern ni_ifworker_type_t	ni_ifworker_type_from_string(const char *);
 extern const char *		ni_ifworker_type_to_string(ni_ifworker_type_t);
+extern ni_ifworker_type_t	ni_ifworker_type_from_object_path(const char *, const char **);
 extern inline ni_bool_t	ni_ifworker_state_in_range(const ni_uint_range_t *, const unsigned int);
 extern const char *		ni_ifworker_state_name(ni_fsm_state_t state);
 extern ni_bool_t		ni_ifworker_state_from_name(const char *, unsigned int *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -50,6 +50,7 @@ typedef struct ni_fsm		ni_fsm_t;
 typedef struct ni_ifworker	ni_ifworker_t;
 typedef struct ni_fsm_require	ni_fsm_require_t;
 typedef struct ni_fsm_policy	ni_fsm_policy_t;
+typedef struct ni_fsm_event	ni_fsm_event_t;
 
 typedef struct ni_ifworker_array {
 	unsigned int		count;
@@ -231,6 +232,7 @@ struct ni_fsm {
 	unsigned int		timeout_count;
 	unsigned int		event_seq;
 	unsigned int		last_event_seq[__NI_EVENT_MAX];
+	ni_fsm_event_t *	events;
 
 	ni_fsm_policy_t *	policies;
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -456,6 +456,12 @@ ni_ifworker_complete(const ni_ifworker_t *w)
 }
 
 static inline ni_bool_t
+ni_ifworker_is_running(const ni_ifworker_t *w)
+{
+	return w->kickstarted && !w->dead && !ni_ifworker_complete(w);
+}
+
+static inline ni_bool_t
 ni_ifworker_is_factory_device(ni_ifworker_t *w)
 {
 	return  !w->device && (w->device_api.factory_service &&

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -415,7 +415,7 @@ ni_ifworker_get_modem(const ni_ifworker_t *w)
  * Returns true if the device was configured correctly
  */
 static inline ni_bool_t
-ni_ifworker_is_running(const ni_ifworker_t *w)
+ni_ifworker_has_succeeded(const ni_ifworker_t *w)
 {
 	return w->done && !w->failed;
 }

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -33,10 +33,7 @@
 #include "util_priv.h"
 #include "nanny.h"
 
-static void		ni_nanny_netif_state_change_signal_receive(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
-#ifdef MODEM
-static void		ni_nanny_modem_state_change_signal_receive(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
-#endif
+static void		ni_nanny_process_fsm_event(ni_fsm_t *, ni_ifworker_t *, ni_fsm_event_t *);
 
 static void		__ni_nanny_user_free(ni_nanny_user_t *);
 static int		ni_nanny_prompt(const ni_fsm_prompt_t *, xml_node_t *, void *);
@@ -88,7 +85,6 @@ void
 ni_nanny_start(ni_nanny_t *mgr)
 {
 	ni_nanny_devmatch_t *match;
-	ni_dbus_client_t *client;
 
 	mgr->server = ni_server_listen_dbus(NI_OBJECTMODEL_DBUS_BUS_NAME_NANNY);
 	if (!mgr->server)
@@ -98,6 +94,7 @@ ni_nanny_start(ni_nanny_t *mgr)
 	mgr->fsm->worker_timeout = NI_IFWORKER_INFINITE_TIMEOUT;
 
 	ni_fsm_set_user_prompt_fn(mgr->fsm, ni_nanny_prompt, mgr);
+	ni_fsm_set_process_event_callback(mgr->fsm, ni_nanny_process_fsm_event, mgr);
 
 	ni_objectmodel_nanny_init(mgr);
 
@@ -117,19 +114,8 @@ ni_nanny_start(ni_nanny_t *mgr)
 	}
 
 	if (ni_config_use_nanny()) {
-		if (!(client = ni_fsm_create_client(mgr->fsm)))
+		if (!ni_fsm_create_client(mgr->fsm))
 			ni_fatal("Unable to create FSM client");
-
-		ni_dbus_client_add_signal_handler(client, NULL, NULL,
-				NI_OBJECTMODEL_NETIF_INTERFACE,
-				ni_nanny_netif_state_change_signal_receive,
-				mgr);
-#ifdef MODEM
-		ni_dbus_client_add_signal_handler(client, NULL, NULL,
-				NI_OBJECTMODEL_MODEM_INTERFACE,
-				ni_nanny_modem_state_change_signal_receive,
-				mgr);
-#endif
 	}
 }
 
@@ -806,169 +792,37 @@ ni_objectmodel_nanny_unwrap(const ni_dbus_object_t *object, DBusError *error)
  * Wickedd is sending us a signal (such a linkUp/linkDown, or change in the set of
  * visible WLANs)
  */
-void
-ni_nanny_netif_state_change_signal_receive(ni_dbus_connection_t *conn, ni_dbus_message_t *msg, void *user_data)
+static void
+ni_nanny_process_fsm_event(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_event_t *ev)
 {
-	ni_nanny_t *mgr = user_data;
-	const char *signal_name = dbus_message_get_member(msg);
-	const char *object_path = dbus_message_get_path(msg);
-	ni_event_t event;
+	ni_nanny_t *mgr = fsm->process_event.user_data;
 	ni_managed_device_t *mdev;
-	ni_ifworker_t *w;
 
-	if (ni_objectmodel_signal_to_event(signal_name, &event) < 0) {
-		ni_debug_nanny("received unknown signal \"%s\" from object \"%s\"",
-				signal_name, object_path);
-		return;
-	}
+	switch (ev->event_type) {
+	case NI_EVENT_DEVICE_READY:
+		ni_nanny_register_device(mgr, w);
+		break;
 
-	if (event == NI_EVENT_DEVICE_CREATE)
-		return;
-
-	if (event == NI_EVENT_DEVICE_READY) {
-		if ((w = ni_fsm_recv_new_netif_path(mgr->fsm, object_path)))
-			ni_nanny_register_device(mgr, w);
-	}
-
-	w = ni_fsm_ifworker_by_object_path(mgr->fsm, object_path);
-	if (!w) {
-		ni_warn("received signal \"%s\" from unknown object \"%s\"",
-				signal_name, object_path);
-		return;
-	}
-
-	if (event == NI_EVENT_DEVICE_DELETE) {
-		ni_debug_nanny("%s: received signal \"%s\" from \"%s\"",
-				w->name, signal_name, object_path);
-		// delete the worker and the managed netif
+	case NI_EVENT_DEVICE_DELETE:
 		ni_nanny_unregister_device(mgr, w);
-		return;
+		break;
+
+	default:
+		break;
 	}
 
-	if (w->type != NI_IFWORKER_TYPE_NETDEV || w->device == NULL) {
-		ni_error("%s: received signal \"%s\" from \"%s\" (not a managed network device)",
-				w->name, signal_name, object_path);
-		return;
-	}
-
-	if ((mdev = ni_nanny_get_device(mgr, w)) == NULL) {
-		ni_debug_nanny("%s: received signal \"%s\" from \"%s\" (not a managed device)",
-				w->name, signal_name, object_path);
-		return;
-	}
-
-	ni_debug_nanny("%s: received signal %s; state=%s, policy=%s%s%s",
-			w->name, signal_name,
+	if ((mdev = ni_nanny_get_device(mgr, w))) {
+		ni_debug_nanny("%s: processed event %s; state=%s, policy=%s%s%s",
+			w->name, ev->signal_name,
 			ni_managed_state_to_string(mdev->state),
 			mdev->selected_policy? ni_fsm_policy_name(mdev->selected_policy->fsm_policy): "<none>",
 			mdev->allowed? ", user control allowed" : "",
 			mdev->monitor? ", monitored" : "");
-
-	switch (event) {
-	case NI_EVENT_DEVICE_READY:
-#if 0
-		ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		break;
-
-	case NI_EVENT_LINK_DOWN:
-		// If we have recorded a policy for this device, it means
-		// we were the ones who took it up - so bring it down
-		// again
-#if 0
-		if (mdev->selected_policy != NULL && mdev->monitor)
-			ni_nanny_schedule_recheck(&mgr->down, w);
-#endif
-#if 0
-		ni_nanny_unschedule(&mgr->recheck, w);
-#endif
-		break;
-
-	case NI_EVENT_LINK_ASSOCIATION_LOST:
-		// If we have recorded a policy for this device, it means
-		// we were the ones who took it up - so bring it down
-		// again
-#if 0
-		if (mdev->selected_policy != NULL && mdev->monitor)
-			ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		break;
-
-	case NI_EVENT_LINK_SCAN_UPDATED:
-#if 0
-		if (mdev->monitor)
-			ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		break;
-
-	case NI_EVENT_LINK_UP:
-		// Link detection - eg for ethernet
-#if 0
-		if (mdev->monitor)
-			ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		break;
-
-	default: ;
-	}
-}
-
-#ifdef MODEM
-/*
- * Wickedd is sending us a modem signal (usually discovery or removal of a modem)
- */
-void
-ni_nanny_modem_state_change_signal_receive(ni_dbus_connection_t *conn, ni_dbus_message_t *msg, void *user_data)
-{
-	ni_nanny_t *mgr = user_data;
-	const char *signal_name = dbus_message_get_member(msg);
-	const char *object_path = dbus_message_get_path(msg);
-	ni_event_t event;
-	ni_ifworker_t *w;
-
-	if (ni_objectmodel_signal_to_event(signal_name, &event) < 0) {
-		ni_debug_nanny("received unknown signal \"%s\" from object \"%s\"",
-				signal_name, object_path);
-		return;
-	}
-
-	/* We receive a deviceCreate signal when a modem was plugged in */
-	w = ni_fsm_ifworker_by_object_path(mgr->fsm, object_path);
-	if (!w && event == NI_EVENT_DEVICE_CREATE) {
-		if ((w = ni_fsm_recv_new_modem_path(mgr->fsm, object_path))) {
-			ni_nanny_register_device(mgr, w);
-#if 0
-			ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		}
-		return;
-	}
-	if (!w) {
-		ni_warn("received signal \"%s\" from unknown object \"%s\"",
-				signal_name, object_path);
-		return;
-	}
-
-	if (w->type != NI_IFWORKER_TYPE_MODEM || w->modem == NULL) {
-		ni_error("%s: received signal \"%s\" from \"%s\" (not a managed modem device)",
-				w->name, signal_name, object_path);
-		return;
-	}
-
-	ni_debug_nanny("%s: received signal %s from %s", w->name, signal_name, object_path);
-	if (event == NI_EVENT_DEVICE_DELETE) {
-		// delete the worker and the managed modem
-		ni_nanny_unregister_device(mgr, w);
-	} else if (event == NI_EVENT_DEVICE_READY) {
-#if 0
-		ni_nanny_schedule_recheck(&mgr->recheck, w);
-#endif
-		;
 	} else {
-		// ignore
+		ni_debug_nanny("%s: received event \"%s\" from \"%s\" (not a managed device)",
+				w->name, ev->signal_name, ev->object_path);
 	}
 }
-#endif
 
 /*
  * Nanny.getDevice(devname)

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -567,7 +567,6 @@ ni_nanny_unregister_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 	ni_objectmodel_unregister_managed_device(mdev);
 	ni_nanny_unschedule(&mgr->recheck, w);
 	ni_nanny_policy_drop(w->name);
-	ni_fsm_destroy_worker(mgr->fsm, w);
 }
 
 /*

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -806,6 +806,17 @@ ni_nanny_process_fsm_event(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_event_t *ev)
 		ni_nanny_unregister_device(mgr, w);
 		break;
 
+	case NI_EVENT_DEVICE_DOWN:
+	case NI_EVENT_LINK_DOWN:
+	case NI_EVENT_NETWORK_DOWN:
+	case NI_EVENT_LINK_UP:
+	case NI_EVENT_LINK_ASSOCIATION_LOST:
+	case NI_EVENT_ADDRESS_LOST:
+		/* We should restart FSM on successful devices */
+		if (ni_ifworker_complete(w))
+			ni_ifworker_rearm(w);
+		break;
+
 	default:
 		break;
 	}

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -232,7 +232,7 @@ ni_nanny_recheck_do(ni_nanny_t *mgr)
 	for (i = 0; i < mgr->recheck.count; ++i) {
 		ni_ifworker_t *w = mgr->recheck.data[i];
 
-		if (!w->failed && !w->done && !w->pending && !ni_ifworker_active(w))
+		if (!w->failed && !w->done && !w->pending && !ni_ifworker_is_running(w))
 			count += ni_nanny_recheck(mgr, w);
 	}
 

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -232,7 +232,7 @@ ni_nanny_recheck_do(ni_nanny_t *mgr)
 	for (i = 0; i < mgr->recheck.count; ++i) {
 		ni_ifworker_t *w = mgr->recheck.data[i];
 
-		if (!w->failed && !w->done && !w->pending && !ni_ifworker_is_running(w))
+		if (!w->dead && !w->pending && !w->kickstarted && !w->done && !w->failed)
 			count += ni_nanny_recheck(mgr, w);
 	}
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -227,8 +227,6 @@ __ni_ifworker_destroy_action_table(ni_ifworker_t *w)
 static void
 __ni_ifworker_reset_fsm(ni_ifworker_t *w)
 {
-	ni_fsm_require_t *req_list;
-
 	if (!w)
 		return;
 
@@ -237,9 +235,16 @@ __ni_ifworker_reset_fsm(ni_ifworker_t *w)
 
 	__ni_ifworker_reset_action_table(w);
 
-	req_list = w->fsm.child_state_req_list;
-	memset(&w->fsm, 0, sizeof(w->fsm));
-	w->fsm.child_state_req_list = req_list;
+	w->fsm.state = NI_FSM_STATE_NONE;
+}
+
+static void
+__ni_ifworker_destroy_fsm(ni_ifworker_t *w)
+{
+	__ni_ifworker_reset_fsm(w);
+
+	__ni_ifworker_destroy_action_table(w);
+	ni_fsm_require_list_destroy(&w->fsm.child_state_req_list);
 }
 
 void

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2204,6 +2204,22 @@ ni_ifworker_type_to_string(ni_ifworker_type_t type)
 	return NULL;
 }
 
+ni_ifworker_type_t
+ni_ifworker_type_from_object_path(const char *path, const char **suffix)
+{
+	if (ni_string_startswith(path, NI_OBJECTMODEL_NETIF_LIST_PATH "/")) {
+		if (suffix)
+			*suffix = path + sizeof(NI_OBJECTMODEL_NETIF_LIST_PATH);
+		return NI_IFWORKER_TYPE_NETDEV;
+	}
+	if (ni_string_startswith(path, NI_OBJECTMODEL_MODEM_LIST_PATH "/")) {
+		if (suffix)
+			*suffix = path + sizeof(NI_OBJECTMODEL_MODEM_LIST_PATH);
+		return NI_IFWORKER_TYPE_MODEM;
+	}
+	return NI_IFWORKER_TYPE_NONE;
+}
+
 /*
  * Get all interfaces matching some user-specified criteria
  */

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -119,12 +119,12 @@ __ni_ifworker_new(ni_ifworker_type_t type, const char *name)
 }
 
 static ni_ifworker_t *
-ni_ifworker_new(ni_fsm_t *fsm, ni_ifworker_type_t type, const char *name)
+ni_ifworker_new(ni_ifworker_array_t *array, ni_ifworker_type_t type, const char *name)
 {
 	ni_ifworker_t *worker;
 
 	worker = __ni_ifworker_new(type, name);
-	ni_ifworker_array_append(&fsm->workers, worker);
+	ni_ifworker_array_append(array, worker);
 	worker->refcount--;
 
 	return worker;
@@ -1785,7 +1785,7 @@ ni_fsm_workers_from_xml(ni_fsm_t *fsm, xml_node_t *ifnode, const char *origin)
 		} else {
 			ifname = node->cdata;
 			if (ifname && (w = ni_fsm_ifworker_by_name(fsm, type, ifname)) == NULL)
-				w = ni_ifworker_new(fsm, type, ifname);
+				w = ni_ifworker_new(&fsm->workers, type, ifname);
 		}
 	}
 
@@ -3200,7 +3200,7 @@ ni_fsm_recv_new_netif(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh
 		found = ni_fsm_ifworker_by_object_path(fsm, object->path);
 	if (!found) {
 		ni_debug_application("received new device %s (%s)", dev->name, object->path);
-		found = ni_ifworker_new(fsm, NI_IFWORKER_TYPE_NETDEV, dev->name);
+		found = ni_ifworker_new(&fsm->workers, NI_IFWORKER_TYPE_NETDEV, dev->name);
 		found->readonly = fsm->readonly;
 		if (dev->client_state)
 			ni_ifworker_refresh_client_state(found, dev->client_state);
@@ -3286,7 +3286,7 @@ ni_fsm_recv_new_modem(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh
 		found = ni_fsm_ifworker_by_object_path(fsm, object->path);
 	if (!found) {
 		ni_debug_application("received new modem %s (%s)", modem->device, object->path);
-		found = ni_ifworker_new(fsm, NI_IFWORKER_TYPE_MODEM, modem->device);
+		found = ni_ifworker_new(&fsm->workers, NI_IFWORKER_TYPE_MODEM, modem->device);
 	}
 
 	if (!found->object_path)

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3004,6 +3004,9 @@ ni_fsm_build_hierarchy(ni_fsm_t *fsm, ni_bool_t destructive)
 			continue;
 		}
 
+		ni_fsm_require_list_destroy(&w->fsm.child_state_req_list);
+		w->fsm.child_state_req_list = NULL;
+
 		if ((rv = ni_ifworker_bind_early(w, fsm, FALSE)) < 0) {
 			if (destructive) {
 				if (-NI_ERROR_DOCUMENT_ERROR == rv)

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2500,7 +2500,7 @@ __ni_ifworker_flatten(ni_ifworker_t *w, ni_ifworker_array_t *array, unsigned int
 	for (i = 0; i < w->children.count; ++i) {
 		ni_ifworker_t *child = w->children.data[i];
 
-		if (ni_ifworker_is_running(child))
+		if (ni_ifworker_has_succeeded(child))
 			continue;
 
 		__ni_ifworker_flatten(child, array, depth + 1);

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -210,8 +210,14 @@ __ni_ifworker_reset_action_table(ni_ifworker_t *w)
 		ni_fsm_require_list_destroy(&action->require.list);
 		ni_ifworker_cancel_callbacks(w, &action->callbacks);
 	}
-	free(w->fsm.action_table);
+}
 
+static void
+__ni_ifworker_destroy_action_table(ni_ifworker_t *w)
+{
+	__ni_ifworker_reset_action_table(w);
+
+	free(w->fsm.action_table);
 	w->fsm.wait_for = NULL;
 	w->fsm.next_action = NULL;
 	w->fsm.action_table = NULL;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2723,7 +2723,7 @@ ni_fsm_destroy_worker(ni_fsm_t *fsm, ni_ifworker_t *w)
 	ni_ifworker_cancel_secondary_timeout(w);
 	ni_ifworker_cancel_timeout(w);
 
-	if (ni_ifworker_active(w))
+	if (ni_ifworker_is_running(w))
 		ni_ifworker_fail(w, "device has been deleted");
 
 	ni_fsm_clear_hierarchy(w);
@@ -4241,7 +4241,7 @@ ni_fsm_schedule_init(ni_fsm_t *fsm, ni_ifworker_t *w, unsigned int from_state, u
 	int increment;
 	int rv;
 
-	if (ni_ifworker_active(w))
+	if (ni_ifworker_is_running(w))
 		return 0;
 
 	if (from_state <= target_state)

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4048,6 +4048,9 @@ ni_ifworker_bind_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transiti
 static int
 ni_ifworker_call_device_factory(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_transition_t *action)
 {
+	/* Initially, enable waiting for this action */
+	w->fsm.wait_for = action;
+
 	if (!ni_ifworker_device_bound(w)) {
 		struct ni_fsm_transition_binding *bind;
 		const char *relative_path = NULL;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1483,9 +1483,6 @@ ni_ifworker_advance_state(ni_ifworker_t *w, ni_event_t event_type)
 		max_state = NI_FSM_STATE_DEVICE_EXISTS - 1;
 		break;
 	case NI_EVENT_DEVICE_DOWN:
-		/* We should restart FSM on successful devices */
-		if (ni_ifworker_complete(w))
-			ni_ifworker_rearm(w);
 		max_state = NI_FSM_STATE_DEVICE_UP - 1;
 		break;
 	case NI_EVENT_DEVICE_CREATE:
@@ -1501,9 +1498,6 @@ ni_ifworker_advance_state(ni_ifworker_t *w, ni_event_t event_type)
 		min_state = NI_FSM_STATE_LINK_UP;
 		break;
 	case NI_EVENT_LINK_DOWN:
-		/* We should restart FSM on successful devices */
-		if (ni_ifworker_complete(w))
-			ni_ifworker_rearm(w);
 		max_state = NI_FSM_STATE_LINK_UP - 1;
 		break;
 	case NI_EVENT_ADDRESS_DEFERRED:

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -210,6 +210,8 @@ __ni_ifworker_reset_action_table(ni_ifworker_t *w)
 		ni_fsm_require_list_destroy(&action->require.list);
 		ni_ifworker_cancel_callbacks(w, &action->callbacks);
 	}
+	w->fsm.wait_for = NULL;
+	w->fsm.next_action = w->fsm.action_table;
 }
 
 static void
@@ -218,7 +220,6 @@ __ni_ifworker_destroy_action_table(ni_ifworker_t *w)
 	__ni_ifworker_reset_action_table(w);
 
 	free(w->fsm.action_table);
-	w->fsm.wait_for = NULL;
 	w->fsm.next_action = NULL;
 	w->fsm.action_table = NULL;
 }

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1368,8 +1368,7 @@ ni_ifworker_set_state(ni_ifworker_t *w, unsigned int new_state)
 		if (w->fsm.wait_for && w->fsm.wait_for->next_state == new_state)
 			w->fsm.wait_for = NULL;
 
-		if ((new_state == NI_FSM_STATE_DEVICE_READY ||
-		    new_state == NI_FSM_STATE_DEVICE_SETUP) && w->object && !w->readonly) {
+		if ((new_state == NI_FSM_STATE_DEVICE_READY) && w->object && !w->readonly) {
 			ni_ifworker_update_client_state_control(w);
 			ni_ifworker_update_client_state_config(w);
 		}

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4401,19 +4401,15 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 
 			if (rv >= 0) {
 				made_progress = 1;
-				if (w->fsm.state == action->next_state) {
-					/* We should not have transitioned to the next state while
-					 * we were still waiting for some event. */
-					ni_assert(w->fsm.wait_for == NULL);
-					ni_debug_application("%s: successfully transitioned from %s to %s",
-						w->name,
-						ni_ifworker_state_name(prev_state),
-						ni_ifworker_state_name(w->fsm.state));
-				} else {
+
+				if (w->fsm.wait_for) {
 					ni_debug_application("%s: waiting for event in state %s",
-						w->name,
-						ni_ifworker_state_name(w->fsm.state));
-					w->fsm.wait_for = action;
+						w->name, ni_ifworker_state_name(w->fsm.state));
+				} else {
+					ni_debug_application("%s: successfully transitioned from %s to %s",
+							w->name,
+							ni_ifworker_state_name(prev_state),
+							ni_ifworker_state_name(w->fsm.state));
 				}
 			} else
 			if (!w->failed) {

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4368,9 +4368,7 @@ ni_fsm_schedule(ni_fsm_t *fsm)
 			}
 
 			if (!w->kickstarted) {
-				if (!ni_ifworker_device_bound(w))
-					ni_ifworker_set_state(w, NI_FSM_STATE_DEVICE_DOWN);
-				else if (w->object)
+				if (w->object && ni_netdev_device_is_ready(w->device))
 					ni_call_clear_event_filters(w->object);
 				w->kickstarted = TRUE;
 			}

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -644,17 +644,17 @@ ni_ifworker_array_free(ni_ifworker_array_t *array)
 }
 
 static ni_ifworker_t *
-ni_ifworker_array_find(ni_ifworker_array_t *array, ni_ifworker_type_t type, const char *ifname)
+ni_ifworker_array_find_by_name(ni_ifworker_array_t *array, ni_ifworker_type_t type, const char *name)
 {
 	unsigned int i;
 
-	if (ni_string_empty(ifname))
+	if (ni_string_empty(name))
 		return NULL;
 
 	for (i = 0; i < array->count; ++i) {
 		ni_ifworker_t *worker = array->data[i];
 
-		if (worker->type == type && !strcmp(worker->name, ifname))
+		if (worker->type == type && ni_string_eq(worker->name, name))
 			return worker;
 	}
 	return NULL;
@@ -761,9 +761,9 @@ __ni_fsm_dbus_objectpath_to_name(const char *object_path)
 }
 
 ni_ifworker_t *
-ni_fsm_ifworker_by_name(ni_fsm_t *fsm, ni_ifworker_type_t type, const char *ifname)
+ni_fsm_ifworker_by_name(ni_fsm_t *fsm, ni_ifworker_type_t type, const char *name)
 {
-	return ni_ifworker_array_find(&fsm->workers, type, ifname);
+	return ni_ifworker_array_find_by_name(&fsm->workers, type, name);
 }
 
 ni_ifworker_t *
@@ -1039,7 +1039,7 @@ ni_ifworker_resolve_reference(ni_fsm_t *fsm, xml_node_t *devnode, ni_ifworker_ty
 			child = __ni_ifworker_identify_device(fsm, namespace, devnode, type, origin);
 		} else if (devnode->cdata) {
 			const char *slave_name = devnode->cdata;
-			child = ni_ifworker_array_find(&fsm->workers, type, slave_name);
+			child = ni_fsm_ifworker_by_name(fsm, type, slave_name);
 
 			if (child == NULL) {
 				ni_error("%s: <%s> element references unknown device %s",

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2037,6 +2037,7 @@ ni_ifworker_child_state_req_free(ni_fsm_require_t *req)
 	struct ni_child_state_req_data *data = (struct ni_child_state_req_data *) req->user_data;
 
 	if (data) {
+		ni_ifworker_release(data->child);
 		ni_string_free(&data->method);
 		free(data);
 	}
@@ -2050,8 +2051,8 @@ ni_ifworker_add_child_state_req(ni_ifworker_t *w, const char *method, ni_ifworke
 	struct ni_child_state_req_data *data;
 	ni_fsm_require_t *req;
 
-	data = calloc(1, sizeof(*data));
-	data->child = child_worker;
+	data = xcalloc(1, sizeof(*data));
+	data->child = ni_ifworker_get(child_worker);
 	ni_string_dup(&data->method, method);
 	data->child_state.min = min_state;
 	data->child_state.max = max_state;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4261,8 +4261,10 @@ ni_fsm_schedule_init(ni_fsm_t *fsm, ni_ifworker_t *w, unsigned int from_state, u
 	ni_debug_application("%s: set up FSM from %s -> %s", w->name,
 			ni_ifworker_state_name(from_state),
 			ni_ifworker_state_name(target_state));
+
 	num_actions = 0;
 
+	__ni_ifworker_destroy_action_table(w);
 do_it_again:
 	index = 0;
 	for (cur_state = from_state; cur_state != target_state; ) {
@@ -4288,7 +4290,7 @@ do_it_again:
 	}
 
 	if (w->fsm.action_table == NULL) {
-		w->fsm.action_table = calloc(num_actions + 1, sizeof(ni_fsm_transition_t));
+		w->fsm.action_table = xcalloc(num_actions + 1, sizeof(ni_fsm_transition_t));
 		goto do_it_again;
 	}
 	w->fsm.next_action = w->fsm.action_table;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -301,6 +301,8 @@ ni_ifworker_reset(ni_ifworker_t *w)
 	w->done = FALSE;
 	w->kickstarted = FALSE;
 	w->readonly = FALSE;
+	w->dead = FALSE;
+	w->pending = FALSE;
 }
 
 void

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -311,6 +311,7 @@ ni_ifworker_free(ni_ifworker_t *w)
 		ni_netdev_put(w->device);
 	if (w->modem)
 		ni_modem_release(w->modem);
+	__ni_ifworker_destroy_fsm(w);
 	ni_string_free(&w->name);
 	free(w);
 }

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -402,7 +402,7 @@ ni_wireless_association_changed(unsigned int ifindex, ni_wireless_assoc_state_t 
 
 	wlan->assoc.state = new_state;
 	if (new_state == NI_WIRELESS_ESTABLISHED)
-		__ni_netdev_event(nc, dev, NI_EVENT_LINK_UP);
+		__ni_netdev_event(nc, dev, NI_EVENT_LINK_ASSOCIATED);
 
 	/* We keep track of when we were last changing to or
 	 * from fully authenticated state.


### PR DESCRIPTION
Instead to add not yet ready devices to the normal fsm worker set, add them into a special
pending worker set to avoid confusions while resolving dependencies by name before or
while udev renames them and thus assign wrong config to devices (bsc#918662) and handle
related event race conditions (bsc#921218).