### PR TITLE
time: use boot time for timer instead of real time (bsc#1129986)

### DIFF
--- a/autoip4/autoip.h
+++ b/autoip4/autoip.h
@@ -42,7 +42,7 @@ struct ni_autoip_device {
 	    unsigned int	nprobes;
 	    unsigned int	nclaims;
 	    unsigned int	nconflicts;
-	    time_t		last_defense;
+	    struct timeval	last_defense;
 	} autoip;
 
 	ni_auto4_request_t 	request;

--- a/include/wicked/socket.h
+++ b/include/wicked/socket.h
@@ -39,6 +39,8 @@ extern void *		ni_timer_cancel(const ni_timer_t *);
 extern const ni_timer_t *ni_timer_rearm(const ni_timer_t *, unsigned long);
 extern long		ni_timer_next_timeout(void);
 extern int		ni_timer_get_time(struct timeval *tv);
+extern int		ni_time_timer_to_real(const struct timeval *, struct timeval *);
+extern int		ni_time_real_to_timer(const struct timeval *, struct timeval *);
 
 extern ni_socket_t *	ni_socket_hold(ni_socket_t *);
 extern void		ni_socket_release(ni_socket_t *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -168,7 +168,7 @@ struct ni_wireless_network {
 	unsigned int			fragment_size;		/* used with EAP */
 
 	struct ni_wireless_scan_info {
-		time_t			timestamp;
+		struct timeval 		timestamp;
 		ni_bool_t		updating;		/* retrieving new scan info */
 		int			noise;
 		double			level;			/* in dBm*/
@@ -267,16 +267,16 @@ struct ni_wireless {
 
 struct ni_wireless_scan {
 	/* Scanning interval */
-	unsigned int		interval;
+	unsigned int			interval;
 
 	/* Time in seconds after which we forget BSSes */
-	unsigned int		max_age;
+	unsigned int			max_age;
 
-	time_t			timestamp;
-	time_t			lifetime;
-	ni_wireless_network_array_t networks;
+	struct timeval			timestamp;
+	unsigned int			lifetime;
+	ni_wireless_network_array_t	networks;
 
-	const ni_timer_t *	timer;
+	const ni_timer_t *		timer;
 };
 
 extern void		ni_wireless_set_scanning(ni_bool_t enable);

--- a/src/async-resolver.c
+++ b/src/async-resolver.c
@@ -96,7 +96,7 @@ gaicb_list_resolve(struct gaicb **greqs, unsigned int nreqs, unsigned int timeou
 			return -1;
 		}
 
-		gettimeofday(&deadline, NULL);
+		ni_timer_get_time(&deadline);
 		deadline.tv_sec += timeout;
 
 		while (1) {
@@ -104,13 +104,12 @@ gaicb_list_resolve(struct gaicb **greqs, unsigned int nreqs, unsigned int timeou
 			struct timespec ts;
 			int status;
 
-			gettimeofday(&now, NULL);
+			ni_timer_get_time(&now);
 			if (timercmp(&now, &deadline, >=))
 				break;
 
 			timersub(&deadline, &now, &delta);
-			ts.tv_sec = delta.tv_sec;
-			ts.tv_nsec = 1000 * delta.tv_usec;
+			TIMEVAL_TO_TIMESPEC(&delta, &ts);
 
 			status = gai_suspend((const struct gaicb * const *) greqs, nreqs, &ts);
 			if (status == EAI_ALLDONE || status == EAI_AGAIN)

--- a/src/capture.c
+++ b/src/capture.c
@@ -343,7 +343,7 @@ ni_capture_force_retransmit(ni_capture_t *capture, unsigned int delay)
 	if (timerisset(&capture->retrans.deadline)) {
 		struct timeval *deadline = &capture->retrans.deadline;
 
-		gettimeofday(deadline, NULL);
+		ni_timer_get_time(deadline);
 		deadline->tv_sec += delay;
 	}
 }

--- a/src/dbus-objects/wireless.c
+++ b/src/dbus-objects/wireless.c
@@ -468,7 +468,7 @@ __ni_objectmodel_wireless_get_scan(const ni_dbus_object_t *object,
 	if (!(scan = __ni_objectmodel_get_scan(object, error)))
 		return TRUE;
 
-	ni_dbus_dict_add_uint32(result, "timestamp", scan->timestamp);
+	ni_dbus_dict_add_int64(result, "timestamp", scan->timestamp.tv_sec);
 	for (i = 0; i < scan->networks.count; ++i) {
 		child = ni_dbus_dict_add(result, "network");
 		ni_dbus_variant_init_dict(child);
@@ -488,17 +488,19 @@ __ni_objectmodel_wireless_set_scan(ni_dbus_object_t *object,
 	ni_wireless_t *wlan;
 	ni_wireless_scan_t *scan;
 	const ni_dbus_variant_t *child;
-	uint32_t valu32;
+	int64_t value64;
 
 	if (!(wlan = __ni_objectmodel_wireless_write_handle(object, error)))
 		return FALSE;
 
 	if ((scan = wlan->scan) != NULL)
 		ni_wireless_scan_free(scan);
-	wlan->scan = scan = ni_wireless_scan_new(NULL, 0);
 
-	if (ni_dbus_dict_get_uint32(argument, "timestamp", &valu32))
-		scan->timestamp = valu32;
+	wlan->scan = scan = ni_wireless_scan_new(NULL, 0);
+	if (ni_dbus_dict_get_int64(argument, "timestamp", &value64)) {
+		scan->timestamp.tv_sec = value64;
+		scan->timestamp.tv_usec = 0;
+	}
 
 	child = NULL;
 	while ((child = ni_dbus_dict_get_next(argument, "network", child)) != NULL) {

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -697,7 +697,7 @@ ni_dhcp4_device_send_message(ni_dhcp4_device_t *dev, unsigned int msg_code, cons
 	}
 
 	ni_debug_dhcp("%s: sending %s with xid 0x%x in state %s", dev->ifname,
-			ni_dhcp4_message_name(msg_code), htonl(dev->dhcp4.xid),
+			ni_dhcp4_message_name(msg_code), dev->dhcp4.xid,
 			ni_dhcp4_fsm_state_name(dev->fsm.state));
 
 	if ((rv = ni_dhcp4_device_prepare_message(dev)) < 0)
@@ -755,7 +755,7 @@ ni_dhcp4_device_send_message_unicast(ni_dhcp4_device_t *dev, unsigned int msg_co
 		return -1;
 	}
 
-	ni_debug_dhcp("sending %s with xid 0x%x", ni_dhcp4_message_name(msg_code), htonl(dev->dhcp4.xid));
+	ni_debug_dhcp("sending %s with xid 0x%x", ni_dhcp4_message_name(msg_code), dev->dhcp4.xid);
 
 	if (ni_dhcp4_device_prepare_message(dev) < 0)
 		return -1;

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -58,7 +58,7 @@ ni_dhcp4_device_new(const char *ifname, const ni_linkinfo_t *link)
 		return NULL;
 	}
 
-	dev->start_time = time(NULL);
+	ni_timer_get_time(&dev->start_time);
 	dev->fsm.state = NI_DHCP4_STATE_INIT;
 
 	/* append to end of list */
@@ -184,10 +184,14 @@ ni_dhcp4_device_put(ni_dhcp4_device_t *dev)
 unsigned int
 ni_dhcp4_device_uptime(const ni_dhcp4_device_t *dev, unsigned int clamp)
 {
-	unsigned int uptime;
+	struct timeval now, uptime;
 
-	uptime = time(NULL) - dev->start_time;
-	return (uptime < clamp)? uptime : clamp;
+	ni_timer_get_time(&now);
+	if (timercmp(&now, &dev->start_time, >))
+		timersub(&now, &dev->start_time, &uptime);
+	else
+		timerclear(&uptime);
+	return (uptime.tv_sec < clamp) ? uptime.tv_sec : clamp;
 }
 
 void

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -51,7 +51,7 @@ typedef struct ni_dhcp4_device {
 
 	ni_capture_devinfo_t	system;
 
-	time_t			start_time;	/* when we starting managing */
+	struct timeval		start_time;	/* when we starting managing */
 
 	ni_dhcp4_request_t *	request;
 	ni_dhcp4_config_t *	config;

--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -101,10 +101,10 @@ ni_dhcp4_fsm_process_dhcp4_packet(ni_dhcp4_device_t *dev, ni_buffer_t *msgbuf, n
 				sender ? " sender " : "", sender ? sender : "");
 		return -1;
 	}
-	if (dev->dhcp4.xid != message->xid) {
+	if (dev->dhcp4.xid != ntohl(message->xid)) {
 		sender = ni_capture_from_hwaddr_print(from);
 		ni_debug_dhcp("%s: ignoring packet with wrong xid 0x%x (expected 0x%x)%s%s",
-				dev->ifname, htonl(message->xid), htonl(dev->dhcp4.xid),
+				dev->ifname, ntohl(message->xid), dev->dhcp4.xid,
 				sender ? " sender " : "", sender ? sender : "");
 		return -1;
 	}
@@ -156,7 +156,7 @@ ni_dhcp4_fsm_process_dhcp4_packet(ni_dhcp4_device_t *dev, ni_buffer_t *msgbuf, n
 	}
 
 	ni_debug_dhcp("%s: received %s message xid 0x%x in state %s%s%s",
-			dev->ifname, ni_dhcp4_message_name(msg_code), message->xid,
+			dev->ifname, ni_dhcp4_message_name(msg_code), ntohl(message->xid),
 			ni_dhcp4_fsm_state_name(dev->fsm.state),
 			sender ? " sender " : "", sender ? sender : "");
 

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -697,14 +697,14 @@ __ni_dhcp4_build_msg_init_head(const ni_dhcp4_device_t *dev,
 
 	memset(message, 0, sizeof(*message));
 	message->op = DHCP4_BOOTREQUEST;
-	message->xid = dev->dhcp4.xid;
+	message->xid = htonl(dev->dhcp4.xid);
 	message->secs = htons(ni_dhcp4_device_uptime(dev, 0xFFFF));
 	message->cookie = htonl(MAGIC_COOKIE);
 	message->hwtype = dev->system.hwaddr.type;
 
 	ni_dhcp4_option_put8(msgbuf, DHCP4_MESSAGETYPE, msg_code);
 	ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
-			"%s: xid: %x, secs: %u", dev->ifname,
+			"%s: xid: 0x%x, secs: %u", dev->ifname,
 			ntohl(message->xid), ntohs(message->secs));
 	ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
 			"%s: using message type: %s", dev->ifname,

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -727,8 +727,8 @@ ni_dhcp6_device_retransmit_disarm(ni_dhcp6_device_t *dev)
 	ni_timer_get_time(&now);
 
 	if (dev->dhcp6.xid || dev->retrans.params.timeout) {
-		ni_debug_dhcp("%s: disarming retransmission at %s",
-				dev->ifname, ni_dhcp6_print_timeval(&now));
+		ni_debug_dhcp("%s: disarming xid 0x%06x retransmission",
+				dev->ifname, dev->dhcp6.xid);
 	}
 
 	dev->dhcp6.xid = 0;
@@ -767,16 +767,15 @@ ni_dhcp6_device_retransmit_advance(ni_dhcp6_device_t *dev)
 				&dev->retrans.deadline,
 				&dev->retrans.params);
 
-		ni_debug_dhcp("%s: increased retransmission timeout from %u to %u [%d .. %d]: %s",
-				dev->ifname, old_timeout,
+		ni_debug_dhcp("%s: advanced xid 0x%06x retransmission timeout from %u to %u [%d .. %d]",
+				dev->ifname, dev->dhcp6.xid, old_timeout,
 				dev->retrans.params.timeout,
 				dev->retrans.params.jitter.min,
-				dev->retrans.params.jitter.max,
-				ni_dhcp6_print_timeval(&dev->retrans.deadline));
+				dev->retrans.params.jitter.max);
 
 		return TRUE;
 	}
-	ni_debug_dhcp("%s: retransmission limit reached", dev->ifname);
+	ni_debug_dhcp("%s: xid 0x%06x retransmission limit reached", dev->ifname, dev->dhcp6.xid);
 	return FALSE;
 }
 
@@ -794,8 +793,8 @@ ni_dhcp6_device_retransmit(ni_dhcp6_device_t *dev)
 	if ((rv = ni_dhcp6_fsm_retransmit(dev)) < 0)
 		return rv;
 
-	ni_debug_dhcp("%s: retransmitted, next deadline at %s", dev->ifname,
-			ni_dhcp6_print_timeval(&dev->retrans.deadline));
+	ni_debug_dhcp("%s: xid 0x%06x retransmitted, next deadline in %s", dev->ifname,
+			dev->dhcp6.xid, ni_dhcp6_print_timeval(&dev->retrans.deadline));
 	return 0;
 }
 
@@ -1254,10 +1253,9 @@ ni_dhcp6_device_transmit(ni_dhcp6_device_t *dev)
 		ni_timer_get_time(&now);
 		ni_debug_verbose(NI_LOG_DEBUG, NI_TRACE_DHCP,
 				"%s: %s message #%u, xid 0x%x sent with %zd of %zu"
-				" byte to %s at %s",
+				" byte to %s",
 				dev->ifname, name, dev->retrans.count, xid, rv, cnt,
-				ni_sockaddr_print(&dev->mcast.dest),
-				ni_dhcp6_print_timeval(&now));
+				ni_sockaddr_print(&dev->mcast.dest));
 
 		ni_buffer_clear(&dev->message);
 		return 0;

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -1661,7 +1661,7 @@ static int
 ni_dhcp6_fsm_renew(ni_dhcp6_device_t *dev)
 {
 	unsigned int deadline;
-	struct timeval now;
+	struct timeval duration;
 	int rv = -1;
 
 	if (!dev->lease)
@@ -1677,11 +1677,11 @@ ni_dhcp6_fsm_renew(ni_dhcp6_device_t *dev)
 		}
 
 		deadline = ni_dhcp6_fsm_get_rebind_timeout(dev);
-		ni_timer_get_time(&now);
-		now.tv_sec += deadline;
+		ni_timer_get_time(&duration);
+		duration.tv_sec += deadline;
 
-		ni_info("%s: Initiating renewal of DHCPv6 lease, duration %u sec until %s",
-				dev->ifname, deadline, ni_dhcp6_print_timeval(&now));
+		ni_info("%s: Initiating renewal of DHCPv6 lease, duration %s",
+				dev->ifname, ni_dhcp6_print_timeval(&duration));
 
 		dev->dhcp6.xid = 0;
 		if (ni_dhcp6_init_message(dev, NI_DHCP6_RENEW, dev->lease) != 0)
@@ -1709,7 +1709,7 @@ static int
 ni_dhcp6_fsm_rebind(ni_dhcp6_device_t *dev)
 {
 	unsigned int deadline;
-	struct timeval now;
+	struct timeval duration;
 	int rv = -1;
 
 	if (!dev->lease)
@@ -1732,11 +1732,11 @@ ni_dhcp6_fsm_rebind(ni_dhcp6_device_t *dev)
 		}
 
 		deadline = ni_dhcp6_fsm_get_expire_timeout(dev);
-		ni_timer_get_time(&now);
-		now.tv_sec += deadline;
+		ni_timer_get_time(&duration);
+		duration.tv_sec += deadline;
 
-		ni_info("%s: Initiating rebind of DHCPv6 lease, duration %u sec until %s",
-			dev->ifname, deadline, ni_dhcp6_print_timeval(&now));
+		ni_info("%s: Initiating rebind of DHCPv6 lease, duration %s",
+			dev->ifname, ni_dhcp6_print_timeval(&duration));
 
 		dev->dhcp6.xid = 0;
 		if (ni_dhcp6_init_message(dev, NI_DHCP6_REBIND, dev->lease) != 0)
@@ -2061,7 +2061,7 @@ static int
 ni_dhcp6_fsm_bound(ni_dhcp6_device_t *dev)
 {
 	unsigned int timeout;
-	struct timeval now;
+	struct timeval start;
 
 	if (!dev->lease)
 		return -1;
@@ -2079,12 +2079,12 @@ ni_dhcp6_fsm_bound(ni_dhcp6_device_t *dev)
 					dev->ifname,
 					ni_dhcp6_fsm_state_name(dev->fsm.state));
 		} else {
-			ni_timer_get_time(&now);
-			now.tv_sec += timeout;
+			ni_timer_get_time(&start);
+			start.tv_sec += timeout;
 
-			ni_debug_dhcp("%s: Reached %s state, scheduled RENEW in %u sec at %s",
+			ni_debug_dhcp("%s: Reached %s state, scheduled RENEW to start in %s",
 					dev->ifname, ni_dhcp6_fsm_state_name(dev->fsm.state),
-					timeout, ni_dhcp6_print_timeval(&now));
+					ni_dhcp6_print_timeval(&start));
 
 			ni_dhcp6_fsm_set_timeout_msec(dev, timeout * 1000);
 		}

--- a/src/dhcp6/lease.c
+++ b/src/dhcp6/lease.c
@@ -31,6 +31,7 @@
 
 #include <wicked/netinfo.h>
 #include <wicked/addrconf.h>
+#include <wicked/socket.h>	/* ni_time functions */
 #include <wicked/xml.h>
 
 #include "duid.h"
@@ -121,6 +122,7 @@ __ni_dhcp6_lease_ia_data_to_xml(const ni_dhcp6_ia_t *ia, xml_node_t *node)
 	const char *ia_address = ni_dhcp6_option_name(NI_DHCP6_OPTION_IA_ADDRESS);
 	const char *ia_prefix  = ni_dhcp6_option_name(NI_DHCP6_OPTION_IA_PREFIX);
 	const ni_dhcp6_ia_addr_t *iadr;
+	struct timeval acquired;
 	xml_node_t *iadr_node;
 	unsigned int count = 0;
 	char buf[32] = { '\0' };
@@ -129,13 +131,15 @@ __ni_dhcp6_lease_ia_data_to_xml(const ni_dhcp6_ia_t *ia, xml_node_t *node)
 	switch (ia->type) {
 	case NI_DHCP6_OPTION_IA_TA:
 		xml_node_new_element_uint("interface-id", node, ia->iaid);
-		snprintf(buf, sizeof(buf), "%"PRId64, (int64_t)ia->acquired.tv_sec);
+		ni_time_timer_to_real(&ia->acquired, &acquired);
+		snprintf(buf, sizeof(buf), "%"PRId64, (int64_t)acquired.tv_sec);
 		xml_node_new_element("acquired", node, buf);
 		break;
 	case NI_DHCP6_OPTION_IA_NA:
 	case NI_DHCP6_OPTION_IA_PD:
 		xml_node_new_element_uint("interface-id", node, ia->iaid);
-		snprintf(buf, sizeof(buf), "%"PRId64, (int64_t)ia->acquired.tv_sec);
+		ni_time_timer_to_real(&ia->acquired, &acquired);
+		snprintf(buf, sizeof(buf), "%"PRId64, (int64_t)acquired.tv_sec);
 		xml_node_new_element("acquired", node, buf);
 		xml_node_new_element_uint("renewal-time", node, ia->renewal_time);
 		xml_node_new_element_uint("rebind-time", node, ia->rebind_time);
@@ -374,19 +378,22 @@ __ni_dhcp6_lease_ia_data_from_xml(ni_dhcp6_ia_t *ia, const xml_node_t *node)
 		iadr_name = ni_dhcp6_option_name(NI_DHCP6_OPTION_IA_ADDRESS);
 	}
 
+	ni_timer_get_time(&ia->acquired); /* pre-init */
 	for (child = node->children; child; child = child->next) {
 		if (ni_string_eq(child->name, "interface-id")) {
 			if (ni_parse_uint(child->cdata, &ia->iaid, 10) !=  0)
 				return -1;
 		} else
 		if (ni_string_eq(child->name, "acquired")) {
-			int64_t acquired;
+			struct timeval acquired;
+			int64_t sec;
 
-			if (ni_parse_int64(child->cdata, &acquired, 10))
+			if (ni_parse_int64(child->cdata, &sec, 10))
 				return -1;
 
-			ia->acquired.tv_sec = acquired;
-			ia->acquired.tv_usec = 0;
+			acquired.tv_sec = sec;
+			acquired.tv_usec = 0;
+			ni_time_real_to_timer(&acquired, &ia->acquired);
 		} else
 		if (ni_string_eq(child->name, "renewal-time") &&
 		    ia->type != NI_DHCP6_OPTION_IA_TA) {

--- a/src/dhcp6/protocol.h
+++ b/src/dhcp6/protocol.h
@@ -272,7 +272,6 @@ extern int		ni_dhcp6_ia_list_copy(ni_dhcp6_ia_t **, const ni_dhcp6_ia_t *, ni_bo
 extern unsigned int	ni_dhcp6_ia_copy_to_lease_addrs(const ni_dhcp6_device_t *, ni_addrconf_lease_t *);
 
 extern const char *	ni_dhcp6_print_timeval(const struct timeval *);
-extern const char *	ni_dhcp6_print_time(time_t);
 
 extern const char *	ni_dhcp6_address_print(const struct in6_addr *);
 

--- a/src/leaseinfo.c
+++ b/src/leaseinfo.c
@@ -44,6 +44,7 @@
 #include <wicked/netinfo.h>
 #include <wicked/nis.h>
 #include <wicked/route.h>
+#include <wicked/socket.h>	/* ni_time functions */
 
 #include "appconfig.h"
 #include "util_priv.h"
@@ -486,6 +487,7 @@ __ni_leaseinfo_dhcp4_dump(FILE *out, const ni_addrconf_lease_t *lease,
 	char *key = NULL;
 	ni_sockaddr_t sa;
 
+
 	/*
 	 * Hmm...
 	 * Address and netmask specified as part of generic dump, so not
@@ -511,10 +513,13 @@ __ni_leaseinfo_dhcp4_dump(FILE *out, const ni_addrconf_lease_t *lease,
 					lease->dhcp4.sender_hwa, NULL, 0);
 	}
 
-	if (lease->acquired.tv_sec) {
+	{
+		struct timeval acquired;
+
+		ni_time_timer_to_real(&lease->acquired, &acquired);
 		fprintf(out, "%s='%"PRId64"'\n", __ni_keyword_format
 				(&key, prefix, "ACQUIRED", 0),
-				(int64_t) lease->acquired.tv_sec);
+				(int64_t) acquired.tv_sec);
 	}
 	if (lease->dhcp4.lease_time)  {
 		fprintf(out, "%s='%"PRIu32"'\n", __ni_keyword_format
@@ -576,10 +581,13 @@ __ni_leaseinfo_dhcp6_dump(FILE *out, const ni_addrconf_lease_t *lease,
 	char *key = NULL;
 	ni_sockaddr_t sa;
 
-	if (lease->acquired.tv_sec) {
+	{
+		struct timeval acquired;
+
+		ni_time_timer_to_real(&lease->acquired, &acquired);
 		fprintf(out, "%s='%"PRIu64"'\n", __ni_keyword_format
 				(&key, prefix, "ACQUIRED", 0),
-				(uint64_t) lease->acquired.tv_sec);
+				(uint64_t) acquired.tv_sec);
 	}
 
 	if (lease->dhcp6.client_id.len) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -144,7 +144,7 @@ ni_socket_array_wait(ni_socket_array_t *array, long timeout)
 		socket_count++;
 	}
 
-	gettimeofday(&now, NULL);
+	ni_timer_get_time(&now);
 	if (timerisset(&expires)) {
 		struct timeval delta;
 		long delta_ms;
@@ -220,7 +220,7 @@ done_with_this_socket:
 		ni_socket_release(sock);
 	}
 
-	gettimeofday(&now, NULL);
+	ni_timer_get_time(&now);
 	for (i = 0; i < array->count && i < socket_count; ++i) {
 		ni_socket_t *sock = array->data[i];
 

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -149,7 +149,7 @@ __ni_wireless_do_scan(ni_netdev_t *dev)
 	ni_wpa_interface_t *wpa_dev;
 	ni_wireless_t *wlan;
 	ni_wireless_scan_t *scan;
-	time_t now;
+	struct timeval now;
 
 	wlan = dev->wireless;
 	if ((scan = wlan->scan) == NULL) {
@@ -189,13 +189,13 @@ __ni_wireless_do_scan(ni_netdev_t *dev)
 	}
 
 	/* If we haven't seen a scan in a long time, request one. */
-	now = time(NULL);
-	if (scan->timestamp + scan->interval < now) {
+	ni_timer_get_time(&now);
+	if (timerisset(&scan->timestamp) && scan->timestamp.tv_sec + scan->interval < now.tv_sec) {
 		/* We can do this only if the device is up */
 		if (dev->link.ifflags & NI_IFF_DEVICE_UP) {
-			if (scan->timestamp)
+			if (now.tv_sec > scan->timestamp.tv_sec)
 				ni_debug_wireless("%s: requesting wireless scan (last scan was %u seconds ago)",
-						dev->name, (unsigned int) (now - scan->timestamp));
+						dev->name, (unsigned int)(now.tv_sec - scan->timestamp.tv_sec));
 			else
 				ni_debug_wireless("%s: requesting wireless scan", dev->name);
 			ni_wpa_interface_request_scan(wpa_dev, scan);

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -38,7 +38,7 @@ struct ni_wpa_interface {
 	ni_dbus_object_t *	proxy;
 
 	struct {
-		time_t		timestamp;
+		struct timeval	timestamp;
 		unsigned char	pending;
 	} scan;
 


### PR DESCRIPTION
Fixes to use boot time for timers/timeouts and real time only in lease
files to not stuck in timers due to adjustments of the system time.
Consistently log dhcp xid and enabled to log dhcp6 timings line.