### PR TITLE
man: add missing documentation for DHCLIENT6_CLIENT_ID

### DIFF
--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -97,6 +97,17 @@ DHCLIENT6_FQDN_UPDATE=""
 #
 DHCLIENT6_FQDN_QUALIFY="yes"
 
+## Type:        string
+## Default:     ""
+#
+# specify a client ID for DHCPv6
+#
+# This option allows to manually specify a client identifier (DUID) as a colon 
+# separated hex byte string for DHCPv6. It disables the default behavior to
+# maintain the client-id automatically, see wicked-config(5) and `wicked duid --help`
+# for more details.
+DHCLIENT6_CLIENT_ID=""
+
 ## Type:	list(,default,none,all,dns,ntp,tz,boot,nis,sip)
 ## Default:	""
 #

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -221,6 +221,12 @@ variable adding a final dot ('foo.bar' -> 'foo.bar.').
 When disabled, the DHCP server may append it's update domain the host-
 name (e.g. 'foo.bar' -> 'foo.bar.example.net').
 .TP
+.BR DHCLIENT6_CLIENT_ID
+This option allows to manually specify a client identifier (DUID) as a colon 
+separated hex byte string for DHCPv6. It disables the default behavior to
+maintain the client-id automatically, see wicked-config(5) and `wicked duid --help`
+for more details.
+.TP
 .BR DHCLIENT6_REQUEST_OPTION[SUFFIX]
 Specifies a space separate list of additional DHCPv6 options to request.
 The options can be specified by their code number or by name when defined


### PR DESCRIPTION
This option was implemented a while ago but was not still documented in sysconfig/network/dhcp nor man pages.