### PR TITLE
rules: do not fail completely when kernel support is missed (bsc#981887)

### DIFF
--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -406,7 +406,8 @@ autoip4_supplicant(void)
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
 	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
-					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN|
+					NI_NETCONFIG_DISCOVER_ROUTE_RULES);
 
 	ni_objectmodel_autoip4_init();
 

--- a/client/tester.c
+++ b/client/tester.c
@@ -144,7 +144,8 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
 	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
-					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN|
+					NI_NETCONFIG_DISCOVER_ROUTE_RULES);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp4_tester_run(tester);
@@ -265,7 +266,8 @@ ni_do_test_dhcp6(const char *caller, int argc, char **argv)
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
 	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
-					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN|
+					NI_NETCONFIG_DISCOVER_ROUTE_RULES);
 
 	tester->ifname = argv[optind];
 	status = ni_dhcp6_tester_run(tester);

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -258,7 +258,8 @@ main(int argc, char **argv)
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET);
 	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
-					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN|
+					NI_NETCONFIG_DISCOVER_ROUTE_RULES);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -285,7 +285,8 @@ main(int argc, char **argv)
 
 	ni_netconfig_set_family_filter(ni_global_state_handle(0), AF_INET6);
 	ni_netconfig_set_discover_filter(ni_global_state_handle(0),
-					NI_NETCONFIG_DISCOVER_LINK_EXTERN);
+					NI_NETCONFIG_DISCOVER_LINK_EXTERN|
+					NI_NETCONFIG_DISCOVER_ROUTE_RULES);
 
 	if (tester) {
 		/* Create necessary directories if not yet there */

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -4830,6 +4830,12 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 		ni_trace("%s: no old lease rules", dev->name);
 	}
 
+	if (!del_rules.count && !mod_rules.count)
+		return 0;
+
+	if (__ni_system_refresh_rules(nc))
+		return -1;
+
 	for (i = 0; i < del_rules.count; ++i) {
 		rule = del_rules.data[i];
 
@@ -4923,6 +4929,8 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 			ni_netconfig_rule_add(nc, r);
 		}
 	}
+
+	(void)__ni_system_refresh_rules(nc);
 
 	return 0;
 }

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -4780,7 +4780,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 		for (i = 0; i < new_rules->count; ++i) {
 			rule = new_rules->data[i];
 
-			ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
 					"%s: checking new lease rule %s",
 					dev->name, ni_rule_print(&out, rule));
 			ni_stringbuf_destroy(&out);
@@ -4789,7 +4789,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 				continue;
 
 			r = ni_rule_array_find_match(old_rules, rule, ni_rule_equal);
-			ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
 					"%s: rule to %s: %s", dev->name,
 					r ? "update" : "create",
 					ni_rule_print(&out, rule));
@@ -4799,7 +4799,8 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 			ni_rule_array_append(&mod_rules, ni_rule_ref(rule));
 		}
 	} else {
-		ni_trace("%s: no new lease rules", dev->name);
+		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+				"%s: no new lease rules", dev->name);
 	}
 
 	if (old_lease && (old_rules = old_lease->rules)) {
@@ -4808,7 +4809,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 		for (i = 0; i < old_rules->count; ++i) {
 			rule = old_rules->data[i];
 
-			ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
 					"%s: checking old lease rule %s",
 					dev->name, ni_rule_print(&out, rule));
 			ni_stringbuf_destroy(&out);
@@ -4819,7 +4820,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 			if (ni_rule_array_find_match(&mod_rules, rule, ni_rule_equal))
 				continue;
 
-			ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+			ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
 					"%s: rule to delete: %s",
 					dev->name, ni_rule_print(&out, rule));
 			ni_stringbuf_destroy(&out);
@@ -4827,7 +4828,8 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 			ni_rule_array_append(&del_rules, ni_rule_ref(rule));
 		}
 	} else {
-		ni_trace("%s: no old lease rules", dev->name);
+		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+				"%s: no old lease rules", dev->name);
 	}
 
 	if (!del_rules.count && !mod_rules.count)
@@ -4856,13 +4858,15 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 					ni_uuid_print(&r->owner), is_ours);
 
 			if ((lease = ni_netinfo_find_rule_owner(nc, r, 0))) {
-				ni_trace("%s: keeping rule, lease %s:%s uuid %s prio %u provides the rule",
+				ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+						"%s: keeping rule, lease %s:%s uuid %s prio %u provides the rule",
 						dev->name,
 						ni_addrfamily_type_to_name(lease->family),
 						ni_addrconf_type_to_name(lease->type),
 						ni_uuid_print(&lease->uuid),
 						ni_addrconf_lease_get_priority(lease));
-				ni_trace("%s: taking over rule lease owner", dev->name);
+				ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+						"%s: taking over rule lease owner", dev->name);
 				r->owner = lease->uuid;
 				continue;
 			}
@@ -4896,14 +4900,16 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 					ni_uuid_print(&r->owner), is_ours, prio);
 
 			if ((lease = ni_netinfo_find_rule_owner(nc, r, prio))) {
-				ni_trace("%s: keeping rule lease %s:%s owner %s prio %u (ours %u)",
+				ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+						"%s: keeping rule lease %s:%s owner %s prio %u (ours %u)",
 						dev->name,
 						ni_addrfamily_type_to_name(lease->family),
 						ni_addrconf_type_to_name(lease->type),
 						ni_uuid_print(&lease->uuid),
 						ni_addrconf_lease_get_priority(lease), prio);
 			} else {
-				ni_trace("%s: taking over rule lease owner", dev->name);
+				ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
+						"%s: taking over rule lease owner", dev->name);
 				r->owner = new_lease->uuid;
 			}
 			continue;

--- a/src/ifevent.c
+++ b/src/ifevent.c
@@ -78,8 +78,6 @@ static int	__ni_rtevent_newrule(ni_netconfig_t *, const struct sockaddr_nl *, st
 static int	__ni_rtevent_delrule(ni_netconfig_t *, const struct sockaddr_nl *, struct nlmsghdr *);
 static int	__ni_rtevent_nduseropt(ni_netconfig_t *, const struct sockaddr_nl *, struct nlmsghdr *);
 
-static const char *	__ni_rtevent_msg_name(unsigned int);
-
 
 /*
  * Helper to trigger interface events
@@ -138,7 +136,7 @@ __ni_rtevent_process(ni_netconfig_t *nc, const struct sockaddr_nl *nladdr, struc
 #if 0
 	const char *rtnl_name;
 
-	if ((rtnl_name = __ni_rtevent_msg_name(h->nlmsg_type)) != NULL)
+	if ((rtnl_name = ni_rtnl_msg_type_to_name(h->nlmsg_type, NULL)) != NULL)
 		ni_debug_events("received %s event", rtnl_name);
 	else
 		ni_debug_events("received rtnetlink event %u", h->nlmsg_type);
@@ -902,32 +900,11 @@ __ni_rtevent_process_cb(struct nl_msg *msg, void *ptr)
 	nlh = nlmsg_hdr(msg);
 	if (__ni_rtevent_process(nc, sender, nlh) < 0) {
 		ni_debug_events("ignoring %s rtnetlink event",
-			__ni_rtevent_msg_name(nlh->nlmsg_type));
+			ni_rtnl_msg_type_to_name(nlh->nlmsg_type, "unknown"));
 		return NL_SKIP;
 	}
 
 	return NL_OK;
-}
-
-/*
- * Helper returning name of a rtnetlink message
- */
-static const char *
-__ni_rtevent_msg_name(unsigned int nlmsg_type)
-{
-#define _t2n(x)	[x] = #x
-	static const char *rtnl_name[RTM_MAX] = {
-	_t2n(RTM_NEWLINK),	_t2n(RTM_DELLINK),
-	_t2n(RTM_NEWADDR),	_t2n(RTM_DELADDR),
-	_t2n(RTM_NEWROUTE),	_t2n(RTM_DELROUTE),
-	_t2n(RTM_NEWPREFIX),	_t2n(RTM_NEWNDUSEROPT),
-	};
-#undef _t2n
-
-	if (nlmsg_type < RTM_MAX && rtnl_name[nlmsg_type])
-		return rtnl_name[nlmsg_type];
-	else
-		return NULL;
 }
 
 static ni_bool_t	__ni_rtevent_restart(ni_socket_t *sock);

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -2901,7 +2901,9 @@ failure:
 int
 ni_rtnl_rule_parse_msg(struct nlmsghdr *h, struct fib_rule_hdr *frh, ni_rule_t *rule)
 {
-#define RULE_LOG_LEVEL		NI_LOG_DEBUG
+#ifndef RULE_LOG_LEVEL
+#define RULE_LOG_LEVEL		NI_LOG_DEBUG2
+#endif
 	struct nlattr *tb[FRA_MAX+1];
 	const char *prefix;
 	char *tmp = NULL;

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -655,7 +655,9 @@ __ni_system_refresh_all(ni_netconfig_t *nc, ni_netdev_t **del_list)
 	/* issue separate query ingnoring the error to not break
 	 * the bootstrap, e.g. when a kernel lacks rule support.
 	 */
-	(void)__ni_system_refresh_rules(nc);
+	if (!ni_netconfig_discover_filtered(nc, NI_NETCONFIG_DISCOVER_ROUTE_RULES))
+		(void)__ni_system_refresh_rules(nc);
+
 	res = 0;
 
 failed:

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -542,15 +542,17 @@ ni_nl_dump_store(int af, int type, struct ni_nlmsg_list *list)
 		.list = list,
 	};
 	struct nl_cb *cb;
+	const char *name;
 	int rv;
 
+	name = ni_rtnl_msg_type_to_name(type, __func__);
 	if (!__ni_global_netlink || !(nl_sock = __ni_global_netlink->nl_sock)) {
-		ni_error("%s: no netlink socket", __func__);
+		ni_error("%s: no netlink socket", name);
 		return -NLE_BAD_SOCK;
 	}
 
 	if ((rv = nl_rtgen_request(nl_sock, type, af, NLM_F_DUMP)) < 0) {
-		ni_error("%s: failed to send request", __func__);
+		ni_error("%s: failed to send request", name);
 		return rv;
 	}
 
@@ -567,16 +569,16 @@ retry:
 	case -NLE_AGAIN:
 		/* debug only, we retry to receive */
 		ni_debug_socket("%s: failed to receive response: %s",
-				__func__, nl_geterror(rv));
+				name, nl_geterror(rv));
 		goto retry;
 	case -NLE_DUMP_INTR:
 		/* debug only, we repeat the query */
 		ni_debug_socket("%s: failed to receive response: %s",
-				__func__, nl_geterror(rv));
+				name, nl_geterror(rv));
 		break;
 	default:
 		ni_error("%s: failed to receive response: %s",
-				__func__, nl_geterror(rv));
+				name, nl_geterror(rv));
 		break;
 	}
 	nl_cb_put(cb);
@@ -605,5 +607,105 @@ ni_nl_talk(struct nl_msg *msg, struct ni_nlmsg_list *list)
 
 		return __ni_nl_talk(__ni_global_netlink, msg, __ni_nl_dump_valid, &data);
 	}
+}
+
+#define ni_t2n(x)	[x] = #x
+static const char *	ni_rtnl_msg_type_names[RTM_MAX] = {
+#ifdef	RTM_NEWLINK
+	ni_t2n(RTM_NEWLINK),
+	ni_t2n(RTM_DELLINK),
+	ni_t2n(RTM_GETLINK),
+	ni_t2n(RTM_SETLINK),
+#endif
+#ifdef	RTM_NEWADDR
+	ni_t2n(RTM_NEWADDR),
+	ni_t2n(RTM_DELADDR),
+	ni_t2n(RTM_GETADDR),
+#endif
+#ifdef	RTM_NEWROUTE
+	ni_t2n(RTM_NEWROUTE),
+	ni_t2n(RTM_DELROUTE),
+	ni_t2n(RTM_GETROUTE),
+#endif
+#ifdef	RTM_NEWNEIGH
+	ni_t2n(RTM_NEWNEIGH),
+	ni_t2n(RTM_DELNEIGH),
+	ni_t2n(RTM_GETNEIGH),
+#endif
+#ifdef	RTM_NEWRULE
+	ni_t2n(RTM_NEWRULE),
+	ni_t2n(RTM_DELRULE),
+	ni_t2n(RTM_GETRULE),
+#endif
+#ifdef	RTM_NEWQDISC
+	ni_t2n(RTM_NEWQDISC),
+	ni_t2n(RTM_DELQDISC),
+	ni_t2n(RTM_GETQDISC),
+#endif
+#ifdef	RTM_NEWTCLASS
+	ni_t2n(RTM_NEWTCLASS),
+	ni_t2n(RTM_DELTCLASS),
+	ni_t2n(RTM_GETTCLASS),
+#endif
+#ifdef	RTM_NEWTFILTER
+	ni_t2n(RTM_NEWTFILTER),
+	ni_t2n(RTM_DELTFILTER),
+	ni_t2n(RTM_GETTFILTER),
+#endif
+#ifdef	RTM_NEWACTION
+	ni_t2n(RTM_NEWACTION),
+	ni_t2n(RTM_DELACTION),
+	ni_t2n(RTM_GETACTION),
+#endif
+#ifdef	RTM_NEWPREFIX
+	ni_t2n(RTM_NEWPREFIX),
+#endif
+#ifdef	RTM_GETMULTICAST
+	ni_t2n(RTM_GETMULTICAST),
+#endif
+#ifdef	RTM_GETANYCAST
+	ni_t2n(RTM_GETANYCAST),
+#endif
+#ifdef	RTM_NEWNEIGHTBL
+	ni_t2n(RTM_NEWNEIGHTBL),
+	ni_t2n(RTM_GETNEIGHTBL),
+	ni_t2n(RTM_SETNEIGHTBL),
+#endif
+#ifdef	RTM_NEWNDUSEROPT
+	ni_t2n(RTM_NEWNDUSEROPT),
+#endif
+#ifdef	RTM_NEWADDRLABEL
+	ni_t2n(RTM_NEWADDRLABEL),
+	ni_t2n(RTM_DELADDRLABEL),
+	ni_t2n(RTM_GETADDRLABEL),
+#endif
+#ifdef	RTM_GETDCB
+	ni_t2n(RTM_GETDCB),
+	ni_t2n(RTM_SETDCB),
+#endif
+#ifdef	RTM_NEWNETCONF
+	ni_t2n(RTM_NEWNETCONF),
+	ni_t2n(RTM_GETNETCONF),
+#endif
+#ifdef	RTM_NEWMDB
+	ni_t2n(RTM_NEWMDB),
+	ni_t2n(RTM_DELMDB),
+	ni_t2n(RTM_GETMDB),
+#endif
+#ifdef	RTM_NEWNSID
+	ni_t2n(RTM_NEWNSID),
+	ni_t2n(RTM_DELNSID),
+	ni_t2n(RTM_GETNSID),
+#endif
+};
+#undef	ni_t2n
+
+const char *
+ni_rtnl_msg_type_to_name(unsigned int type, const char *unknown)
+{
+	if (type > RTM_BASE && type < RTM_MAX)
+		return ni_rtnl_msg_type_names[type];
+	else
+		return unknown;
 }
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -90,6 +90,8 @@ extern int	ni_nl_dump_store(int af, int type, struct ni_nlmsg_list *list);
 extern void	ni_nlmsg_list_init(struct ni_nlmsg_list *);
 extern void	ni_nlmsg_list_destroy(struct ni_nlmsg_list *);
 
+extern const char *	ni_rtnl_msg_type_to_name(unsigned int, const char *);
+
 static inline void *
 __ni_rtnl_msgdata(struct nlmsghdr *h, int expected_type, size_t min_size)
 {

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -32,6 +32,7 @@ struct ni_event_filter {
 enum {
 	/* link details discover filter using external calls */
 	NI_NETCONFIG_DISCOVER_LINK_EXTERN = 1U << 0,
+	NI_NETCONFIG_DISCOVER_ROUTE_RULES = 1U << 1,
 };
 
 /*


### PR DESCRIPTION
All our kernel support routing policy rules since ages, but fail to start even
when rules are not used in the configuraion, is not the right error handling.
Also improved rtnetlink failure error messages and debug logging.