### PR TITLE
service: fixed wicked client and nanny dependencies (bsc#950333)

### DIFF
--- a/etc/systemd/wicked.service.in
+++ b/etc/systemd/wicked.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=wicked managed network interfaces
-Wants=network.target
+Wants=network.target wickedd.service
 After=network-pre.target wickedd.service wickedd-nanny.service
 Before=network-online.target network.target
 

--- a/etc/systemd/wicked.service.in
+++ b/etc/systemd/wicked.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=wicked managed network interfaces
-Wants=network.target wickedd.service
+Wants=network.target wickedd.service wickedd-nanny.service
 After=network-pre.target wickedd.service wickedd-nanny.service
 Before=network-online.target network.target
 

--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -15,6 +15,5 @@ StandardError=null
 Restart=on-abort
 
 [Install]
-WantedBy=wickedd.service
 Alias=dbus-org.opensuse.Network.AUTO4.service
 

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -15,6 +15,5 @@ StandardError=null
 Restart=on-abort
 
 [Install]
-WantedBy=wickedd.service
 Alias=dbus-org.opensuse.Network.DHCP4.service
 

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -15,6 +15,5 @@ StandardError=null
 Restart=on-abort
 
 [Install]
-WantedBy=wickedd.service
 Alias=dbus-org.opensuse.Network.DHCP6.service
 

--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -15,6 +15,5 @@ StandardError=null
 Restart=on-abort
 
 [Install]
-WantedBy=wickedd.service
 Alias=dbus-org.opensuse.Network.Nanny.service
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
+Wants=wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
 After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service
 Before=wicked.service network.target
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -15,7 +15,6 @@ StandardError=null
 Restart=on-abort
 
 [Install]
-WantedBy=wicked.service
 Also=wickedd-nanny.service
 Also=wickedd-auto4.service
 Also=wickedd-dhcp4.service

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
 After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service
-Before=wicked.service network.target
+Before=wickedd-nanny.service wicked.service network.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Fixed to want nanny in wicked client (rcnetwork) service, added explicit before
wickedd-nanny ordering to wickedd service and changed to use wants instead
of wantedby install dependencies which are active for enabled services only.