### PR TITLE
Correct client Makefile.am for new %{_fillupdir} location (boo#1069468)

### DIFF
--- a/client/suse/Makefile.am
+++ b/client/suse/Makefile.am
@@ -27,7 +27,7 @@ libwicked_client_suse_la_SOURCES		= \
 noinst_HEADERS					= \
 						  ifsysctl.h
 
-suse_fillupdir					= ${localstatedir}/adm/fillup-templates
+suse_fillupdir					= /usr/share/fillup-templates
 suse_fillup_DATA				= config/sysconfig.config-wicked \
 						  config/sysconfig.dhcp-wicked
 


### PR DESCRIPTION
Required in order to make SR#544833 buildable

Needed for SLE/CaaSP 15, so please review and merge quickly