### PR TITLE
dhcp4: verify client-id if send back by the server

### DIFF
--- a/dhcp4/protocol.c
+++ b/dhcp4/protocol.c
@@ -233,6 +233,21 @@ underflow:
 }
 
 static int
+ni_dhcp4_option_get_opaque(ni_buffer_t *bp, ni_opaque_t *opaque)
+{
+	unsigned int len = ni_buffer_count(bp);
+
+	if (!len || len > sizeof(opaque->data))
+		return -1;
+
+	if (ni_buffer_get(bp, opaque->data, len) < 0)
+		return -1;
+
+	opaque->len = len;
+	return 0;
+}
+
+static int
 ni_dhcp4_option_get_sockaddr(ni_buffer_t *bp, ni_sockaddr_t *addr)
 {
 	struct sockaddr_in *sin = &addr->sin;
@@ -1687,6 +1702,9 @@ parse_more:
 			break;
 		case DHCP4_SERVERIDENTIFIER:
 			ni_dhcp4_option_get_ipv4(&buf, &lease->dhcp4.server_id);
+			break;
+		case DHCP4_CLIENTID:
+			ni_dhcp4_option_get_opaque(&buf, &lease->dhcp4.client_id);
 			break;
 		case DHCP4_LEASETIME:
 			ni_dhcp4_option_get32(&buf, &lease->dhcp4.lease_time);


### PR DESCRIPTION
RFC 6842 requires that servers MUST send back client-id as
sent by the client and that client MUST verify it, when it
receives it in server responses.
Some servers need a config option (e.g. echo-client-id on
recent ISC dhcp) to send client-id back.