### PR TITLE
Fix show-xml filtering by interface name (issue #735,bsc#954758)

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -522,23 +522,35 @@ __dump_fake_xml(const ni_dbus_variant_t *variant, unsigned int indent, const cha
 	}
 }
 
-static xml_node_t *
-__dump_object_xml(const char *object_path, const ni_dbus_variant_t *variant, ni_xs_scope_t *schema, xml_node_t *parent)
+static ni_bool_t
+__dump_object_xml(const char *object_path, const ni_dbus_variant_t *variant, 
+	ni_xs_scope_t *schema, xml_node_t *parent, const ni_string_array_t *filter)
 {
 	xml_node_t *object_node;
 	ni_dbus_dict_entry_t *entry;
 	unsigned int index;
+	const char *ifname, *interface_name;
 
 	if (!ni_dbus_variant_is_dict(variant)) {
 		ni_error("%s: dbus data is not a dict", __func__);
-		return NULL;
+		return FALSE;
 	}
 
-	object_node = xml_node_new("object", parent);
-	xml_node_add_attr(object_node, "path", object_path);
+	object_node = xml_node_new("object", NULL);
+	xml_node_add_attr(object_node, "path", object_path);	
+
+	if (filter && !filter->count)
+		filter = NULL;	
 
 	for (entry = variant->dict_array_value, index = 0; index < variant->array.len; ++index, ++entry) {
-		const char *interface_name = entry->key;
+		interface_name = entry->key;		
+		if (filter 
+		 && ni_string_eq(interface_name, NI_OBJECTMODEL_NETIF_INTERFACE)
+		 && ni_dbus_dict_get_string(&entry->datum, "name", &ifname)
+		 && ni_string_array_index(filter, ifname) == -1) {
+			xml_node_free(object_node);
+			return TRUE;
+		}
 
 		/* Ignore well-known interfaces that never have properties */
 		if (!strcmp(interface_name, "org.freedesktop.DBus.ObjectManager")
@@ -548,11 +560,15 @@ __dump_object_xml(const char *object_path, const ni_dbus_variant_t *variant, ni_
 		ni_dbus_xml_deserialize_properties(schema, interface_name, &entry->datum, object_node);
 	}
 
-	return object_node;
+	if (object_node->children)
+		xml_node_add_child(parent, object_node);
+	else
+		xml_node_free(object_node);
+	return TRUE;
 }
 
 static xml_node_t *
-__dump_schema_xml(const ni_dbus_variant_t *variant, ni_xs_scope_t *schema)
+__dump_schema_xml(const ni_dbus_variant_t *variant, ni_xs_scope_t *schema, const ni_string_array_t *filter)
 {
 	xml_node_t *root = xml_node_new(NULL, NULL);
 	ni_dbus_dict_entry_t *entry;
@@ -562,10 +578,10 @@ __dump_schema_xml(const ni_dbus_variant_t *variant, ni_xs_scope_t *schema)
 		ni_error("%s: dbus data is not a dict", __func__);
 		return NULL;
 	}
-
+	
 	for (entry = variant->dict_array_value, index = 0; index < variant->array.len; ++index, ++entry) {
-		if (!__dump_object_xml(entry->key, &entry->datum, schema, root))
-			return NULL;
+		if (!__dump_object_xml(entry->key, &entry->datum, schema, root, filter))
+			return NULL;		
 	}
 
 	return root;
@@ -598,6 +614,7 @@ do_show_xml(int argc, char **argv)
 	int opt_modems = 0;
 #endif
 	int c, rv = 1;
+	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
 
 	optind = 1;
 	while ((c = getopt_long(argc, argv, "", local_options, NULL)) != EOF) {
@@ -631,12 +648,14 @@ do_show_xml(int argc, char **argv)
 		}
 	}
 
-	if (optind < argc)
-		ifname = argv[optind++];
-	(void)ifname; /* FIXME; not used yet */
-
-	if (optind != argc)
-		goto usage;
+	/* warning: this is a shallow-copy from argv, 
+	 * use this only with _index() for filtering */
+	ifnames.count = argc - optind;
+	ifnames.data = argv + optind;
+	if (ni_string_array_index(&ifnames, "all") != -1) {
+		ifnames.count = 0;
+		ifnames.data = NULL;
+	}
 
 	if (!(object = ni_call_create_client()))
 		return 1;
@@ -670,7 +689,7 @@ do_show_xml(int argc, char **argv)
 		ni_xs_scope_t *schema = ni_objectmodel_init(NULL);
 		xml_node_t *tree;
 
-		tree = __dump_schema_xml(&result, schema);
+		tree = __dump_schema_xml(&result, schema, &ifnames);
 		if (tree == NULL) {
 			ni_error("unable to represent properties as xml");
 			goto out;
@@ -1737,4 +1756,3 @@ do_convert(int argc, char **argv)
 
 	return do_show_config(argc, argv, "compat:");
 }
-

--- a/client/main.c
+++ b/client/main.c
@@ -553,8 +553,7 @@ __dump_object_xml(const char *object_path, const ni_dbus_variant_t *variant,
 		}
 
 		/* Ignore well-known interfaces that never have properties */
-		if (!strcmp(interface_name, "org.freedesktop.DBus.ObjectManager")
-		 || !strcmp(interface_name, "org.freedesktop.DBus.Properties"))
+		if (!ni_string_startswith(interface_name, NI_OBJECTMODEL_NAMESPACE))
 			continue;
 
 		ni_dbus_xml_deserialize_properties(schema, interface_name, &entry->datum, object_node);


### PR DESCRIPTION
This PR adds filtering functionality to the show-xml command, with the following behaviour:
  - `wicked show-xml <ifname1> <ifname2>`: show xml *only* for `ifname1` and `ifname2`
  - `wicked show-xml all`: show xml for all available network interfaces
  - `wicked show-xml`: same as above, show all interfaces

This should address issue #735