### PR TITLE
systemd: change to depend on udev settle service (bsc#1136034,bsc#1132774)

### DIFF
--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,15 +1,14 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
-After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service systemd-udev-settle.service
+After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service systemd-udev-settle.service
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]
 Type=notify
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/network/config
-ExecStartPre=-/usr/bin/udevadm settle
 ExecStart=@wicked_sbindir@/wickedd --systemd --foreground
 StandardError=null
 Restart=on-abort


### PR DESCRIPTION
This change moves the ExecStartPre call that was causing wickedd.service to timeout under some scenarios to a proper systemd dependency where the udev settle wait time doesn't count as wickedd.service start time