### PR TITLE
nanny: correct workers starting order and do not restart FSM on slaves/ports

### DIFF
--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -243,6 +243,10 @@ usage:
 		return NI_WICKED_RC_ERROR;
 	}
 
+
+	ni_ifworker_array_flatten(&fsm->workers);
+	ni_ifworker_array_depth_sort(&fsm->workers);
+
 	/* Get workers that match given criteria */
 	nmarked = 0;
 	while (optind < argc) {

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -57,6 +57,7 @@ ni_ifdown_stop_policy(const char *policy_name)
 	return TRUE;
 }
 
+#if 0
 static ni_bool_t
 ni_ifdown_stop_device(const char *device_name)
 {
@@ -67,6 +68,7 @@ ni_ifdown_stop_device(const char *device_name)
 
 	return TRUE;
 }
+#endif
 
 ni_bool_t
 ni_ifdown_fire_nanny(ni_ifworker_array_t *array)
@@ -85,6 +87,12 @@ ni_ifdown_fire_nanny(ni_ifworker_array_t *array)
 		ni_string_free(&policy_name);
 	}
 
+/* Do not call disable() on each device, since there is no need to
+ * unschedule recheck() at nanny. Deleting policy has done it already.
+ * Further rearming the worker is unwanted; it should be done by
+ * specific events instead.
+ */
+#if 0
 	/* Disabling all requested devices */
 	for (i = 0; i < array->count; i++) {
 		ni_ifworker_t *w = array->data[i];
@@ -99,6 +107,7 @@ ni_ifdown_fire_nanny(ni_ifworker_array_t *array)
 			/* We ignore errors for now */;
 		}
 	}
+#endif
 
 	return TRUE;
 }

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -662,8 +662,6 @@ usage:
 	}
 
 	ni_fsm_pull_in_children(&up_marked);
-	ni_ifworkers_flatten(&up_marked);
-
 	/* anything to ifup? */
 	if (up_marked.count) {
 		if (!(monitor = ni_nanny_fsm_monitor_new(fsm))) {

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -602,8 +602,6 @@ usage:
 	}
 
 	ni_fsm_pull_in_children(&ifmarked);
-	ni_ifworkers_flatten(&ifmarked);
-
 	if (!ni_ifup_hire_nanny(&ifmarked, set_persistent))
 		status = NI_WICKED_RC_NOT_CONFIGURED;
 
@@ -874,7 +872,6 @@ usage:
 	}
 
 	ni_fsm_pull_in_children(&ifmarked);
-
 	/* Mark and start selected workers */
 	if (ifmarked.count)
 		nmarked = ni_fsm_mark_matching_workers(fsm, &ifmarked, &ifmarker);

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -181,7 +181,7 @@ ni_ifup_hire_nanny(ni_ifworker_array_t *array, ni_bool_t set_persistent)
 
 	/* Send policies to nanny */
 	for (i = 0; i < array->count; i++) {
-		ni_ifworker_t *w = array->data[array->count-1-i];
+		ni_ifworker_t *w = array->data[i];
 
 		if (!w || xml_node_is_empty(w->config.node))
 			continue;
@@ -197,7 +197,7 @@ ni_ifup_hire_nanny(ni_ifworker_array_t *array, ni_bool_t set_persistent)
 
 	/* Enable devices with policies */
 	for (i = 0; i < array->count; i++) {
-		ni_ifworker_t *w = array->data[array->count-1-i];
+		ni_ifworker_t *w = array->data[i];
 		ni_netdev_t *dev = w ? w->device : NULL;
 
 		/* Ignore non-existing device */

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -502,4 +502,7 @@ ni_ifworker_can_delete(const ni_ifworker_t *w)
 	return !!ni_dbus_object_get_service_for_method(w->object, "deleteDevice");
 }
 
+extern ni_bool_t	ni_ifworker_is_loopback(ni_ifworker_t *w);
+
+
 #endif /* __CLIENT_FSM_H__ */

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -319,7 +319,8 @@ extern ni_ifworker_t *		ni_fsm_recv_new_netif_path(ni_fsm_t *fsm, const char *pa
 extern ni_ifworker_t *		ni_fsm_recv_new_modem(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh);
 extern ni_ifworker_t *		ni_fsm_recv_new_modem_path(ni_fsm_t *fsm, const char *path);
 extern void			ni_fsm_destroy_worker(ni_fsm_t *fsm, ni_ifworker_t *w);
-extern void			ni_ifworkers_flatten(ni_ifworker_array_t *);
+extern void			ni_ifworker_array_flatten(ni_ifworker_array_t *);
+extern void			ni_ifworker_array_depth_sort(ni_ifworker_array_t *);
 extern void			ni_fsm_pull_in_children(ni_ifworker_array_t *);
 extern void			ni_fsm_wait_tentative_addrs(ni_fsm_t *);
 

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -169,8 +169,6 @@ ni_factory_device_up(ni_fsm_t *fsm, ni_ifworker_t *w)
 	ifmarker.persistent = w->control.persistent;
 
 	ni_ifworker_array_append(&ifmarked, w);
-	ni_fsm_pull_in_children(&ifmarked);
-
 	ni_fsm_mark_matching_workers(fsm, &ifmarked, &ifmarker);
 	ni_ifworker_array_destroy(&ifmarked);
 
@@ -378,7 +376,6 @@ ni_managed_device_up(ni_managed_device_t *mdev, const char *origin)
 	ifmarker.persistent = w->control.persistent;
 
 	ni_ifworker_array_append(&ifmarked, w);
-	ni_fsm_pull_in_children(&ifmarked);
 
 	/* Binding: this validates the XML configuration document,
 	 * resolves any references to other devices (if there are any),

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -154,7 +154,7 @@ ni_nanny_schedule_recheck(ni_ifworker_array_t *array, ni_ifworker_t *w)
 void
 ni_nanny_unschedule(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
-	ni_ifworker_array_remove_with_children(array, w);
+	ni_ifworker_array_remove(array, w);
 }
 
 /*

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3080,6 +3080,7 @@ ni_fsm_build_hierarchy(ni_fsm_t *fsm, ni_bool_t destructive)
 {
 	unsigned int i;
 
+	ni_fsm_events_block(fsm);
 	for (i = 0; i < fsm->workers.count; ++i) {
 		ni_ifworker_t *w = fsm->workers.data[i];
 		int rv;
@@ -3123,6 +3124,7 @@ ni_fsm_build_hierarchy(ni_fsm_t *fsm, ni_bool_t destructive)
 	}
 
 	ni_ifworker_array_flatten(&fsm->workers);
+	ni_fsm_events_unblock(fsm);
 	return 0;
 }
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2608,6 +2608,9 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 			continue;
 		}
 
+		if (ni_ifworker_is_running(child) || ni_ifworker_has_succeeded(child))
+			continue;
+
 		if (ni_ifworker_array_index(array, child) < 0)
 			ni_ifworker_array_append(array, child);
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4749,9 +4749,6 @@ ni_fsm_process_worker_event(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_event_t *ev)
 	const char *event_name = ev->signal_name;
 	ni_event_t  event_type = ev->event_type;
 
-	if (fsm->process_event.callback)
-		fsm->process_event.callback(fsm, w, ev);
-
 	switch (ev->event_type) {
 	case NI_EVENT_DEVICE_READY:
 	case NI_EVENT_DEVICE_UP:
@@ -4772,6 +4769,9 @@ ni_fsm_process_worker_event(ni_fsm_t *fsm, ni_ifworker_t *w, ni_fsm_event_t *ev)
 	default:
 		break;
 	}
+
+	if (fsm->process_event.callback)
+		fsm->process_event.callback(fsm, w, ev);
 
 	if (!ni_uuid_is_null(&ev->event_uuid)) {
 		ni_objectmodel_callback_info_t *cb;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -5140,3 +5140,28 @@ ni_fsm_set_user_prompt_fn(ni_fsm_t *fsm, ni_fsm_user_prompt_fn_t *fn, void *user
 	ni_fsm_user_prompt_fn = fn;
 	ni_fsm_user_prompt_data = user_data;
 }
+
+ni_bool_t
+ni_ifworker_is_loopback(ni_ifworker_t *w)
+{
+	if (w) {
+		if (ni_netdev_device_is_ready(w->device))
+			return w->device->link.type == NI_IFTYPE_LOOPBACK;
+
+		if (w->iftype == NI_IFTYPE_LOOPBACK)
+			return TRUE;
+
+		if (w->iftype != NI_IFTYPE_UNKNOWN)
+			return FALSE;
+
+		/*
+		 * (recent) kernel ensure, that loopback has ifindex 1
+		 * and is available as first in all namespaces...
+		 * It is rather an internal impementation, than a rule,
+		 * but since the worker is not yet bound to a device...
+		 */
+		return w->ifindex == 1 || ni_string_eq(w->name, "lo");
+	}
+	return FALSE;
+}
+

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2608,11 +2608,9 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 			continue;
 		}
 
-		if (ni_ifworker_array_index(array, child) < 0) {
-			if (ni_ifworker_complete(child))
-				ni_ifworker_rearm(child);
+		if (ni_ifworker_array_index(array, child) < 0)
 			ni_ifworker_array_append(array, child);
-		}
+
 		__ni_fsm_pull_in_children(child, array);
 	}
 }


### PR DESCRIPTION
This pull request has dependency to the #567 .