### PR TITLE
ovs: use --may-exist option in add-port (bsc#951315)

### DIFF
--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -202,7 +202,7 @@ ni_system_interface_enslave(ni_netdev_t *master, ni_netdev_t *dev, const ni_netd
 			return -1;
 		}
 
-		ret = ni_ovs_vsctl_bridge_port_add(dev->name, &req->port->ovsbr);
+		ret = ni_ovs_vsctl_bridge_port_add(dev->name, &req->port->ovsbr, TRUE);
 		if (ret == 0)  {
 			ni_netdev_ref_set(&dev->link.masterdev,
 					master->name, master->link.ifindex);
@@ -257,7 +257,7 @@ ni_system_interface_link_change(ni_netdev_t *dev, const ni_netdev_req_t *ifp_req
 			if (master && master->link.type == NI_IFTYPE_OVS_SYSTEM) {
 				if (ifp_req->port && ifp_req->port->type == NI_IFTYPE_OVS_BRIDGE &&
 				    !ni_string_empty(ifp_req->port->ovsbr.bridge.name)) {
-					ni_ovs_vsctl_bridge_port_add(dev->name, &ifp_req->port->ovsbr);
+					ni_ovs_vsctl_bridge_port_add(dev->name, &ifp_req->port->ovsbr, TRUE);
 				}
 			}
 

--- a/src/ovs.c
+++ b/src/ovs.c
@@ -524,7 +524,7 @@ failure:
 }
 
 int /* process run codes (for now) */
-ni_ovs_vsctl_bridge_port_add(const char *pname, const ni_ovs_bridge_port_config_t *pconf)
+ni_ovs_vsctl_bridge_port_add(const char *pname, const ni_ovs_bridge_port_config_t *pconf, ni_bool_t may_exist)
 {
 	const char *ovs_vsctl;
 	ni_shellcmd_t *cmd;
@@ -541,6 +541,9 @@ ni_ovs_vsctl_bridge_port_add(const char *pname, const ni_ovs_bridge_port_config_
 		return rv;
 
 	if (!ni_shellcmd_add_arg(cmd, ovs_vsctl))
+		goto failure;
+
+	if (may_exist && !ni_shellcmd_add_arg(cmd, "--may-exist"))
 		goto failure;
 
 	if (!ni_shellcmd_add_arg(cmd, "add-port"))

--- a/src/ovs.h
+++ b/src/ovs.h
@@ -34,7 +34,8 @@ extern int	ni_ovs_vsctl_bridge_to_vlan(const char *, uint16_t *);
 extern int	ni_ovs_vsctl_bridge_to_parent(const char *, char **);
 extern int	ni_ovs_vsctl_bridge_ports(const char *, ni_ovs_bridge_port_array_t *);
 
-extern int	ni_ovs_vsctl_bridge_port_add(const char *, const ni_ovs_bridge_port_config_t *);
+extern int	ni_ovs_vsctl_bridge_port_add(const char *, const ni_ovs_bridge_port_config_t *,
+							ni_bool_t);
 extern int	ni_ovs_vsctl_bridge_port_del(const char *, const char *);
 extern int	ni_ovs_vsctl_bridge_port_to_bridge(const char *, char **);
 


### PR DESCRIPTION
This just avoids errors when the port is already in the db,
but does not trigger an enslave inside of openvswitch yet.
The remaining parts have to be addressed in openvswitch.