### PR TITLE
ifcfg: show unknown/invalid bootproto as error

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5623,8 +5623,8 @@ __ni_suse_bootproto(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 			__ni_suse_addrconf_auto6(sc, compat);
 		}
 		else {
-			ni_debug_readwrite("ifcfg-%s: Unknown BOOTPROTO=\"%s\""
-					" value \"%s\"", dev->name, bootproto, s);
+			ni_error("ifcfg-%s: Unknown value in BOOTPROTO=\"%s\"",
+					dev->name, bootproto);
 		}
 		primary = FALSE;
 	}


### PR DESCRIPTION
https://github.com/openSUSE/wicked/issues/756