### PR TITLE
dhcp6: refresh ipv6 link on each prefix event (boo#972471)

### DIFF
--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -1208,8 +1208,8 @@ ni_dhcp6_prefix_event(ni_dhcp6_device_t *dev, ni_netdev_t *ifp, ni_event_t event
 	ni_server_trace_interface_prefix_events(ifp, event, pi);
 	switch (event) {
 	case NI_EVENT_PREFIX_UPDATE:
+		ni_dhcp6_device_refresh_mode(dev, ifp);
 		if (dev->config && dev->config->mode == NI_DHCP6_MODE_AUTO) {
-			ni_dhcp6_device_refresh_mode(dev, ifp);
 			ni_dhcp6_device_start(dev);
 		}
 		break;


### PR DESCRIPTION
Some kernel forget to forward IPv6 RA flags via NEWLINK event
(boo#975020). Refresh ipv6 link info on prefix event also when
there is no request yet to workaround the missed NEWLINK event.