### PR TITLE
wireless: fix eap peap auth mapping for wpa-supplicant (bsc#1026807)

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -4080,6 +4080,16 @@ __ni_wireless_parse_eap_auth(const ni_sysconfig_t *sc, ni_wireless_network_t *ne
 				goto eap_failure;
 			}
 		}
+
+		if (net->wpa_eap.phase2.method == NI_WIRELESS_EAP_NONE) {
+			if (net->wpa_eap.phase1.peapver == 1)
+				net->wpa_eap.phase2.method = NI_WIRELESS_EAP_GTC;
+			else
+				net->wpa_eap.phase2.method = NI_WIRELESS_EAP_MSCHAPV2;
+
+			ni_warn("ifcfg-%s: assuming WIRELESS_EAP_AUTH%s='%s'", dev_name, suffix,
+					ni_wireless_eap_method_to_name(net->wpa_eap.phase2.method));
+		}
 	}
 
 	return TRUE;

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1647,7 +1647,7 @@ __wpa_dbus_bss_get_phase2(const ni_dbus_object_t *object, const ni_dbus_property
 			if (NI_WIRELESS_EAP_NONE == net->wpa_eap.phase2.method)
 				eap_name = "any";
 			else {
-				eap_name = ni_wireless_eap_method_to_name(net->wpa_eap.phase2.method);
+				eap_name = ni_wpa_eap_method_as_string(net->wpa_eap.phase2.method, error);
 				if (ni_string_empty(eap_name))
 					goto not_present;
 			}


### PR DESCRIPTION
Fix for issue https://github.com/openSUSE/wicked/issues/777 to map eap auth method correctly when sending it to wpa-supplicant and to assume mschapv2 as PEAP auth when not specified in ifcfg config.