### PR TITLE
ifconfig: set MTU even if device is up (bsc#1059292)

### DIFF
--- a/src/dbus-objects/interface.c
+++ b/src/dbus-objects/interface.c
@@ -925,20 +925,9 @@ ni_objectmodel_netif_link_up(ni_dbus_object_t *object, const ni_dbus_method_t *m
 			}
 		}
 
-		/*
-		 * MTU change on device-up interfaces quite often causes either
-		 * error -16 (busy) or sets all upper interfaces LOWERLAYERDOWN.
-		 */
-		if (ni_netdev_device_is_up(dev)) {
-			ni_debug_objectmodel("Skipping MTU change on %s: device is up",
-					dev->name);
-			req->mtu = 0;
-		}
+		if  (req->mtu != dev->link.mtu)
+		     ni_system_mtu_change(nc, dev, req->mtu);
 
-		if (req->mtu != dev->link.mtu &&
-		    ni_system_mtu_change(nc, dev, req->mtu) < 0) {
-			ni_info("Unable to set %s MTU to %u", dev->name, req->mtu);
-		}
 		req->mtu = 0;
 	}
 

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -4039,6 +4039,7 @@ __ni_rtnl_link_change_mtu(ni_netdev_t *dev, unsigned int mtu)
 {
 	struct ifinfomsg ifi;
 	struct nl_msg *msg;
+	int err;
 
 	if (!dev || !mtu)
 		return -1;
@@ -4047,15 +4048,20 @@ __ni_rtnl_link_change_mtu(ni_netdev_t *dev, unsigned int mtu)
 	ifi.ifi_family = AF_UNSPEC;
 	ifi.ifi_index = dev->link.ifindex;
 
-	msg = nlmsg_alloc_simple(RTM_NEWLINK, NLM_F_REQUEST);
+	if (!(msg = nlmsg_alloc_simple(RTM_NEWLINK, NLM_F_REQUEST)))
+		goto nla_put_failure;
+
 	if (nlmsg_append(msg, &ifi, sizeof(ifi), NLMSG_ALIGNTO) < 0)
 		goto nla_put_failure;
 
 	if (__ni_rtnl_link_put_mtu(msg, mtu) < 0)
 		goto nla_put_failure;
 
-	if (ni_nl_talk(msg, NULL))
+	if ((err = ni_nl_talk(msg, NULL))) {
+		ni_error("failed to modify interface %s mtu to %u: %s",
+				dev->name, mtu, nl_geterror(err));
 		goto failed;
+	}
 
 	ni_debug_ifconfig("successfully modified interface %s mtu to %u",
 			dev->name, mtu);


### PR DESCRIPTION
wicked should not supplement what drivers in kernel are capable. That
means, that if device is up, and is not capable set MTU on-fly, kernel
returns error. This is driver problem, not wicked and should just
print an error and continue.

Signed-off-by: Nikola Pajkovsky <npajkovsky@suse.cz>