### PR TITLE
netconfig: do not refresh unrelated link details of address families

### DIFF
--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -405,6 +405,8 @@ autoip4_supplicant(void)
 		ni_fatal("unable to initialize dbus service");
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
+	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
 
 	ni_objectmodel_autoip4_init();
 

--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -404,6 +404,8 @@ autoip4_supplicant(void)
 	if (autoip4_dbus_server == NULL)
 		ni_fatal("unable to initialize dbus service");
 
+	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
+
 	ni_objectmodel_autoip4_init();
 
 	autoip4_register_services(autoip4_dbus_server);

--- a/client/tester.c
+++ b/client/tester.c
@@ -143,6 +143,8 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 	}
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
+	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp4_tester_run(tester);
@@ -262,6 +264,8 @@ ni_do_test_dhcp6(const char *caller, int argc, char **argv)
 	}
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
+	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp6_tester_run(tester);

--- a/client/tester.c
+++ b/client/tester.c
@@ -40,6 +40,7 @@
 #include "tester.h"
 #include "dhcp4/tester.h"
 #include "dhcp6/tester.h"
+#include "netinfo_priv.h"
 
 
 int
@@ -140,6 +141,8 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 		fprintf(stderr, "Error: %s: multiple interface names not supported\n", program);
 		goto cleanup;
 	}
+
+	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp4_tester_run(tester);
@@ -257,6 +260,8 @@ ni_do_test_dhcp6(const char *caller, int argc, char **argv)
 		fprintf(stderr, "Error: %s: multiple interface names not supported\n", program);
 		goto cleanup;
 	}
+
+	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp6_tester_run(tester);

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -256,6 +256,8 @@ main(int argc, char **argv)
 		opt_state_file = dirname;
 	}
 
+	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
+
 	if (tester) {
 		/* Create necessary directories if not yet there */
 		ni_config_storedir();

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -257,6 +257,8 @@ main(int argc, char **argv)
 	}
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
+	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -284,6 +284,8 @@ main(int argc, char **argv)
 	}
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
+	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -40,6 +40,7 @@
 
 #include "dhcp6/dbus-api.h"
 #include "dhcp6/tester.h"
+#include "netinfo_priv.h"
 #include "duid.h"
 
 
@@ -281,6 +282,8 @@ main(int argc, char **argv)
 							CONFIG_DHCP6_STATE_FILE);
 		opt_state_file = dirname;
 	}
+
+	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -178,6 +178,7 @@ typedef struct ni_global {
 	char *			config_dir;
 	ni_config_t *		config;
 
+	ni_netconfig_t *	state;
 	void			(*interface_event)(ni_netdev_t *, ni_event_t);
 	void			(*interface_addr_event)(ni_netdev_t *, ni_event_t, const ni_address_t *);
 	void			(*interface_prefix_event)(ni_netdev_t *, ni_event_t, const ni_ipv6_ra_pinfo_t *);
@@ -186,12 +187,5 @@ typedef struct ni_global {
 } ni_global_t;
 
 extern ni_global_t	ni_global;
-
-static inline void
-__ni_assert_initialized(void)
-{
-	if (!ni_global.initialized)
-		ni_fatal("Library not initialized, please call ni_init() first");
-}
 
 #endif /* __NI_NETINFO_APPCONFIG_H__ */

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -138,15 +138,15 @@ ni_rtnl_query_destroy(struct ni_rtnl_query *q)
 }
 
 static int
-ni_rtnl_query(struct ni_rtnl_query *q, unsigned int ifindex)
+ni_rtnl_query(struct ni_rtnl_query *q, unsigned int ifindex, unsigned int family)
 {
 	memset(q, 0, sizeof(*q));
 	q->ifindex = ifindex;
 
 	if (__ni_rtnl_query(&q->link_info, AF_UNSPEC, RTM_GETLINK) < 0
-	 || __ni_rtnl_query(&q->ipv6_info, AF_INET6, RTM_GETLINK) < 0
-	 || __ni_rtnl_query(&q->addr_info, AF_UNSPEC, RTM_GETADDR) < 0
-	 || __ni_rtnl_query(&q->route_info, AF_UNSPEC, RTM_GETROUTE) < 0) {
+	 || (family != AF_INET && __ni_rtnl_query(&q->ipv6_info, AF_INET6, RTM_GETLINK) < 0)
+	 || __ni_rtnl_query(&q->addr_info, family, RTM_GETADDR) < 0
+	 || __ni_rtnl_query(&q->route_info, family, RTM_GETROUTE) < 0) {
 		ni_rtnl_query_destroy(q);
 		return -1;
 	}
@@ -221,12 +221,12 @@ ni_rtnl_query_next_ipv6_link_info(struct ni_rtnl_query *q, struct nlmsghdr **hp)
 }
 
 static int
-ni_rtnl_query_addr_info(struct ni_rtnl_query *q, unsigned int ifindex)
+ni_rtnl_query_addr_info(struct ni_rtnl_query *q, unsigned int ifindex, unsigned int family)
 {
 	memset(q, 0, sizeof(*q));
 	q->ifindex = ifindex;
 
-	if (__ni_rtnl_query(&q->addr_info, AF_UNSPEC, RTM_GETADDR) < 0) {
+	if (__ni_rtnl_query(&q->addr_info, family, RTM_GETADDR) < 0) {
 		ni_rtnl_query_destroy(q);
 		return -1;
 	}
@@ -253,7 +253,7 @@ ni_rtnl_query_next_addr_info(struct ni_rtnl_query *q, struct nlmsghdr **hp)
 }
 
 static int
-ni_rtnl_query_route_info(struct ni_rtnl_query *q, unsigned int ifindex)
+ni_rtnl_query_route_info(struct ni_rtnl_query *q, unsigned int ifindex, unsigned int family)
 {
 	memset(q, 0, sizeof(*q));
 	q->ifindex = ifindex;
@@ -351,7 +351,7 @@ __ni_system_refresh_all(ni_netconfig_t *nc, ni_netdev_t **del_list)
 				"Full refresh of all interfaces (enforced)");
 	}
 
-	if (ni_rtnl_query(&query, 0) < 0)
+	if (ni_rtnl_query(&query, 0, ni_netconfig_get_family_filter(nc)) < 0)
 		goto failed;
 
 	/* Find tail of iflist */
@@ -510,7 +510,7 @@ __ni_system_refresh_interface(ni_netconfig_t *nc, ni_netdev_t *dev)
 		__ni_global_seqno++;
 	} while (!__ni_global_seqno);
 
-	if (ni_rtnl_query(&query, dev->link.ifindex) < 0)
+	if (ni_rtnl_query(&query, dev->link.ifindex, ni_netconfig_get_family_filter(nc)) < 0)
 		goto failed;
 
 	dev->seq = 0;
@@ -586,7 +586,7 @@ __ni_system_refresh_interface_addrs(ni_netconfig_t *nc, ni_netdev_t *dev)
 		dev->seq = ++__ni_global_seqno;
 	} while (!dev->seq);
 
-	if (ni_rtnl_query_addr_info(&query, dev->link.ifindex) < 0)
+	if (ni_rtnl_query_addr_info(&query, dev->link.ifindex, ni_netconfig_get_family_filter(nc)) < 0)
 		goto failed;
 
 	__ni_address_list_reset_seq(dev->addrs);
@@ -623,7 +623,7 @@ __ni_system_refresh_interface_routes(ni_netconfig_t *nc, ni_netdev_t *dev)
 			dev->name);
 
 	__ni_global_seqno++;
-	if (ni_rtnl_query_route_info(&query, dev->link.ifindex) < 0)
+	if (ni_rtnl_query_route_info(&query, dev->link.ifindex, ni_netconfig_get_family_filter(nc)) < 0)
 		goto failed;
 
 	ni_netdev_clear_routes(dev);

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -2507,8 +2507,6 @@ __ni_discover_addrconf(ni_netdev_t *dev)
 {
 	ni_addrconf_lease_t *lease;
 
-	__ni_assert_initialized();
-
 	for (lease = dev->leases; lease; lease = lease->next) {
 		switch (lease->family) {
 		case AF_INET:

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -38,6 +38,7 @@ extern void		ni_addrconf_updater_free(ni_addrconf_updater_t **);
 
 typedef struct ni_netconfig_filter {
 	unsigned int		family;
+	unsigned int		discover;
 } ni_netconfig_filter_t;
 
 struct ni_netconfig {
@@ -520,6 +521,22 @@ ni_netconfig_destroy(ni_netconfig_t *nc)
 /*
  * apply filter
  */
+ni_bool_t
+ni_netconfig_set_discover_filter(ni_netconfig_t *nc, unsigned int flag)
+{
+	if (nc) {
+		nc->filter.discover |= flag;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+ni_bool_t
+ni_netconfig_discover_filtered(ni_netconfig_t *nc, unsigned int flag)
+{
+	return nc && nc->filter.discover & flag;
+}
+
 ni_bool_t
 ni_netconfig_set_family_filter(ni_netconfig_t *nc, unsigned int family)
 {

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -36,7 +36,13 @@
 
 extern void		ni_addrconf_updater_free(ni_addrconf_updater_t **);
 
+typedef struct ni_netconfig_filter {
+	unsigned int		family;
+} ni_netconfig_filter_t;
+
 struct ni_netconfig {
+	ni_netconfig_filter_t	filter;
+
 	ni_netdev_t *		interfaces;
 	ni_modem_t *		modems;
 
@@ -509,6 +515,25 @@ ni_netconfig_destroy(ni_netconfig_t *nc)
 {
 	__ni_netdev_list_destroy(&nc->interfaces);
 	memset(nc, 0, sizeof(*nc));
+}
+
+/*
+ * apply filter
+ */
+ni_bool_t
+ni_netconfig_set_family_filter(ni_netconfig_t *nc, unsigned int family)
+{
+	if (nc) {
+		nc->filter.family = family;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+unsigned int
+ni_netconfig_get_family_filter(ni_netconfig_t *nc)
+{
+	return nc ? nc->filter.family : AF_UNSPEC;
 }
 
 /*

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -163,6 +163,13 @@ ni_init_ex(const char *appname, ni_init_appdata_callback_t *cb, void *appdata)
 	return 0;
 }
 
+static inline void
+ni_global_assert_initialized(void)
+{
+	if (!ni_global.initialized)
+		ni_fatal("Library not initialized, please call ni_init() first");
+}
+
 const char *
 ni_get_global_config_dir(void)
 {
@@ -383,7 +390,7 @@ ni_server_listen_other_events(void (*event_handler)(ni_event_t))
 ni_dbus_server_t *
 ni_server_listen_dbus(const char *dbus_name)
 {
-	__ni_assert_initialized();
+	ni_global_assert_initialized();
 	if (dbus_name == NULL)
 		dbus_name = ni_global.config->dbus_name;
 	if (dbus_name == NULL) {
@@ -397,7 +404,7 @@ ni_server_listen_dbus(const char *dbus_name)
 ni_dbus_client_t *
 ni_create_dbus_client(const char *dbus_name)
 {
-	__ni_assert_initialized();
+	ni_global_assert_initialized();
 	if (dbus_name == NULL)
 		dbus_name = ni_global.config->dbus_name;
 	if (dbus_name == NULL) {
@@ -435,22 +442,29 @@ ni_server_dbus_xml_schema(void)
  * If refresh is 0, this will just return the current handle; if it is non-zero,
  * the current state is retrieved.
  */
+static inline ni_netconfig_t *
+ni_global_state_init(void)
+{
+	ni_global_assert_initialized();
+	if (ni_global.state)
+		return ni_global.state;
+
+	if (__ni_global_netlink == NULL) {
+		__ni_global_netlink = __ni_netlink_open(0);
+		if (__ni_global_netlink == NULL)
+			return NULL;
+	}
+
+	ni_global.state = ni_netconfig_new();
+	return ni_global.state;
+}
+
 ni_netconfig_t *
 ni_global_state_handle(int refresh)
 {
-	static ni_netconfig_t *nc = NULL;
+	ni_netconfig_t *nc = ni_global_state_init();
 
-	if (nc == NULL) {
-		if (__ni_global_netlink == NULL) {
-			__ni_global_netlink = __ni_netlink_open(0);
-			if (__ni_global_netlink == NULL)
-				return NULL;
-		}
-
-		nc = ni_netconfig_new();
-	}
-
-	if (refresh) {
+	if (nc && refresh) {
 		if (__ni_system_refresh_interfaces(nc) < 0) {
 			ni_error("failed to refresh interface list");
 			return NULL;

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -29,6 +29,11 @@ struct ni_event_filter {
 	ni_uuid_t		uuid;
 };
 
+enum {
+	/* link details discover filter using external calls */
+	NI_NETCONFIG_DISCOVER_LINK_EXTERN = 1U << 0,
+};
+
 /*
  * These constants describe why/how the interface has been brought up
  */
@@ -42,6 +47,8 @@ extern void		ni_netconfig_device_remove(ni_netconfig_t *, ni_netdev_t *);
 extern ni_netdev_t **	ni_netconfig_device_list_head(ni_netconfig_t *);
 extern void		ni_netconfig_modem_append(ni_netconfig_t *, ni_modem_t *);
 
+extern ni_bool_t	ni_netconfig_set_discover_filter(ni_netconfig_t *, unsigned int);
+extern ni_bool_t	ni_netconfig_discover_filtered(ni_netconfig_t *, unsigned int);
 extern ni_bool_t	ni_netconfig_set_family_filter(ni_netconfig_t *, unsigned int);
 extern unsigned int	ni_netconfig_get_family_filter(ni_netconfig_t *);
 

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -42,6 +42,9 @@ extern void		ni_netconfig_device_remove(ni_netconfig_t *, ni_netdev_t *);
 extern ni_netdev_t **	ni_netconfig_device_list_head(ni_netconfig_t *);
 extern void		ni_netconfig_modem_append(ni_netconfig_t *, ni_modem_t *);
 
+extern ni_bool_t	ni_netconfig_set_family_filter(ni_netconfig_t *, unsigned int);
+extern unsigned int	ni_netconfig_get_family_filter(ni_netconfig_t *);
+
 extern ni_bool_t	__ni_linkinfo_kind_to_type(const char *, ni_iftype_t *);
 
 extern void		__ni_netdev_list_append(ni_netdev_t **, ni_netdev_t *);


### PR DESCRIPTION
dhcp6 does not need IPv4 related state, dhcp4 and auto4 do not need IPv6.