### PR TITLE
ipoib: do not fail setup on mode or umcast set failure (bsc#1084462)

### DIFF
--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -1489,14 +1489,12 @@ __ni_system_infiniband_setup(const char *ifname, unsigned int mode, unsigned int
 	    ni_sysfs_netif_put_string(ifname, "mode", mstr) < 0) {
 		ni_error("%s: Cannot set infiniband IPoIB connection-mode '%s'",
 			ifname, mstr);
-		ret = -1;
 	}
 
 	if ((umcast == 0 || umcast == 1) &&
 	    ni_sysfs_netif_put_uint(ifname, "umcast", umcast) < 0) {
 		ni_error("%s: Cannot set infiniband IPoIB user-multicast '%s' (%u)",
 			ifname, ni_infiniband_get_umcast_name(umcast), umcast);
-		ret = -1;
 	}
 
 	return ret;


### PR DESCRIPTION
The connected mode is optional for Target Channel Adapters (TCAs) acc. to RFC rfc4755,
so report failure to set it as (configuration) error, but do not fail the setup completely, same
with user-multicast option for consistency.