### PR TITLE
Ifreload: properly handle rename cases

### DIFF
--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -330,6 +330,14 @@ usage:
 		ni_debug_application("No interfaces to be brought down\n");
 	}
 
+	/* Build the up tree */
+	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
+		ni_error("ifreload: unable to build device hierarchy");
+		/* Severe error we always explicitly return */
+		status = NI_WICKED_RC_ERROR;
+		goto cleanup;
+	}
+
 	ni_fsm_pull_in_children(&up_marked);
 	/* Drop deleted or apply the up range */
 	ni_fsm_reset_matching_workers(fsm, &up_marked, &up_range, FALSE);
@@ -643,6 +651,14 @@ usage:
 	}
 	else {
 		ni_debug_application("No interfaces to be brought down\n");
+	}
+
+	/* Build the up tree */
+	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
+		ni_error("ifreload: unable to build device hierarchy");
+		/* Severe error we always explicitly return */
+		status = NI_WICKED_RC_ERROR;
+		goto cleanup;
 	}
 
 	ni_fsm_pull_in_children(&up_marked);

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -221,7 +221,7 @@ usage:
 					fsm->worker_timeout/1000);
 
 	/* Build the up tree */
-	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
+	if (ni_fsm_build_hierarchy(fsm, FALSE) < 0) {
 		ni_error("ifreload: unable to build device hierarchy");
 		/* Severe error we always explicitly return */
 		status = NI_WICKED_RC_ERROR;
@@ -539,7 +539,7 @@ usage:
 					fsm->worker_timeout/1000);
 
 	/* Build the up tree */
-	if (ni_fsm_build_hierarchy(fsm, TRUE) < 0) {
+	if (ni_fsm_build_hierarchy(fsm, FALSE) < 0) {
 		ni_error("ifreload: unable to build device hierarchy");
 		/* Severe error we always explicitly return */
 		status = NI_WICKED_RC_ERROR;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1290,7 +1290,7 @@ ni_ifworker_add_child(ni_ifworker_t *parent, ni_ifworker_t *child, xml_node_t *d
 		/* The reference allows sharing with other uses, e.g. VLANs. */
 		if (parent->lowerdev) {
 			if (xml_node_is_empty(parent->lowerdev->config.node)) {
-				ni_error("%s (%s): subordinate interface's lowerdev %s has no config node",
+				ni_debug_application("%s (%s): subordinate interface's lowerdev %s has no config node",
 					parent->name, xml_node_location(devnode), parent->lowerdev->name);
 				return FALSE;
 			}
@@ -1310,7 +1310,7 @@ ni_ifworker_add_child(ni_ifworker_t *parent, ni_ifworker_t *child, xml_node_t *d
 	else {
 		if (child->masterdev) {
 			if (xml_node_is_empty(child->masterdev->config.node)) {
-				ni_error("%s (%s): subordinate interface's master device %s has no config node",
+				ni_debug_application("%s (%s): subordinate interface's master device %s has no config node",
 					child->name, xml_node_location(devnode), child->masterdev->name);
 				return FALSE;
 			}


### PR DESCRIPTION
In order to handle such a case properly we need:
- initial hierarchy build be non-destructive otherwise we delete the competing worker (e.g. two bridge workers: one is created, second is the replacement)
- next hierarchy rebuild after ifdown part of ifreload
- remove the <master>$name</master> from the <link/> node of the child's config.