### PR TITLE
systemd: wait haveged to meet entropy requirements (bsc#1131369)

### DIFF
--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked AutoIPv4 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service SuSEfirewall2_init.service haveged.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked DHCPv4 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service SuSEfirewall2_init.service haveged.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked DHCPv6 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service SuSEfirewall2_init.service haveged.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked network nanny service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service wickedd.service
+After=local-fs.target dbus.service SuSEfirewall2_init.service wickedd.service haveged.service
 Before=wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
-After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service haveged.service
+After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service haveged.service
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]


### PR DESCRIPTION
Add a systemd (soft) dependency on havaged to wait for enough entropy without allowing this time to account as wicked start time.