### PR TITLE
fsm: do not segfault on device hierarchy loops (bnc#959356)

### DIFF
--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -662,7 +662,6 @@ usage:
 	}
 
 	ni_fsm_pull_in_children(&up_marked);
-	ni_ifworkers_flatten(&up_marked);
 
 	/* anything to ifup? */
 	if (up_marked.count) {

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -677,7 +677,6 @@ usage:
 	}
 
 	ni_fsm_pull_in_children(&ifmarked);
-	ni_ifworkers_flatten(&ifmarked);
 
 	if (!ni_ifup_hire_nanny(&ifmarked, set_persistent))
 		status = NI_WICKED_RC_NOT_CONFIGURED;

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -274,7 +274,7 @@ ni_ifup_hire_nanny(ni_ifworker_array_t *array, ni_bool_t set_persistent)
 
 	/* Send policies to nanny */
 	for (i = 0; i < array->count; i++) {
-		ni_ifworker_t *w = array->data[array->count-1-i];
+		ni_ifworker_t *w = array->data[i];
 
 		if (!w || xml_node_is_empty(w->config.node))
 			continue;

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -202,7 +202,6 @@ struct ni_ifworker {
 	ni_ifworker_t *		masterdev;
 	ni_ifworker_t * 	lowerdev;
 
-	unsigned int		depth;		/* depth in device graph */
 	ni_ifworker_array_t	children;
 	ni_ifworker_array_t	lowerdev_for;
 };

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -320,7 +320,6 @@ extern ni_ifworker_t *		ni_fsm_recv_new_netif_path(ni_fsm_t *fsm, const char *pa
 extern ni_ifworker_t *		ni_fsm_recv_new_modem(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh);
 extern ni_ifworker_t *		ni_fsm_recv_new_modem_path(ni_fsm_t *fsm, const char *path);
 extern void			ni_fsm_destroy_worker(ni_fsm_t *fsm, ni_ifworker_t *w);
-extern void			ni_ifworkers_flatten(ni_ifworker_array_t *);
 extern void			ni_fsm_pull_in_children(ni_ifworker_array_t *);
 extern void			ni_fsm_wait_tentative_addrs(ni_fsm_t *);
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -346,6 +346,7 @@ extern void			ni_ifworker_success(ni_ifworker_t *);
 extern void			ni_ifworker_set_progress_callback(ni_ifworker_t *, void (*)(ni_ifworker_t *, ni_fsm_state_t), void *);
 extern void			ni_ifworker_set_completion_callback(ni_ifworker_t *, void (*)(ni_ifworker_t *), void *);
 extern ni_rfkill_type_t		ni_ifworker_get_rfkill_type(const ni_ifworker_t *);
+extern ni_ifworker_t *		ni_ifworker_set_ref(ni_ifworker_t **, ni_ifworker_t *);
 extern void			ni_ifworker_free(ni_ifworker_t *);
 
 extern ni_ifworker_control_t *	ni_ifworker_control_new(void);

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3085,8 +3085,9 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 			if (ni_ifworker_complete(child))
 				ni_ifworker_rearm(child);
 			ni_ifworker_array_append(array, child);
+
+			__ni_fsm_pull_in_children(child, array);
 		}
-		__ni_fsm_pull_in_children(child, array);
 	}
 }
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3157,7 +3157,6 @@ ni_fsm_clear_hierarchy(ni_ifworker_t *w)
 		}
 	}
 
-	w->depth = 0;
 	ni_ifworker_array_destroy(&w->children);
 	ni_ifworker_array_destroy(&w->lowerdev_for);
 }

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2966,7 +2966,7 @@ ni_ifworker_check_loops(const ni_ifworker_t *w, unsigned int *counter)
 }
 
 static ni_bool_t
-ni_ifworkers_check_loops(ni_fsm_t *fsm, ni_ifworker_array_t *array)
+ni_ifworkers_check_loops(ni_fsm_t *fsm)
 {
 	unsigned int i, num_edges;
 
@@ -3038,8 +3038,6 @@ unsigned int
 ni_fsm_mark_matching_workers(ni_fsm_t *fsm, ni_ifworker_array_t *marked, const ni_ifmarker_t *marker)
 {
 	unsigned int i, count = 0;
-
-	ni_ifworkers_check_loops(fsm, marked);
 
 	/* Mark all our primary devices with the requested marker values */
 	for (i = 0; i < marked->count; ++i) {
@@ -3490,6 +3488,7 @@ int
 ni_fsm_build_hierarchy(ni_fsm_t *fsm, ni_bool_t destructive)
 {
 	unsigned int i;
+	int ret = 0;
 
 	ni_fsm_events_block(fsm);
 	for (i = 0; i < fsm->workers.count; ++i) {
@@ -3521,10 +3520,13 @@ ni_fsm_build_hierarchy(ni_fsm_t *fsm, ni_bool_t destructive)
 		}
 	}
 
+	if (!ni_ifworkers_check_loops(fsm))
+		ret = -1;
+
 	ni_fsm_events_unblock(fsm);
 	if (ni_log_facility(NI_TRACE_APPLICATION))
 		ni_fsm_print_hierarchy(fsm);
-	return 0;
+	return ret;
 }
 
 dbus_bool_t

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1864,7 +1864,7 @@ ni_ifworker_control_set_usercontrol(ni_ifworker_t *w, ni_bool_t value)
 {
 	unsigned int i;
 
-	if (!w)
+	if (!w || w->failed)
 		return FALSE;
 
 	if (w->control.usercontrol == value)
@@ -1900,7 +1900,7 @@ ni_ifworker_control_set_persistent(ni_ifworker_t *w, ni_bool_t value)
 {
 	unsigned int i;
 
-	if (!w)
+	if (!w || w->failed)
 		return FALSE;
 
 	if (w->control.persistent == value)
@@ -3072,6 +3072,11 @@ __ni_fsm_pull_in_children(ni_ifworker_t *w, ni_ifworker_array_t *array)
 	for (i = 0; i < w->children.count; i++) {
 		ni_ifworker_t *child = w->children.data[i];
 
+		if (child->failed) {
+			ni_debug_application("%s: ignoring failed child %s", w->name, child->name);
+			continue;
+		}
+
 		if (xml_node_is_empty(child->config.node))
 			ni_ifworker_generate_default_config(w, child);
 
@@ -3101,6 +3106,11 @@ ni_fsm_pull_in_children(ni_ifworker_array_t *array)
 
 	for (i = 0; i < array->count; i++) {
 		ni_ifworker_t *w = array->data[i];
+
+		if (w->failed) {
+			ni_debug_application("%s: ignoring failed worker", w->name);
+			continue;
+		}
 
 		__ni_fsm_pull_in_children(w, array);
 	}


### PR DESCRIPTION
Since fsm check requirements are dynamic, we do not need to enforce any order of workers or policies being processed. Thus flatten functionality can be removed.

The fsm worker hierarchy loops should be checked earlier and on every hierarchy rebuild. That way we can always detect misconfiguration and fail affected workers.