### PR TITLE
policy: fix to worker must be ready to satisfy match check

### DIFF
--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -395,10 +395,12 @@ ni_fsm_policy_applicable(ni_fsm_policy_t *policy, ni_ifworker_t *w)
 	}
 
 	/* 3rd match check - physical worker must be ready  */
-	if (!ni_ifworker_is_factory_device(w)) {
+	if (ni_ifworker_is_device_created(w)) {
 		if (!ni_netdev_device_is_ready(w->device))
 			return FALSE;
 	}
+	else if (!ni_ifworker_is_factory_device(w))
+		return FALSE;
 
 	/* 4th match check - <match> condition must be fulfilled */
 	if (!ni_ifcondition_check(policy->match, w)) {
@@ -1149,7 +1151,11 @@ __ni_fsm_policy_match_and_children_check(const ni_ifcondition_t *cond, ni_ifwork
 	for (i = 0; i < w->children.count; i++) {
 		ni_ifworker_t *child = w->children.data[i];
 
-		if (!ni_netdev_device_is_ready(child->device))
+		if (ni_ifworker_is_device_created(child)) {
+			if (!ni_netdev_device_is_ready(child->device))
+				continue;
+		}
+		else if (!ni_ifworker_is_factory_device(child))
 			continue;
 
 		rv = ni_ifcondition_check(cond->args.terms.left, child);


### PR DESCRIPTION
Reject worker (or child) in the <match> check only when:
- device has been created for a given worker,
  but it isn't ready.
- it's a config worker

This commit fixes ae67663af679414d2020437689d22cacefb5d92f.