### PR TITLE
firewall: do not assign default zone, but pass as is (bsc#1109147)

### DIFF
--- a/extensions/firewall
+++ b/extensions/firewall
@@ -66,10 +66,7 @@ firewalld_up()
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
 
 	local ZONE=`wicked_config_get_zone "$WICKED_ARGFILE"`
-	if test "X$ZONE" = "X" ; then
-		ZONE=`"$firewalld_cmd" --get-default-zone 2>/dev/null`
-		test "X$ZONE" = "X" && return 1
-	fi
+
 	"$firewalld_cmd" --zone="$ZONE" --change-interface="$WICKED_INTERFACE_NAME" &>/dev/null
 }
 


### PR DESCRIPTION
This PR changes the firewall extension to not get the default zone from firewall-cmd for the --change-interface, but rather pass a empty zone string; firewalld should interpret this empty string as "use default zone".