### PR TITLE
compat: OVS_BRIDGE option parsing and generation (fate#318840)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1775,6 +1775,12 @@ __ni_compat_generate_ifcfg(xml_node_t *ifnode, const ni_compat_netdev_t *compat)
 		}
 	}
 
+	if (dev->ovs_bridge) {
+		xml_node_t *child;
+		child = xml_node_create(ifnode, "ovs-bridge");
+		xml_node_new_element("name", child, dev->ovs_bridge);
+	}
+
 	switch (dev->link.type) {
 	case NI_IFTYPE_ETHERNET:
 		__ni_compat_generate_ethernet(ifnode, compat);

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -4279,6 +4279,16 @@ __ni_suse_get_scripts(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 	__ni_suse_qualify_scripts(compat, "post-down", value);
 }
 
+static void
+__ni_suse_get_ovs_bridge(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
+{
+	const char *ovs_bridge;
+
+	if ((ovs_bridge = ni_sysconfig_get_value(sc, "OVS_BRIDGE")) != NULL) {
+		ni_string_dup(&compat->dev->ovs_bridge, ovs_bridge);
+	}
+}
+
 /*
  * Read ifsysctl file
  */
@@ -4568,6 +4578,7 @@ __ni_suse_sysconfig_read(ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 	__ni_suse_read_ifsysctl(sc, compat);
 	__ni_suse_bootproto(sc, compat);
 	__ni_suse_get_scripts(sc, compat);
+	__ni_suse_get_ovs_bridge(sc, compat);
 
 	/* FIXME: What to do with these:
 		NAME

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -86,6 +86,9 @@ struct ni_netdev {
 	ni_lldp_t *		lldp;
 	ni_dcb_t *		dcb;
 
+	/* If device is used as a port for an ovs_bridge, set the bridge name. */
+	char *			ovs_bridge;
+
 	ni_pci_dev_t *		pci_dev;
 
 	ni_event_filter_t *	event_filter;


### PR DESCRIPTION
Needed for ovsbr-conf script to determine which ovs bridge a port belongs to - during ifup/ifdown - allowing for add-port/del-port operations.