### PR TITLE
ifup: replace policies to avoid a race (bsc#953107)

### DIFF
--- a/client/ifup.c
+++ b/client/ifup.c
@@ -247,24 +247,6 @@ ni_ifup_start_policy(ni_ifworker_t *w)
 	if (!policy)
 		goto error;
 
-#if 0
-	/* Do we need this? */
-
-	/* Add link type to match node*/
-	if (dev) {
-		ni_debug_application("%s: adding link type (%s) to match",
-			w->name, ni_linktype_type_to_name(dev->link.type));
-		ni_ifpolicy_match_add_link_type(policy, dev->link.type);
-	}
-
-	ni_debug_application("%s: adding minimum device state (%s) to match",
-		w->name, ni_ifworker_state_name(w->fsm.state));
-
-	/* Add minimum device state to match node */
-	if (!ni_ifpolicy_match_add_min_state(policy, w->fsm.state))
-		goto error;
-#endif
-
 	ni_debug_application("%s: adding policy %s to nanny", w->name,
 		xml_node_get_attr(policy, NI_NANNY_IFPOLICY_NAME));
 
@@ -288,6 +270,7 @@ ni_ifup_hire_nanny(ni_ifworker_array_t *array, ni_bool_t set_persistent)
 {
 	unsigned int i;
 	ni_bool_t rv = TRUE;
+	ni_string_array_t names = NI_STRING_ARRAY_INIT;
 
 	/* Send policies to nanny */
 	for (i = 0; i < array->count; i++) {
@@ -301,37 +284,19 @@ ni_ifup_hire_nanny(ni_ifworker_array_t *array, ni_bool_t set_persistent)
 
 		if (!ni_ifup_start_policy(w))
 			rv = FALSE;
-		else
+		else {
 			ni_info("%s: configuration applied to nanny", w->name);
-	}
-
-	/* Enable devices with policies */
-	for (i = 0; i < array->count; i++) {
-		ni_ifworker_t *w = array->data[array->count-1-i];
-		ni_netdev_t *dev = w ? w->device : NULL;
-
-		/* Ignore non-existing device */
-		if (!dev || !ni_netdev_device_is_ready(dev) ||
-		    xml_node_is_empty(w->config.node)) {
-			continue;
-		}
-
-		if (w->failed) {
-			ni_debug_application("%s: disabling failed device for nanny", w->name);
-			ni_nanny_call_device_disable(w->name);
-		}
-		else if (w->done) {
-			ni_debug_application("%s: enabling device for nanny", w->name);
-			if (!ni_nanny_call_device_enable(w->name)) {
-				ni_error("%s: unable to enable device", w->name);
-				rv = FALSE;
-			}
+			ni_string_array_append(&names, w->name);
 		}
 	}
 
+	/* Recheck policies on modified devices */
 	if (0 == array->count)
 		ni_note("ifup: no matching interfaces");
+	else
+		ni_nanny_call_recheck(&names);
 
+	ni_string_array_destroy(&names);
 	return rv;
 }
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -283,10 +283,11 @@ extern ni_fsm_t *		ni_fsm_new(void);
 extern void			ni_fsm_free(ni_fsm_t *);
 
 extern ni_fsm_policy_t *	ni_fsm_policy_new(ni_fsm_t *, const char *, xml_node_t *);
+extern ni_fsm_policy_t *	ni_fsm_policy_ref(ni_fsm_policy_t *);
 extern void			ni_fsm_policy_free(ni_fsm_policy_t *);
 extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
-extern ni_fsm_policy_t *	ni_fsm_policy_by_name(ni_fsm_t *, const char *);
 extern ni_bool_t		ni_fsm_policy_remove(ni_fsm_t *, ni_fsm_policy_t *);
+extern ni_fsm_policy_t *	ni_fsm_policy_by_name(const ni_fsm_t *, const char *);
 extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
 						const ni_fsm_policy_t **, unsigned int);
 extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_fsm_policy_t *, ni_ifworker_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -292,7 +292,8 @@ extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_
 extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_fsm_policy_t *, ni_ifworker_t *);
 extern xml_node_t *		ni_fsm_policy_transform_document(xml_node_t *, ni_fsm_policy_t * const *, unsigned int);
 extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
-extern xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);
+extern const xml_node_t *	ni_fsm_policy_node(const ni_fsm_policy_t *);
+extern const xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);
 extern const char *		ni_fsm_policy_get_origin(const ni_fsm_policy_t *);
 extern ni_bool_t		ni_fsm_policies_changed_since(const ni_fsm_t *, unsigned int *tstamp);
 

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -113,8 +113,10 @@ ni_managed_device_set_policy(ni_managed_device_t *mdev, ni_managed_policy_t *mpo
 	xml_node_free(mdev->selected_config);
 	mdev->selected_config = xml_node_clone_ref(config);
 
-	mdev->selected_policy = mpolicy;
-	mdev->selected_policy_seq = mpolicy? mpolicy->seqno : 0;
+	ni_managed_policy_free(mdev->selected_policy);
+	mdev->selected_policy = ni_managed_policy_ref(mpolicy);
+
+	mdev->selected_policy_seq = mpolicy ? mpolicy->seqno : 0;
 }
 
 void

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -238,6 +238,9 @@ ni_nanny_policy_load(ni_nanny_t *mgr)
 		}
 	}
 
+	if (files.count)
+		ni_nanny_recheck_policies(mgr, NULL);
+
 	ni_string_array_destroy(&files);
 	return TRUE;
 }

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -912,6 +912,11 @@ ni_objectmodel_nanny_create_policy(ni_dbus_object_t *object, const ni_dbus_metho
 	}
 	xml_document_free(doc);
 
+	if (!ni_objectmodel_managed_policy_save(policy_object)) {
+		ni_warn("Unable to save created managed nanny policy %s",
+			ni_dbus_object_get_path(policy_object));
+	}
+
 	return ni_dbus_message_append_object_path(reply, ni_dbus_object_get_path(policy_object));
 }
 

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -396,7 +396,7 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, xml_do
 		ni_managed_policy_t *mpolicy;
 		ni_dbus_object_t *po_tmp;
 
-		mpolicy = ni_managed_policy_new(mgr, policy, NULL);
+		mpolicy = ni_managed_policy_new(mgr, policy);
 		po_tmp = ni_objectmodel_register_managed_policy(mgr->server, mpolicy);
 		if (!po_tmp) {
 			ni_error("%s: Unable to register managed policy", pname);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -118,6 +118,7 @@ extern ni_nanny_t *		ni_nanny_new(void);
 extern void			ni_nanny_start(ni_nanny_t *);
 extern void			ni_nanny_free(ni_nanny_t *);
 extern const char *		ni_nanny_statedir(void);
+extern void			ni_nanny_recheck_policies(ni_nanny_t *, const ni_string_array_t *);
 extern void			ni_nanny_schedule_recheck(ni_ifworker_array_t *, ni_ifworker_t *);
 extern void			ni_nanny_unschedule(ni_ifworker_array_t *, ni_ifworker_t *);
 extern unsigned int		ni_nanny_recheck_do(ni_nanny_t *mgr);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -69,7 +69,6 @@ struct ni_managed_policy {
 	uid_t			owner;
 	unsigned int		seqno;
 	ni_fsm_policy_t *	fsm_policy;
-	xml_document_t *	doc;
 };
 
 typedef struct ni_nanny_devmatch ni_nanny_devmatch_t;
@@ -153,7 +152,7 @@ extern void			ni_managed_device_set_policy(ni_managed_device_t *, ni_managed_pol
 extern void			ni_managed_device_down(ni_managed_device_t *mdev);
 extern ni_bool_t		ni_managed_policy_filename(const char *, char *, size_t);
 
-extern ni_managed_policy_t *	ni_managed_policy_new(ni_nanny_t *, ni_fsm_policy_t *, xml_document_t *);
+extern ni_managed_policy_t *	ni_managed_policy_new(ni_nanny_t *, ni_fsm_policy_t *);
 extern void			ni_managed_policy_free(ni_managed_policy_t *);
 
 extern const char *		ni_managed_state_to_string(ni_managed_state_t);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -160,6 +160,7 @@ extern const char *		ni_managed_state_to_string(ni_managed_state_t);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_netdev(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_modem(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_policy(ni_dbus_server_t *, ni_managed_policy_t *);
+extern ni_bool_t		ni_objectmodel_managed_policy_save(ni_dbus_object_t *);
 extern dbus_bool_t		ni_objectmodel_unregister_managed_policy(ni_dbus_server_t *, ni_managed_policy_t *, const char*);
 extern void			ni_objectmodel_unregister_managed_device(ni_managed_device_t *);
 

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -64,6 +64,8 @@ struct ni_nanny_user {
 };
 
 struct ni_managed_policy {
+	unsigned int		refcount;
+	ni_managed_policy_t **	pprev;
 	ni_managed_policy_t *	next;
 
 	uid_t			owner;
@@ -125,7 +127,6 @@ extern void			ni_nanny_unregister_device(ni_nanny_t *, ni_ifworker_t *);
 extern ni_managed_device_t *	ni_nanny_get_device_by_ifindex(ni_nanny_t *, unsigned int);
 extern void			ni_nanny_remove_device(ni_nanny_t *, ni_managed_device_t *);
 extern ni_managed_policy_t *	ni_nanny_get_policy(ni_nanny_t *, const ni_fsm_policy_t *);
-extern ni_bool_t		ni_nanny_remove_policy(ni_nanny_t *, ni_managed_policy_t *);
 extern ni_nanny_user_t *	ni_nanny_get_user(ni_nanny_t *, uid_t);
 extern ni_nanny_user_t *	ni_nanny_create_user(ni_nanny_t *, uid_t);
 extern void			ni_nanny_clear_secrets(ni_nanny_t *mgr,
@@ -152,7 +153,9 @@ extern void			ni_managed_device_set_policy(ni_managed_device_t *, ni_managed_pol
 extern void			ni_managed_device_down(ni_managed_device_t *mdev);
 extern ni_bool_t		ni_managed_policy_filename(const char *, char *, size_t);
 
+extern ni_dbus_object_t *	ni_managed_policy_register(ni_nanny_t *, ni_fsm_policy_t *);
 extern ni_managed_policy_t *	ni_managed_policy_new(ni_nanny_t *, ni_fsm_policy_t *);
+extern ni_managed_policy_t *	ni_managed_policy_ref(ni_managed_policy_t *);
 extern void			ni_managed_policy_free(ni_managed_policy_t *);
 
 extern const char *		ni_managed_state_to_string(ni_managed_state_t);

--- a/nanny/policy.c
+++ b/nanny/policy.c
@@ -199,8 +199,15 @@ ni_objectmodel_managed_policy_update(ni_dbus_object_t *object, const ni_dbus_met
 	const char *ifxml;
 	xml_node_t *node;
 
-	if ((mpolicy = ni_objectmodel_managed_policy_unwrap(object, error)) == NULL)
+	if ((mpolicy = ni_objectmodel_managed_policy_unwrap(object, error)) == NULL) {
+		dbus_set_error_const(error, NI_DBUS_ERROR_POLICY_DOESNOTEXIST, NULL);
 		return FALSE;
+	}
+
+	if (caller_uid != 0 && caller_uid != mpolicy->owner) {
+		dbus_set_error_const(error, NI_DBUS_ERROR_PERMISSION_DENIED, NULL);
+		return FALSE;
+	}
 
 	if (argc != 1 || !ni_dbus_variant_get_string(&argv[0], &ifxml))
 		return ni_dbus_error_invalid_args(error, ni_dbus_object_get_path(object), method->name);

--- a/src/client/ifconfig.h
+++ b/src/client/ifconfig.h
@@ -79,6 +79,7 @@ extern ni_bool_t		ni_nanny_call_device_enable(const char *ifname);
 extern ni_bool_t		ni_nanny_call_device_disable(const char *ifname);
 extern ni_dbus_object_t *	ni_nanny_call_get_device(const char *);
 extern ni_bool_t		ni_nanny_call_add_secret(const ni_security_id_t *, const char *, const char *);
+extern ni_bool_t		ni_nanny_call_recheck(const ni_string_array_t *);
 
 extern ni_bool_t		ni_ifconfig_generate_uuid(const xml_node_t *, ni_uuid_t *);
 

--- a/src/client/ifconfig.h
+++ b/src/client/ifconfig.h
@@ -89,7 +89,7 @@ ni_ifconfig_is_config(xml_node_t *ifnode)
 }
 
 static inline ni_bool_t
-ni_ifconfig_is_policy(xml_node_t *pnode)
+ni_ifconfig_is_policy(const xml_node_t *pnode)
 {
 	return !xml_node_is_empty(pnode) &&
 		(ni_string_eq(pnode->name, NI_NANNY_IFPOLICY) ||
@@ -97,19 +97,19 @@ ni_ifconfig_is_policy(xml_node_t *pnode)
 }
 
 static inline const char *
-ni_ifpolicy_get_origin(xml_node_t *pnode)
+ni_ifpolicy_get_origin(const xml_node_t *pnode)
 {
 	return xml_node_get_attr(pnode, NI_NANNY_IFPOLICY_ORIGIN);
 }
 
 static inline const char *
-ni_ifpolicy_get_name(xml_node_t *pnode)
+ni_ifpolicy_get_name(const xml_node_t *pnode)
 {
 	return xml_node_get_attr(pnode, NI_NANNY_IFPOLICY_NAME);
 }
 
 static inline ni_bool_t
-ni_ifpolicy_is_valid(xml_node_t *pnode)
+ni_ifpolicy_is_valid(const xml_node_t *pnode)
 {
 	if (!ni_ifconfig_is_policy(pnode))
 		return FALSE;

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -360,9 +360,18 @@ ni_fsm_policy_name(const ni_fsm_policy_t *policy)
 }
 
 /*
+ * Get the policy xml node
+ */
+const xml_node_t *
+ni_fsm_policy_node(const ni_fsm_policy_t *policy)
+{
+	return policy ? policy->node : NULL;
+}
+
+/*
  * Get the policy's location (if set)
  */
-xml_location_t *
+const xml_location_t *
 ni_fsm_policy_location(const ni_fsm_policy_t *policy)
 {
 	if (!policy || !policy->node)

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -98,6 +98,8 @@ typedef enum {
 } ni_fsm_policy_type_t;
 
 struct ni_fsm_policy {
+	unsigned int			refcount;
+	ni_fsm_policy_t **		pprev;
 	ni_fsm_policy_t *		next;
 
 	unsigned int			seq;
@@ -115,6 +117,7 @@ struct ni_fsm_policy {
 
 
 static void			__ni_fsm_policy_reset(ni_fsm_policy_t *);
+static void			__ni_fsm_policy_destroy(ni_fsm_policy_t *);
 static ni_ifcondition_t *	ni_fsm_policy_conditions_from_xml(xml_node_t *);
 static ni_bool_t		ni_ifcondition_check(const ni_ifcondition_t *, const ni_fsm_t *, ni_ifworker_t *);
 static ni_ifcondition_t *	ni_ifcondition_from_xml(xml_node_t *);
@@ -129,18 +132,57 @@ static ni_fsm_template_input_t *ni_fsm_template_input_new(const char *id, ni_fsm
 static void			ni_fsm_template_input_free(ni_fsm_template_input_t *);
 
 /*
+ * fsm policy list primitives
+ */
+static inline void
+__ni_fsm_policy_list_insert(ni_fsm_policy_t **list, ni_fsm_policy_t *policy)
+{
+	policy->pprev = list;
+	policy->next = *list;
+	if (policy->next)
+		policy->next->pprev = &policy->next;
+	*list = policy;
+}
+
+static inline void
+__ni_fsm_policy_list_unlink(ni_fsm_policy_t *policy)
+{
+	ni_fsm_policy_t **pprev, *next;
+
+	pprev = policy->pprev;
+	next = policy->next;
+	if (pprev)
+		*pprev = next;
+	if (next)
+		next->pprev = pprev;
+	policy->pprev = NULL;
+	policy->next = NULL;
+}
+
+/*
  * Destructor for policy objects
  */
 void
 ni_fsm_policy_free(ni_fsm_policy_t *policy)
 {
 	if (policy) {
-		ni_string_free(&policy->name);
-		xml_node_free(policy->node);
-		__ni_fsm_policy_reset(policy);
-		memset(policy, 0, sizeof(*policy));
-		free(policy);
+		ni_assert(policy->refcount);
+		policy->refcount--;
+		if (policy->refcount == 0) {
+			__ni_fsm_policy_list_unlink(policy);
+			__ni_fsm_policy_destroy(policy);
+			free(policy);
+		}
 	}
+}
+
+static void
+__ni_fsm_policy_destroy(ni_fsm_policy_t *policy)
+{
+	__ni_fsm_policy_reset(policy);
+	ni_string_free(&policy->name);
+	xml_node_free(policy->node);
+	memset(policy, 0, sizeof(*policy));
 }
 
 static void
@@ -162,6 +204,10 @@ __ni_fsm_policy_reset(ni_fsm_policy_t *policy)
 	}
 }
 
+
+/*
+ * Constructor for policy objects
+ */
 static ni_bool_t
 __ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 {
@@ -262,9 +308,12 @@ ni_fsm_policy_t *
 ni_fsm_policy_new(ni_fsm_t *fsm, const char *name, xml_node_t *node)
 {
 	ni_fsm_policy_t *policy;
-	ni_fsm_policy_t *pos, **tail;
-	
+
+	if (!fsm || ni_string_empty(name) || xml_node_is_empty(node))
+		return NULL;
+
 	policy = xcalloc(1, sizeof(*policy));
+	policy->refcount = 1;
 	ni_string_dup(&policy->name, name);
 
 	if (!__ni_fsm_policy_from_xml(policy, node)) {
@@ -272,10 +321,17 @@ ni_fsm_policy_new(ni_fsm_t *fsm, const char *name, xml_node_t *node)
 		return NULL;
 	}
 
-	for (tail = &fsm->policies; (pos = *tail) != NULL; tail = &pos->next)
-		;
-	*tail = policy;
+	__ni_fsm_policy_list_insert(&fsm->policies, policy);
+	return policy;
+}
 
+ni_fsm_policy_t *
+ni_fsm_policy_ref(ni_fsm_policy_t *policy)
+{
+	if (policy) {
+		ni_assert(policy->refcount);
+		policy->refcount++;
+	}
 	return policy;
 }
 
@@ -289,8 +345,10 @@ ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
 		return FALSE;
 
 	memset(&temp, 0, sizeof(temp));
-	if (!__ni_fsm_policy_from_xml(&temp, node))
+	if (!__ni_fsm_policy_from_xml(&temp, node)) {
+		__ni_fsm_policy_destroy(&temp);
 		return FALSE;
+	}
 
 	__ni_fsm_policy_reset(policy);
 	policy->type = temp.type;
@@ -303,6 +361,29 @@ ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
 	xml_node_free(policy->node);
 	policy->node = temp.node;
 	return TRUE;
+}
+
+ni_bool_t
+ni_fsm_policy_remove(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
+{
+	ni_fsm_policy_t *cur;
+
+	if (!fsm || !policy)
+		return FALSE;
+
+	for (cur = fsm->policies; cur; cur = cur->next) {
+		if (cur == policy) {
+			/*
+			 * force remove if in fsm list,
+			 * even it is not the last ref.
+			 */
+			__ni_fsm_policy_list_unlink(cur);
+			ni_fsm_policy_free(cur);
+			return TRUE;
+		}
+	}
+
+	return FALSE;
 }
 
 ni_bool_t
@@ -321,7 +402,7 @@ ni_fsm_policies_changed_since(const ni_fsm_t *fsm, unsigned int *tstamp)
 }
 
 ni_fsm_policy_t *
-ni_fsm_policy_by_name(ni_fsm_t *fsm, const char *name)
+ni_fsm_policy_by_name(const ni_fsm_t *fsm, const char *name)
 {
 	ni_fsm_policy_t *policy;
 
@@ -329,25 +410,7 @@ ni_fsm_policy_by_name(ni_fsm_t *fsm, const char *name)
 		if (policy->name && ni_string_eq(policy->name, name))
 			return policy;
 	}
-
 	return NULL;
-}
-
-ni_bool_t
-ni_fsm_policy_remove(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
-{
-	ni_fsm_policy_t **pos, *cur;
-
-	ni_assert(fsm);
-	for (pos = &fsm->policies; (cur = *pos); pos = &cur->next) {
-		if (cur == policy) {
-			*pos = cur->next;
-			ni_fsm_policy_free(cur);
-			return TRUE;
-		}
-	}
-
-	return FALSE;
 }
 
 /*
@@ -356,7 +419,7 @@ ni_fsm_policy_remove(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
 const char *
 ni_fsm_policy_name(const ni_fsm_policy_t *policy)
 {
-	return policy->name;
+	return policy ? policy->name : NULL;
 }
 
 /*


### PR DESCRIPTION
Instead to create and kickstart or update policies (two step replace),
then try to enable managed devices, immediately replace policies and
schedule recheck to activate them to avoid a device detection race
condition, where the client creates/updates the policy, but skips to
activate it, because it doesn't know the device (ifindex) yet.
