### PR TITLE
fsm: use netif-reference shared flag as relation indicator in meta:require too

### DIFF
--- a/client/ifup.c
+++ b/client/ifup.c
@@ -95,8 +95,9 @@ __ni_ifup_generate_match(const char *name, ni_ifworker_t *w)
 			ni_ifworker_t *child = w->children.data[i];
 			xml_node_t *cnode;
 
-			cnode = __ni_ifup_generate_match(NI_NANNY_IFPOLICY_MATCH_COND_CHILD, child);
-			xml_node_add_child(or ,cnode);
+			cnode = xml_node_new(NI_NANNY_IFPOLICY_MATCH_COND_CHILD, or);
+			if (!cnode || !__ni_ifup_generate_match_dev(cnode, child))
+				goto error;
 		}
 	}
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -186,7 +186,7 @@ struct ni_ifworker {
 		const ni_timer_t *timer;
 		const ni_timer_t *secondary_timer;
 
-		ni_fsm_require_t *child_state_req_list;
+		ni_fsm_require_t *check_state_req_list;
 
 	} fsm;
 	unsigned int		extra_waittime;

--- a/schema/bridge.xml
+++ b/schema/bridge.xml
@@ -12,10 +12,10 @@
       -->
     <device type="string">
       <meta:netif-reference shared="false"/>
-      <meta:require check="netif-child-state" op="changeDevice" min-state="device-up" />
+      <meta:require check="netif-check-state" op="changeDevice" min-state="device-up" />
       <!-- bnc#862530 workaround to not require link-up on all ports
-      <meta:require check="netif-child-state" op="login" min-state="link-authenticated" />
-      <meta:require check="netif-child-state" op="linkUp" min-state="link-up" />
+      <meta:require check="netif-check-state" op="login" min-state="link-authenticated" />
+      <meta:require check="netif-check-state" op="linkUp" min-state="link-up" />
        -->
     </device>
 

--- a/schema/infiniband.xml
+++ b/schema/infiniband.xml
@@ -35,7 +35,7 @@
 
       <device type="string" description="Infiniband parent / lower device reference">
       <meta:netif-reference shared="true"/>
-      <!-- meta:require check="netif-child-state" op="newDevice" min-state="device-exists" / -->
+      <!-- meta:require check="netif-check-state" op="newDevice" min-state="device-exists" / -->
     </device>
 
     <pkey type="uint16" description="Infiniband partition key"/>

--- a/schema/macvlan.xml
+++ b/schema/macvlan.xml
@@ -16,9 +16,9 @@
  <define name="configuration" class="dict">
   <device type="string">
     <meta:netif-reference shared="true"/>
-    <meta:require check="netif-child-state" op="newDevice" min-state="device-up" />
-    <meta:require check="netif-child-state" op="linkUp"    min-state="link-up" />
-    <meta:require check="netif-child-state" op="login"     min-state="link-authenticated" />
+    <meta:require check="netif-check-state" op="newDevice" min-state="device-up" />
+    <meta:require check="netif-check-state" op="linkUp"    min-state="link-up" />
+    <meta:require check="netif-check-state" op="login"     min-state="link-authenticated" />
   </device>
   <address  type="ethernet-address"/>
   <mode     type="builtin-macvlan-mode"/>

--- a/schema/ppp.xml
+++ b/schema/ppp.xml
@@ -87,8 +87,8 @@
      -->
    <device type="string" constraint="required">
      <meta:modem-reference shared="false"/>
-     <meta:require check="netif-child-state" op="newDevice" min-state="device-up" />
-     <meta:require check="netif-child-state" op="linkUp" min-state="link-up"/>
+     <meta:require check="netif-check-state" op="newDevice" min-state="device-up" />
+     <meta:require check="netif-check-state" op="linkUp" min-state="link-up"/>
    </device>
  </define>
 
@@ -121,9 +121,9 @@
  <define name="pppoe-linkinfo" class="dict" extends="ppp:linkinfo">
   <device type="string">
     <meta:netif-reference shared="true" object-class="netif-ethernet"/>
-    <meta:require check="netif-child-state" op="newDevice" min-state="device-up" />
-    <meta:require check="netif-child-state" op="login" min-state="link-authenticated" />
-    <meta:require check="netif-child-state" op="linkUp" min-state="link-up" />
+    <meta:require check="netif-check-state" op="newDevice" min-state="device-up" />
+    <meta:require check="netif-check-state" op="login" min-state="link-authenticated" />
+    <meta:require check="netif-check-state" op="linkUp" min-state="link-up" />
   </device>
  </define>
 

--- a/schema/vlan.xml
+++ b/schema/vlan.xml
@@ -11,9 +11,9 @@
  <define name="linkinfo" class="dict">
   <device type="string">
     <meta:netif-reference shared="true"/>
-    <meta:require check="netif-child-state" op="newDevice" min-state="device-up" />
-    <meta:require check="netif-child-state" op="login" min-state="link-authenticated" />
-    <meta:require check="netif-child-state" op="linkUp" min-state="link-up" />
+    <meta:require check="netif-check-state" op="newDevice" min-state="device-up" />
+    <meta:require check="netif-check-state" op="login" min-state="link-authenticated" />
+    <meta:require check="netif-check-state" op="linkUp" min-state="link-up" />
   </device>
   <address  type="ethernet-address"/>
   <protocol type="builtin-vlan-protocol"/>

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1941,16 +1941,16 @@ static ni_bool_t
 ni_fsm_require_netif_resolve(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_require_t *req)
 {
 	xml_node_t *devnode = req->user_data;
-	ni_ifworker_t *child_worker;
+	ni_ifworker_t *cw;
 
 	if (req->user_data == NULL)
 		return TRUE;
 
-	if (!(child_worker = ni_ifworker_resolve_reference(fsm, devnode, NI_IFWORKER_TYPE_NETDEV, w->name)))
+	if (!(cw = ni_ifworker_resolve_reference(fsm, devnode, NI_IFWORKER_TYPE_NETDEV, w->name)))
 		return FALSE;
 
-	ni_debug_application("%s: resolved reference to subordinate device %s", w->name, child_worker->name);
-	if (!ni_ifworker_add_child(w, child_worker, devnode, FALSE))
+	ni_debug_application("%s: resolved reference to subordinate device %s", w->name, cw->name);
+	if (!ni_ifworker_add_child(w, cw, devnode, FALSE))
 		return FALSE;
 
 	req->user_data = NULL;
@@ -1975,16 +1975,16 @@ static ni_bool_t
 ni_fsm_require_modem_resolve(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_require_t *req)
 {
 	xml_node_t *devnode = req->user_data;
-	ni_ifworker_t *child_worker;
+	ni_ifworker_t *cw;
 
 	if (req->user_data == NULL)
 		return TRUE;
 
-	if (!(child_worker = ni_ifworker_resolve_reference(fsm, devnode, NI_IFWORKER_TYPE_MODEM, w->name)))
+	if (!(cw = ni_ifworker_resolve_reference(fsm, devnode, NI_IFWORKER_TYPE_MODEM, w->name)))
 		return FALSE;
 
-	ni_debug_application("%s: resolved reference to subordinate device %s", w->name, child_worker->name);
-	if (!ni_ifworker_add_child(w, child_worker, devnode, FALSE))
+	ni_debug_application("%s: resolved reference to subordinate device %s", w->name, cw->name);
+	if (!ni_ifworker_add_child(w, cw, devnode, FALSE))
 		return FALSE;
 
 	req->user_data = NULL;
@@ -3126,7 +3126,7 @@ ni_ifworker_netif_resolve_cb(xml_node_t *node, const ni_xs_type_t *type, const x
 {
 	struct ni_ifworker_xml_validation_user_data *closure = user_data;
 	ni_ifworker_t *w = closure->worker;
-	ni_ifworker_t *child_worker = NULL;
+	ni_ifworker_t *cw = NULL;
 	xml_node_t *mchild;
 
 	for (mchild = metadata->children; mchild; mchild = mchild->next) {
@@ -3135,35 +3135,35 @@ ni_ifworker_netif_resolve_cb(xml_node_t *node, const ni_xs_type_t *type, const x
 		if (ni_string_eq(mchild->name, "netif-reference")) {
 			ni_bool_t shared = FALSE;
 
-			if (child_worker) {
+			if (cw) {
 				ni_error("%s: duplicate/conflicting references", xml_node_location(node));
 				return FALSE;
 			}
-			if (!(child_worker = ni_ifworker_resolve_reference(closure->fsm, node, NI_IFWORKER_TYPE_NETDEV, w->name)))
+			if (!(cw = ni_ifworker_resolve_reference(closure->fsm, node, NI_IFWORKER_TYPE_NETDEV, w->name)))
 				continue;
 
 			if ((attr = xml_node_get_attr(mchild, "shared")) != NULL)
 				shared = ni_string_eq(attr, "true");
 
-			ni_debug_application("%s: resolved reference to subordinate device %s", w->name, child_worker->name);
-			if (!ni_ifworker_add_child(w, child_worker, node, shared))
+			ni_debug_application("%s: resolved reference to subordinate device %s", w->name, cw->name);
+			if (!ni_ifworker_add_child(w, cw, node, shared))
 				return FALSE;
 		} else
 		if (ni_string_eq(mchild->name, "modem-reference")) {
 			ni_bool_t shared = FALSE;
 
-			if (child_worker) {
+			if (cw) {
 				ni_error("%s: duplicate/conflicting references", xml_node_location(node));
 				return FALSE;
 			}
-			if (!(child_worker = ni_ifworker_resolve_reference(closure->fsm, node, NI_IFWORKER_TYPE_MODEM, w->name)))
+			if (!(cw = ni_ifworker_resolve_reference(closure->fsm, node, NI_IFWORKER_TYPE_MODEM, w->name)))
 				return FALSE;
 
 			if ((attr = xml_node_get_attr(mchild, "shared")) != NULL)
 				shared = ni_string_eq(attr, "true");
 
-			ni_debug_application("%s: resolved reference to subordinate device %s", w->name, child_worker->name);
-			if (!ni_ifworker_add_child(w, child_worker, node, shared))
+			ni_debug_application("%s: resolved reference to subordinate device %s", w->name, cw->name);
+			if (!ni_ifworker_add_child(w, cw, node, shared))
 				return FALSE;
 		} else
 		if (ni_string_eq(mchild->name, "require")) {
@@ -3203,13 +3203,13 @@ ni_ifworker_netif_resolve_cb(xml_node_t *node, const ni_xs_type_t *type, const x
 				return FALSE;
 			}
 
-			if (child_worker == NULL) {
-				ni_debug_application("%s: <meta:require check=netif-child-state> without netif-reference",
+			if (cw == NULL) {
+				ni_debug_application("%s: <meta:require check=netif-check-state> without netif-reference",
 						xml_node_location(mchild));
 				return FALSE;
 			}
 
-			ni_ifworker_add_check_state_req(w, method, child_worker, min_state, max_state);
+			ni_ifworker_add_check_state_req(w, method, cw, min_state, max_state);
 		}
 	}
 


### PR DESCRIPTION
This is needed in order to catch and order sequence of FSM action steps properly for scenarios where a device has both master and lower device dependency. That it a bond0.21 vlan interface needs to wait for its lower bond0 interface to be at least in device-up state _and_ it has to wait till its master (e.g. lab21) interface is present to it can receive single second NEWLINK with both relationships set.