### PR TITLE
rfkill: In switch statement check enum variable not constant

### DIFF
--- a/src/rfkill.c
+++ b/src/rfkill.c
@@ -129,7 +129,7 @@ __ni_rfkill_recv(ni_socket_t *sock)
 		if (!sw->soft_blocked && !sw->hard_blocked)
 			continue;
 
-		switch (RFKILL_TYPE_ALL) {
+		switch (sw->type) {
 		case RFKILL_TYPE_ALL:
 			for (type = 0; type < __NI_RFKILL_TYPE_MAX; ++type)
 				state[type] = TRUE;


### PR DESCRIPTION
This fixes broken Wifi support reported in:
https://bugzilla.suse.com/show_bug.cgi?id=1140117

Signed-off-by: Egbert Eich <eich@suse.com>