### PR TITLE
ovs: use generic ovs type until we can query ovs (bsc#982231)

### DIFF
--- a/include/wicked/constants.h
+++ b/include/wicked/constants.h
@@ -73,6 +73,7 @@ typedef enum ni_iftype {
 	NI_IFTYPE_TEAM,
 	NI_IFTYPE_OVS_SYSTEM,
 	NI_IFTYPE_OVS_BRIDGE,
+	NI_IFTYPE_OVS_UNSPEC,
 
 	__NI_IFTYPE_MAX
 } ni_iftype_t;

--- a/src/names.c
+++ b/src/names.c
@@ -77,6 +77,7 @@ static const ni_intmap_t	__linktype_names[] = {
 	{ "team",		NI_IFTYPE_TEAM },
 	{ "ovs-system",		NI_IFTYPE_OVS_SYSTEM },
 	{ "ovs-bridge",		NI_IFTYPE_OVS_BRIDGE },
+	{ "ovs",		NI_IFTYPE_OVS_UNSPEC },
 
 	{ NULL }
 };
@@ -114,6 +115,7 @@ static const ni_intmap_t	__linkinfo_kind_names[] = {
 	{ "sit",		NI_IFTYPE_SIT },
 	{ "ipip",		NI_IFTYPE_IPIP },
 	{ "gre",		NI_IFTYPE_GRE },
+	{ "openvswitch",	NI_IFTYPE_OVS_UNSPEC }, /* new in 4.4 kernels */
 
 	{ NULL }
 };


### PR DESCRIPTION
Query if ovs device (kind or driver set to openvswitch) is a bridge using
ovs-vsctl br-exists first, then query ovs about the further bridge details.