### PR TITLE
util: return a result in string utils

### DIFF
--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -91,8 +91,8 @@ extern int		ni_bitfield_testbit(const ni_bitfield_t *, unsigned int);
 
 extern void		ni_string_free(char **);
 extern void		ni_string_clear(char **);
-extern void		ni_string_dup(char **, const char *);
-extern void		ni_string_set(char **, const char *, unsigned int len);
+extern ni_bool_t	ni_string_dup(char **, const char *);
+extern ni_bool_t	ni_string_set(char **, const char *, size_t len);
 extern const char *	ni_string_printf(char **, const char *, ...);
 
 extern void		ni_string_array_init(ni_string_array_t *);

--- a/src/teamd.c
+++ b/src/teamd.c
@@ -1618,7 +1618,8 @@ ni_teamd_service_show_property(const char *ifname, const char *property, char **
 		goto failure;
 
 	ptr = (char *)ni_buffer_head(&buf);
-	ni_string_set(result, ptr, ni_string_len(ptr));
+	if (!ni_string_set(result, ptr, ni_string_len(ptr)))
+		goto failure;
 
 	ni_buffer_destroy(&buf);
 	ni_shellcmd_release(cmd);

--- a/src/util.c
+++ b/src/util.c
@@ -929,38 +929,50 @@ ni_string_free(char **pp)
 void
 ni_string_clear(char **pp)
 {
-	if (pp && !ni_string_empty(*pp)) {
-		memset(*pp, 0, ni_string_len(*pp));
-		ni_string_free(pp);
-	}
+	if (pp && *pp)
+		memset(*pp, 0, strlen(*pp));
+	ni_string_free(pp);
 }
 
-void
+ni_bool_t
 ni_string_dup(char **pp, const char *value)
 {
 	char *newval;
 
 	/* Beware: dup the string first, then free *pp.
 	 * After all, value may be a substing of *pp */
-	newval = value? xstrdup(value) : NULL;
+	newval = xstrdup(value);
+	if (value && !newval)
+		return FALSE;
 	if (*pp)
 		free(*pp);
 	*pp = newval;
+	return TRUE;
 }
 
-void
-ni_string_set(char **pp, const char *value, unsigned int len)
+ni_bool_t
+ni_string_set(char **pp, const char *value, size_t len)
 {
-	if (*pp) {
-		free(*pp);
-		*pp = NULL;
-	}
+	char *newval = NULL;
+
+	if (!pp || (len && !value))
+		return FALSE;
 
 	if (len) {
-		*pp = xmalloc(len + 1);
-		memcpy(*pp, value, len);
-		(*pp)[len] = '\0';
+		if (len == SIZE_MAX)
+			return FALSE;
+		if (!(newval = xmalloc(len + 1)))
+			return FALSE;
+		memcpy(newval, value, len);
+		newval[len] = '\0';
 	}
+
+	if (*pp) {
+		free(*pp);
+		*pp = newval;
+	}
+
+	return TRUE;
 }
 
 const char *


### PR DESCRIPTION
This does not remove the allocation failure assert yet,
but permits to adopt the code to check the results.