### PR TITLE
Init memory before use in ioctl

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -98,6 +98,7 @@ __ni_ethtool(const char *ifname, int cmd, void *data)
 {
 	struct ifreq ifr;
 
+	memset(&ifr, 0, sizeof(ifr));
 	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 	((struct ethtool_cmd *) data)->cmd = cmd;
 	ifr.ifr_data = data;
@@ -116,6 +117,7 @@ __ni_wireless_ext(const ni_netdev_t *dev, int cmd,
 {
 	struct iwreq iwr;
 
+	memset(&iwr, 0, sizeof(iwr));
 	strncpy(iwr.ifr_name, dev->name, IFNAMSIZ);
 	iwr.u.data.pointer = data;
 	iwr.u.data.length = data_len;


### PR DESCRIPTION
Pointed by valgrind.

```
 Syscall param ioctl(SIOCETHTOOL) points to uninitialised byte(s)
==10768==    at 0x6637467: ioctl (in /lib64/libc-2.26.so)
==10768==    by 0x4EDE3F6: __ni_ioctl (kernel.c:66)
==10768==    by 0x4EDE799: __ni_ethtool (kernel.c:106)
==10768==    by 0x4ED4888: __ni_process_ifinfomsg_linktype (iflist.c:1149)
==10768==    by 0x4ED4888: __ni_process_ifinfomsg_linkinfo (iflist.c:1602)
==10768==    by 0x4ED4E34: __ni_netdev_process_newlink (iflist.c:1831)
==10768==    by 0x4EDA2BB: __ni_system_refresh_all (iflist.c:591)
==10768==    by 0x4EDA76E: __ni_system_refresh_interfaces (iflist.c:518)
==10768==    by 0x4EEBB4F: ni_global_state_handle (netinfo.c:480)
==10768==    by 0x402AA9: discover_state (main.c:334)
==10768==    by 0x402AA9: run_interface_server (main.c:277)
==10768==    by 0x402AA9: main (main.c:219)
==10768==  Address 0x1ffefff8c8 is on thread 1's stack
==10768==  in frame #2, created by __ni_ethtool (kernel.c:99)
==10768==  Uninitialised value was created by a stack allocation
==10768==    at 0x4E8F220: ??? (in /root/sandbox/wicked/src/.libs/libwicked-0.so.6.53.0)
```