### PR TITLE
bonding: don't insist on active-backup mode when arp_validate=none  (boo#919573)

### DIFF
--- a/include/wicked/bonding.h
+++ b/include/wicked/bonding.h
@@ -114,7 +114,7 @@ extern ni_bool_t	ni_bonding_set_option(ni_bonding_t *, const char *, const char 
 extern int		ni_bonding_parse_sysfs_attrs(const char *, ni_bonding_t *);
 extern int		ni_bonding_write_sysfs_attrs(const char *ifname,
 						const ni_bonding_t *cfg_bond,
-						const ni_bonding_t *cur_bond,
+						ni_bonding_t       *cur_bond,
 						ni_bool_t is_up, ni_bool_t has_slaves);
 
 extern ni_bool_t	ni_bonding_is_valid_arp_ip_target(const char *);

--- a/schema/bonding.xml
+++ b/schema/bonding.xml
@@ -40,7 +40,7 @@
        <all value="1"/>
      </validate-targets>
      <!-- targets class="array" element-type="ipv4-address" minlen="1"/ -->
-     <targets class="array" constraint="required" minlen="1" element-type="string" />
+     <targets class="array" constraint="required" minlen="1" element-type="string" element-name="address" />
    </arpmon>
 
    <miimon class="dict">

--- a/src/bonding.c
+++ b/src/bonding.c
@@ -251,6 +251,7 @@ ni_bonding_validate(const ni_bonding_t *bonding)
 
 		switch (bonding->arpmon.validate) {
 		case NI_BOND_ARP_VALIDATE_NONE:
+			break;
 		case NI_BOND_ARP_VALIDATE_ACTIVE:
 		case NI_BOND_ARP_VALIDATE_BACKUP:
 		case NI_BOND_ARP_VALIDATE_ALL:

--- a/src/bonding.c
+++ b/src/bonding.c
@@ -241,9 +241,14 @@ ni_bonding_validate(const ni_bonding_t *bonding)
 		if (bonding->miimon.frequency > 0)
 			return "invalid arp and mii monitoring option mix";
 
-		if (bonding->mode == NI_BOND_MODE_BALANCE_TLB ||
-		    bonding->mode == NI_BOND_MODE_BALANCE_ALB)
-			return "invalid arp monitoring in balance-tlb/-alb mode";
+		switch(bonding->mode) {
+		case NI_BOND_MODE_802_3AD:
+		case NI_BOND_MODE_BALANCE_TLB:
+		case NI_BOND_MODE_BALANCE_ALB:
+			return "invalid arp monitoring in balance-tlb/-alb or 802.3ad mode";
+		default:
+			break;
+		}
 
 		if (bonding->arpmon.interval == 0 ||
 		    bonding->arpmon.interval > INT_MAX)

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -1369,6 +1369,7 @@ ni_system_bond_setup(ni_netconfig_t *nc, ni_netdev_t *dev, const ni_bonding_t *b
 		 */
 		ni_debug_ifconfig("%s: configuring bonding device (stage 0.%u.%u)",
 				dev->name, is_up, has_slaves);
+		ni_bonding_parse_sysfs_attrs(dev->name, bond);
 		if (ni_bonding_write_sysfs_attrs(dev->name, bond_cfg, bond,
 						is_up, has_slaves) < 0) {
 			ni_error("%s: cannot configure bonding device (stage 0.%u.%u)",
@@ -1442,6 +1443,7 @@ ni_system_bond_setup(ni_netconfig_t *nc, ni_netdev_t *dev, const ni_bonding_t *b
 		 */
 		ni_debug_ifconfig("%s: configuring bonding device (stage 2.%u.%u)",
 				dev->name, is_up, has_slaves);
+		ni_bonding_parse_sysfs_attrs(dev->name, bond);
 		if (ni_bonding_write_sysfs_attrs(dev->name, bond_cfg, bond,
 						is_up, has_slaves) < 0) {
 			ni_error("%s: cannot configure bonding device (stage 2.%u.%u)",
@@ -1453,6 +1455,7 @@ ni_system_bond_setup(ni_netconfig_t *nc, ni_netdev_t *dev, const ni_bonding_t *b
 				dev->name);
 		return -1;
 	}
+	ni_bonding_parse_sysfs_attrs(dev->name, bond);
 
 	return 0;
 }


### PR DESCRIPTION
Solution to the boo#919573.