### PR TITLE
dhcp6: defer on prefix event if RA flags are unset

### DIFF
--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -1231,7 +1231,10 @@ ni_dhcp6_prefix_event(ni_dhcp6_device_t *dev, ni_netdev_t *ifp, ni_event_t event
 			/* refresh in case kernel forgot a newlink on RA */
 			ni_dhcp6_device_refresh_mode(dev, ifp);
 			ni_server_trace_interface_prefix_events(ifp, event, pi);
-			ni_dhcp6_device_start(dev);
+			if (dev->config->mode == NI_DHCP6_MODE_AUTO)
+				ni_dhcp6_send_event(NI_DHCP6_EVENT_DEFERRED, dev, NULL);
+			else
+				ni_dhcp6_device_start(dev);
 		} else {
 			ni_server_trace_interface_prefix_events(ifp, event, pi);
 		}

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -71,8 +71,6 @@ static unsigned int		ni_dhcp6_fsm_get_expire_timeout(ni_dhcp6_device_t *);
 static unsigned int		ni_dhcp6_fsm_mark_renew_ia(ni_dhcp6_device_t *);
 static unsigned int		ni_dhcp6_fsm_mark_rebind_ia(ni_dhcp6_device_t *);
 
-static void			ni_dhcp6_send_event(enum ni_dhcp6_event, const ni_dhcp6_device_t *, ni_addrconf_lease_t *);
-
 static int			__fsm_parse_client_options(ni_dhcp6_device_t *, struct ni_dhcp6_message *, ni_buffer_t *);
 
 
@@ -2042,7 +2040,7 @@ ni_dhcp6_set_event_handler(ni_dhcp6_event_handler_t func)
         ni_dhcp6_fsm_event_handler = func;
 }
 
-static void
+void
 ni_dhcp6_send_event(enum ni_dhcp6_event ev, const ni_dhcp6_device_t *dev, ni_addrconf_lease_t *lease)
 {
         if (ni_dhcp6_fsm_event_handler)

--- a/src/dhcp6/fsm.h
+++ b/src/dhcp6/fsm.h
@@ -62,5 +62,7 @@ extern int			ni_dhcp6_fsm_retransmit(ni_dhcp6_device_t *dev);
 
 extern void			ni_dhcp6_fsm_address_event(ni_dhcp6_device_t *, ni_netdev_t *,
 								ni_event_t, const ni_address_t *);
+extern void			ni_dhcp6_send_event(enum ni_dhcp6_event, const ni_dhcp6_device_t *, ni_addrconf_lease_t *);
+
 
 #endif /* __WICKED_DHCP6_FSM_H__ */


### PR DESCRIPTION
When a RA prefix event arrives and the managed/other-config
RA flags are not set (dhcp not used on the network), send a
defer event to stop waiting for the lease in ifup earlier (issue #681)