### PR TITLE
dhcp4: add ifcfg option to request broadcast response from server

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -123,6 +123,7 @@ ni_compat_netdev_new(const char *ifname)
 	compat->dhcp4.update = ni_config_addrconf_update(ifname, NI_ADDRCONF_DHCP, AF_INET);
 	compat->dhcp4.recover_lease = TRUE;
 	compat->dhcp4.release_lease = FALSE;
+	compat->dhcp4.broadcast = NI_TRISTATE_DEFAULT;
 	compat->dhcp4.user_class.format = -1U;
 	ni_dhcp_fqdn_init(&compat->dhcp4.fqdn);
 
@@ -2277,6 +2278,10 @@ __ni_compat_generate_dhcp4_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 				ni_format_boolean(compat->dhcp4.recover_lease));
 	xml_node_dict_set(dhcp, "release-lease",
 				ni_format_boolean(compat->dhcp4.release_lease));
+
+	if (compat->dhcp4.broadcast != NI_TRISTATE_DEFAULT)
+		xml_node_dict_set(dhcp, "broadcast",
+				ni_format_boolean(compat->dhcp4.broadcast));
 
 	if (compat->dhcp4.client_id)
 		xml_node_dict_set(dhcp, "client-id", compat->dhcp4.client_id);

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5093,6 +5093,12 @@ __ni_suse_addrconf_dhcp4_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 	ni_bool_t bvalue;
 	ni_bool_t ret = TRUE;
 
+	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_BROADCAST")) != NULL) {
+		if (ni_parse_boolean(string, &bvalue) == 0) {
+			ni_tristate_set(&compat->dhcp4.broadcast, bvalue);
+		}
+	}
+
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_UPDATE")) != NULL) {
 		if (ni_addrconf_update_flags_parse(&uint, string, " \t,")) {
 			uint &= ni_config_addrconf_update_mask(NI_ADDRCONF_DHCP, AF_INET);

--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -57,6 +57,16 @@ DHCLIENT_FQDN_ENCODE="yes"
 #
 DHCLIENT_UPDATE=""
 
+## Type:	list(,yes,no)
+## Default:	""
+#
+# Request broadcast responses from dhcp-server.
+#
+# The default behaviour is to not request broadcast responses for any type
+# of devices except of Infiniband, where it is mandatory and enabled.
+#
+DHCLIENT_BROADCAST=""
+
 ## Type:        list(enabled,disabled,default,)
 ## Default:     ""
 #

--- a/client/tester.c
+++ b/client/tester.c
@@ -51,6 +51,7 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 		OPT_TEST_REQUEST = 'r',
 		OPT_TEST_OUTPUT	 = 'o',
 		OPT_TEST_OUTFMT	 = 'F',
+		OPT_TEST_BROADCAST = 'b',
 	};
 	static struct option	options[] = {
 		{ "help",	no_argument,		NULL,	OPT_HELP	},
@@ -58,6 +59,7 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 		{ "timeout",	required_argument,	NULL,	OPT_TEST_TIMEOUT},
 		{ "output",	required_argument,	NULL,	OPT_TEST_OUTPUT	},
 		{ "format",	required_argument,	NULL,	OPT_TEST_OUTFMT	},
+		{ "broadcast",	no_argument,		NULL,	OPT_TEST_BROADCAST},
 		{ NULL,		no_argument,		NULL,	0		}
 	};
 	int opt = 0, status = NI_WICKED_RC_USAGE;
@@ -76,7 +78,7 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 	}
 
 	optind = 1;
-	while ((opt = getopt_long(argc, argv, "+hr:t:o:F:", options, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+hr:t:o:F:b", options, NULL)) != EOF) {
 		switch (opt) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -89,10 +91,11 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 				"Options:\n"
 				"  --help, -h      show this help text and exit.\n"
 				"\n"
-				"  --timeout, -t   <timeout in sec> (default: 20+10)\n"
-				"  --request, -r   <request.xml>\n"
-				"  --output, -o    <output file name>\n"
-				"  --format, -F    <leaseinfo|lease-xml>\n"
+				"  --timeout, -t   	<timeout in sec> (default: 20+10)\n"
+				"  --request, -r   	<request.xml>\n"
+				"  --output, -o    	<output file name>\n"
+				"  --format, -F    	<leaseinfo|lease-xml>\n"
+				"  --broadcast, -b	request broadcast responses from server\n"
 				"\n", program);
 			goto cleanup;
 
@@ -128,6 +131,10 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 				status = NI_WICKED_RC_ERROR;
 				goto cleanup;
 			}
+			break;
+
+		case OPT_TEST_BROADCAST:
+			tester->broadcast = NI_TRISTATE_ENABLE;
 			break;
 		}
 	}

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -78,6 +78,7 @@ typedef struct ni_compat_netdev {
 		unsigned int	lease_time;
 		ni_bool_t	recover_lease;
 		ni_bool_t	release_lease;
+		ni_tristate_t	broadcast;
 
 		unsigned int	route_priority;
 		unsigned int	update;

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -258,6 +258,8 @@ static ni_dbus_class_t		ni_objectmodel_dhcp4req_class = {
 
 #define DHCP4REQ_STRING_PROPERTY(dbus_name, member_name, rw) \
 	NI_DBUS_GENERIC_STRING_PROPERTY(dhcp4_request, dbus_name, member_name, rw)
+#define DHCP4REQ_INT_PROPERTY(dbus_name, member_name, rw) \
+	NI_DBUS_GENERIC_INT_PROPERTY(dhcp4_request, dbus_name, member_name, rw)	
 #define DHCP4REQ_UINT_PROPERTY(dbus_name, member_name, rw) \
 	NI_DBUS_GENERIC_UINT_PROPERTY(dhcp4_request, dbus_name, member_name, rw)
 #define DHCP4REQ_UUID_PROPERTY(dbus_name, member_name, rw) \
@@ -472,6 +474,7 @@ static ni_dbus_property_t	dhcp4_request_properties[] = {
 	DHCP4REQ_UINT_PROPERTY(lease-time, lease_time, RO),
 	DHCP4REQ_BOOL_PROPERTY(recover-lease, recover_lease, RO),
 	DHCP4REQ_BOOL_PROPERTY(release-lease, release_lease, RO),
+	DHCP4REQ_INT_PROPERTY(broadcast, broadcast, RO),
 	DHCP4REQ_UINT_PROPERTY(update, update, RO),
 	DHCP4REQ_STRING_PROPERTY(hostname, hostname, RO),
 	DHCP4REQ_DICT_PROPERTY(fqdn, fqdn, RO),

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -44,6 +44,7 @@ enum {
 	OPT_TEST_REQUEST,
 	OPT_TEST_OUTPUT,
 	OPT_TEST_OUTFMT,
+	OPT_TEST_BROADCAST,
 };
 
 static struct option	options[] = {
@@ -68,6 +69,7 @@ static struct option	options[] = {
 	{ "test-timeout",	required_argument,	NULL,	OPT_TEST_TIMEOUT },
 	{ "test-output",	required_argument,	NULL,	OPT_TEST_OUTPUT  },
 	{ "test-format",	required_argument,	NULL,	OPT_TEST_OUTFMT  },
+	{ "test-broadcast",	no_argument,		NULL,	OPT_TEST_BROADCAST},
 
 	{ NULL,			no_argument,		NULL,	0 }
 };
@@ -134,6 +136,7 @@ main(int argc, char **argv)
 				"       --test-timeout <timeout in sec> (default: 20+10)\n"
 				"       --test-output  <output file name>\n"
 				"       --test-format  <leaseinfo|lease-xml>\n"
+				"       --test-broadcast\n"
 				, program_name);
 			return status;
 
@@ -214,6 +217,12 @@ main(int argc, char **argv)
 			if (!tester || !ni_dhcp4_tester_set_outfmt(optarg,
 						&tester->outfmt))
 				goto usage;
+			break;
+
+		case OPT_TEST_BROADCAST:
+			if (!tester)
+				goto usage;
+			tester->broadcast = NI_TRISTATE_ENABLE;
 			break;
 		}
 	}

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -149,6 +149,13 @@ remove/disable it from the currently applied set, e.g. "default,-nis"
 disables request for nis options.
 More specific variables as DHCLIENT_SET_DEFAULT_ROUTE,DHCLIENT_SET_HOSTNAME
 or the MTU option have higher precedence.
+.TP
+.BR DHCLIENT_BROADCAST\ { yes | \fIno\fR* }
+Request broadcast responses from dhcp-server.
+
+The default behaviour is to not request broadcast responses for any type
+of devices except of Infiniband, where it is enabled by default and not 
+possible to disable.
 
 .SH DHCPv6 Specific Variables
 .TP

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -194,6 +194,7 @@
     <lease-time type="uint32" />
     <recover-lease type="boolean" />
     <release-lease type="boolean" />
+    <broadcast type="tristate" />
 
     <update type="builtin-addrconf-update-mask" />
     <hostname type="string" />

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -290,6 +290,7 @@ ni_dhcp4_acquire(ni_dhcp4_device_t *dev, const ni_dhcp4_request_t *info)
 	config->route_priority = info->route_priority;
 	config->recover_lease = info->recover_lease;
 	config->release_lease = info->release_lease;
+	config->broadcast = info->broadcast;
 
 	config->max_lease_time = ni_dhcp4_config_max_lease_time();
 	if (config->max_lease_time == 0)
@@ -1042,6 +1043,8 @@ ni_dhcp4_request_new(void)
 
 	req = xcalloc(1, sizeof(*req));
 	req->enabled = TRUE; /* used by wickedd */
+
+	req->broadcast = NI_TRISTATE_DEFAULT;
 
 	/* By default, we try to obtain all sorts of settings from the server */
 	req->update = -1U; /* apply wicked-config(5) defaults later */

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -160,6 +160,7 @@ struct ni_dhcp4_request {
 	 * This is a bitmap; individual bits correspond to
 	 * NI_ADDRCONF_UPDATE_* (this is an index enum, not a bitmask) */
 	unsigned int		update;
+	ni_tristate_t		broadcast;
 };
 
 /*
@@ -190,6 +191,8 @@ struct ni_dhcp4_config {
 	unsigned int		update;
 	unsigned int		doflags;
 	ni_uint_array_t		request_options;
+
+	ni_tristate_t		broadcast;
 
 	unsigned int		route_priority;
 

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -648,10 +648,14 @@ __ni_dhcp4_build_msg_put_hwspec(const ni_dhcp4_device_t *dev, ni_dhcp4_message_t
 			message->hwlen = dev->system.hwaddr.len;
 			memcpy(&message->chaddr, dev->system.hwaddr.data, dev->system.hwaddr.len);
 		}
+		if (ni_tristate_is_enabled(dev->config->broadcast))
+			message->flags = htons(BROADCAST_FLAG);
 		break;
 
 	case ARPHRD_IEEE1394:
 	case ARPHRD_INFINIBAND:
+		if (ni_tristate_is_disabled(dev->config->broadcast))
+			ni_warn_once("%s: broadcast is mandatory on infiniband", dev->ifname);
 		/* See http://tools.ietf.org/html/rfc4390
 		 *
 		 * Note: set the ciaddr before if needed.

--- a/src/dhcp4/tester.c
+++ b/src/dhcp4/tester.c
@@ -54,6 +54,7 @@ ni_dhcp4_tester_init(void)
 	memset(&dhcp4_tester_opts, 0, sizeof(dhcp4_tester_opts));
 	dhcp4_tester_opts.outfmt  = NI_DHCP4_TESTER_OUT_LEASE_INFO;
 	dhcp4_tester_opts.timeout = 0;
+	dhcp4_tester_opts.broadcast = NI_TRISTATE_DEFAULT;
 	dhcp4_tester_status = NI_WICKED_RC_NOT_RUNNING;
 	return &dhcp4_tester_opts;
 }
@@ -339,6 +340,8 @@ ni_dhcp4_tester_run(ni_dhcp4_tester_t *opts)
 
 	if (opts->timeout && opts->timeout != -1U)
 		req->acquire_timeout = opts->timeout;
+
+	req->broadcast = opts->broadcast;
 
 	if ((rv = ni_dhcp4_acquire(dev, req)) < 0) {
 		ni_error("%s: DHCP4v6 acquire request %s failed: %s",

--- a/src/dhcp4/tester.h
+++ b/src/dhcp4/tester.h
@@ -36,6 +36,7 @@ typedef struct ni_dhcp4_tester {
 	const char *	request;
 	const char *	output;
 	unsigned int	outfmt;
+	ni_tristate_t	broadcast;
 } ni_dhcp4_tester_t;
 
 extern ni_dhcp4_tester_t *	ni_dhcp4_tester_init(void);


### PR DESCRIPTION
This PR adds support for a new sysconfig option DHCLIENT_BROADCAST that, when set to "yes", will ask the DHCP server to send a broadcast response instead of a unicast one. 

Note that this is the default behaviour on Infiniband devices but is disabled otherwise. This PR basically adds the option to have this on non-infiniband devices too.
