### PR TITLE
fsm: fixed wrong check causing segmentation fault

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -1410,7 +1410,7 @@ ni_ifworker_set_lower_device(ni_ifworker_t *child, ni_ifworker_t *lower, xml_nod
 		return TRUE;
 	}
 
-	if (xml_node_is_empty(child->lowerdev->config.node))
+	if (!xml_node_is_empty(child->lowerdev->config.node))
 		ni_string_dup(&location, xml_node_location(child->lowerdev->config.node));
 
 	ni_debug_application("%s (%s): subordinate interface already has a lower device %s (%s), cannot set to %s",

--- a/src/xml-reader.c
+++ b/src/xml-reader.c
@@ -862,7 +862,7 @@ xml_node_location(const xml_node_t *node)
 {
 	static char buffer[PATH_MAX];
 
-	if (node->location) {
+	if (node && node->location) {
 		snprintf(buffer, sizeof(buffer), "%s:%u",
 				node->location->shared->filename,
 				node->location->line);


### PR DESCRIPTION
Added also a guard to the underlying xml node location
function to check node before accessing node->location.