### PR TITLE
[RFC/WIP] netdev: improve error messages on invalid ifnames

### DIFF
--- a/client/duid.c
+++ b/client/duid.c
@@ -127,7 +127,7 @@ ni_do_duid_get(int argc, char **argv)
 	if (argc - optind)
 		goto usage;
 
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		status = NI_WICKED_RC_ERROR;
@@ -190,7 +190,7 @@ ni_do_duid_del(int argc, char **argv)
 	if (argc - optind)
 		goto usage;
 
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		status = NI_WICKED_RC_ERROR;
@@ -258,7 +258,7 @@ ni_do_duid_set(int argc, char **argv)
 		goto usage;
 	}
 
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		status = NI_WICKED_RC_ERROR;
@@ -366,7 +366,7 @@ ni_do_duid_create_en(int argc, char **argv)
 	}
 
 	status = NI_WICKED_RC_ERROR;
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		goto cleanup;
@@ -479,7 +479,7 @@ ni_do_duid_create_ll_type(uint16_t type, int argc, char **argv)
 	}
 
 	status = NI_WICKED_RC_ERROR;
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		goto cleanup;
@@ -638,7 +638,7 @@ ni_do_duid_create_uuid(int argc, char **argv)
 	}
 
 	status = NI_WICKED_RC_ERROR;
-	if (scope && !ni_netdev_name_is_valid(scope)) {
+	if (scope && ni_netdev_name_is_valid(scope) != NULL) {
 		fprintf(stderr, "%s: invalid scope interface name '%s'\n", argv[0],
 				ni_print_suspect(scope, ni_string_len(scope)));
 		goto cleanup;

--- a/client/iaid.c
+++ b/client/iaid.c
@@ -125,7 +125,7 @@ ni_do_iaid_get(int argc, char **argv)
 		goto usage;
 	}
 
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		fprintf(stderr, "%s: invalid interface name '%s'\n", argv[0],
 				ni_print_suspect(ifname, ni_string_len(ifname)));
 		status = NI_WICKED_RC_ERROR;
@@ -183,7 +183,7 @@ ni_do_iaid_del(int argc, char **argv)
 		goto usage;
 	}
 
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		fprintf(stderr, "%s: invalid interface name '%s'\n", argv[0],
 				ni_print_suspect(ifname, ni_string_len(ifname)));
 		status = NI_WICKED_RC_ERROR;
@@ -251,7 +251,7 @@ ni_do_iaid_set(int argc, char **argv)
 		goto usage;
 	}
 
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		fprintf(stderr, "%s: invalid interface name '%s'\n", argv[0],
 				ni_print_suspect(ifname, ni_string_len(ifname)));
 		status = NI_WICKED_RC_ERROR;
@@ -334,7 +334,7 @@ ni_do_iaid_create(int argc, char **argv)
 		goto usage;
 	}
 
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		fprintf(stderr, "%s: invalid interface name '%s'\n", argv[0],
 				ni_print_suspect(ifname, ni_string_len(ifname)));
 		status = NI_WICKED_RC_ERROR;

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -287,7 +287,7 @@ extern const char *	ni_oper_state_type_to_name(int);
 
 extern const char *	ni_strerror(int errcode);
 
-extern ni_bool_t	ni_netdev_name_is_valid(const char *);
+extern const char *	ni_netdev_name_is_valid(const char *);
 extern ni_bool_t	ni_netdev_alias_label_is_valid(const char *, const char *);
 
 extern ni_bool_t	ni_netdev_device_is_ready(ni_netdev_t *);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -1151,7 +1151,7 @@ ni_objectmodel_nanny_recheck(ni_dbus_object_t *object, const ni_dbus_method_t *m
 	for (i = 0; i < argv[0].array.len; ++i) {
 		const char *ifname = argv[0].string_array_value[i];
 
-		if (ni_netdev_name_is_valid(ifname) && ni_string_array_append(&ifnames, ifname) == 0)
+		if (ni_netdev_name_is_valid(ifname) == NULL && ni_string_array_append(&ifnames, ifname) == 0)
 			continue;
 
 		ni_string_array_destroy(&ifnames);

--- a/src/dbus-objects/bonding.c
+++ b/src/dbus-objects/bonding.c
@@ -73,7 +73,7 @@ __ni_objectmodel_bond_newlink(ni_netdev_t *cfg, const char *ifname, DBusError *e
 				"Unable to create bonding interface - too many interfaces");
 		goto out;
 	}
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		dbus_set_error(error, DBUS_ERROR_FAILED,
 				"Unable to create bonding interface - invalid interface name '%s'",
 				ni_print_suspect(ifname, ni_string_len(ifname)));

--- a/src/dbus-objects/misc.c
+++ b/src/dbus-objects/misc.c
@@ -1063,7 +1063,7 @@ __ni_objectmodel_route_nexthop_from_dict(ni_route_nexthop_t *nh, const ni_dbus_v
 	}
 
 	if (ni_dbus_dict_get_string(nhdict, "device", &string)) {
-		if (!ni_netdev_name_is_valid(string)) {
+		if (ni_netdev_name_is_valid(string) != NULL) {
 			ni_debug_dbus("%s: invalid route hop device name: %s", __func__,
 					ni_print_suspect(string, ni_string_len(string)));
 			return FALSE;
@@ -1433,12 +1433,12 @@ ni_objectmodel_rule_match_from_dict(ni_rule_t *rule, const ni_dbus_variant_t *di
 	}
 
 	if (ni_dbus_dict_get_string(dict, "iif", &ptr)) {
-		if (!ni_netdev_name_is_valid(ptr) ||
+		if (ni_netdev_name_is_valid(ptr) != NULL ||
 		    !ni_string_dup(&rule->iif.name, ptr))
 			return FALSE;
 	}
 	if (ni_dbus_dict_get_string(dict, "oif", &ptr)) {
-		if (!ni_netdev_name_is_valid(ptr) ||
+		if (ni_netdev_name_is_valid(ptr) != NULL ||
 		    !ni_string_dup(&rule->oif.name, ptr))
 			return FALSE;
 	}

--- a/src/dbus-objects/model.c
+++ b/src/dbus-objects/model.c
@@ -753,7 +753,7 @@ ni_objectmodel_bind_netdev_ref_index(const char *ifname, const char *hint,
 		return set_bind_netdev_ref_index_error(ifname, hint, device,
 				error, "invalid self-reference");
 
-	if (!ni_netdev_name_is_valid(device->name))
+	if (ni_netdev_name_is_valid(device->name) != NULL)
 		return set_bind_netdev_ref_index_error(ifname, hint, device,
 				error, "suspect device name");
 

--- a/src/dbus-objects/vxlan.c
+++ b/src/dbus-objects/vxlan.c
@@ -71,7 +71,7 @@ ni_objectmodel_vxlan_create(ni_netdev_t *cfg, const char *ifname, DBusError *err
 		}
 		ifname = cfg->name;
 	} else
-	if (!ni_netdev_name_is_valid(ifname)) {
+	if (ni_netdev_name_is_valid(ifname) != NULL) {
 		dbus_set_error(error, DBUS_ERROR_INVALID_ARGS,
 				"Unable to create %s interface: "
 				"invalid interface name '%s'",
@@ -185,7 +185,7 @@ ni_objectmodel_vxlan_change(ni_dbus_object_t *object, const ni_dbus_method_t *me
 	if (ni_string_empty(cfg->name))
 		ni_string_dup(&cfg->name, dev->name);
 	else
-	if (!ni_netdev_name_is_valid(cfg->name)) {
+	if (ni_netdev_name_is_valid(cfg->name) != NULL) {
 		dbus_set_error(error, DBUS_ERROR_INVALID_ARGS,
 				"Unable to rename %s interface '%s': "
 				"invalid interface name '%s'",

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -1018,13 +1018,16 @@ ni_netdev_supports_arp(ni_netdev_t *dev)
 	return FALSE;
 }
 
-static size_t
-__ni_netdev_name_is_valid(const char *ifname)
+const char *
+ni_netdev_name_is_valid(const char *ifname)
 {
-	size_t i, len = ni_string_len(ifname);
+	const char *black_list[] = {
+		"all", "default", NULL
+	}, **ptr;
 
+	size_t i, len = ni_string_len(ifname);
 	if (!len || len >= IFNAMSIZ)
-		return 0;
+		return "Rejecting interface name due to excesive length";
 
 	for(i = 0; i < len; ++i) {
 		if(isalnum((unsigned char)ifname[i]) ||
@@ -1032,30 +1035,18 @@ __ni_netdev_name_is_valid(const char *ifname)
 				ifname[i] == '_' ||
 				ifname[i] == '.')
 			continue;
-		return 0;
+		return "Rejecting interface name due to ilegal characters";
 	}
-	return len;
-}
-
-ni_bool_t
-ni_netdev_name_is_valid(const char *ifname)
-{
-	const char *black_list[] = {
-		"all", "default", NULL
-	}, **ptr;
-
-	if (!__ni_netdev_name_is_valid(ifname))
-		return FALSE;
 
 	if (!isalnum((unsigned char)ifname[0]))
-		return FALSE;
+		return "Rejecting interface name due to non-alphanumeric characters";
 
 	for (ptr = black_list; *ptr; ptr++) {
 		if (ni_string_eq(*ptr, ifname))
-			return FALSE;
+			return "Rejecting interface name due to blacklisted name";
 	}
 
-	return TRUE;
+	return NULL;
 }
 
 static size_t


### PR DESCRIPTION
A few days ago I got the "Rejecting suspect interface name:" and as it was the first time I saw this error, I was not entirely sure. Googling it lead me to some results where other people seemed to be unsure what was causing this error. This PR is just a request for comments to see how we can improve this messages.

Also, I'm not entirely sure if removing __ni_netdev_name_is_valid(...) is a good idea.