### PR TITLE
team: fix segfault on teamd discovery failure

### DIFF
--- a/src/teamd.c
+++ b/src/teamd.c
@@ -1022,7 +1022,7 @@ ni_teamd_discover(ni_netdev_t *dev)
 
 failure:
 	ni_json_free(conf);
-	ni_team_free(dev->team);
+	ni_team_free(team);
 	ni_teamd_client_free(tdc);
 	ni_string_free(&val);
 	return -1;


### PR DESCRIPTION
On failure (e.g. teamd currently not running), the discover were
freeing team pointer on the device without proper reset, instead
of the local variable it allocated for the results, causing to
run into a segfault on a dangling pointer later.