### PR TITLE
Fix wicked pkgconfig file to request libnl3 instead of libnl1

### DIFF
--- a/wicked.pc.in
+++ b/wicked.pc.in
@@ -8,5 +8,5 @@ Version: @PACKAGE_VERSION@
 Description: network configuration infrastructure library
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@PACKAGE_NAME@
-Requires: dbus-1 libnl-1
+Requires: dbus-1 libnl-3.0 libnl-route-3.0
 


### PR DESCRIPTION
When wicked switched from `libnl1` to `libnl3` in 4591b86fda9e5b1e9383eb7e1ee0190ee57f8a1e, the required changes to `wicked.pc` were not made. This meant that the modules requested to link against `libwicked` by external applications were wrong and would lead to broken builds.