### PR TITLE
wickedd: explicitly unbind slaves on deletion (bsc#1061051)

### DIFF
--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -581,6 +581,17 @@ ni_netconfig_device_append(ni_netconfig_t *nc, ni_netdev_t *dev)
 	__ni_netdev_list_append(&nc->interfaces, dev);
 }
 
+static inline void
+ni_netconfig_device_unbind_slave_index(ni_netconfig_t *nc, unsigned int master)
+{
+	ni_netdev_t *dev;
+
+	for (dev = nc->interfaces; dev; dev = dev->next) {
+		if (dev->link.masterdev.index == master)
+			ni_netdev_ref_destroy(&dev->link.masterdev);
+	}
+}
+
 void
 ni_netconfig_device_remove(ni_netconfig_t *nc, ni_netdev_t *dev)
 {
@@ -589,6 +600,7 @@ ni_netconfig_device_remove(ni_netconfig_t *nc, ni_netdev_t *dev)
 	for (pos = &nc->interfaces; (cur = *pos) != NULL; pos = &cur->next) {
 		if (cur == dev) {
 			*pos = cur->next;
+			ni_netconfig_device_unbind_slave_index(nc, cur->link.ifindex);
 			ni_netdev_put(cur);
 			return;
 		}


### PR DESCRIPTION
When a master device is deleted, explicitly clear references
pointing to it on slaves instead to let it perform by further
event, which may arrive later than an attempt to enslave them
into a new, recreated master device (with same name).