### PR TITLE
dhcp6: do not default to a /64 address prefix-length (bsc#1132280)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -2283,6 +2283,11 @@ __ni_compat_generate_dhcp6_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 	if ((ptr = ni_dhcp6_mode_type_to_name(compat->dhcp6.mode)) != NULL)
 		xml_node_dict_set(dhcp, "mode", ptr);
 
+	if (compat->dhcp6.address_len) {
+		xml_node_dict_set(dhcp, "address-length",
+				ni_sprint_uint(compat->dhcp6.address_len));
+	}
+
 	xml_node_dict_set(dhcp, "rapid-commit",
 			ni_format_boolean(compat->dhcp6.rapid_commit));
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5322,6 +5322,16 @@ __ni_suse_addrconf_dhcp6_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 		}
 	}
 
+	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_ADDRESS_LENGTH")) != NULL) {
+		if (ni_parse_uint(string, &uint, 10) == 0 &&
+		    uint <= ni_af_address_prefixlen(AF_INET6)) {
+			compat->dhcp6.address_len = uint;
+		} else {
+			ni_warn("%s: Invalid length in DHCLIENT6_ADDRESS_LENGTH='%s'",
+					ni_basename(sc->pathname), string);
+		}
+	}
+
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_RAPID_COMMIT")) != NULL) {
 		if (!strcasecmp(string, "yes")) {
 			compat->dhcp6.rapid_commit = TRUE;

--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -124,3 +124,15 @@ DHCLIENT6_CLIENT_ID=""
 # The more specific variable DHCLIENT6_SET_HOSTNAME has higher precedence.
 #
 DHCLIENT6_UPDATE=""
+
+#
+# Type:		integer
+# Default:	""
+#
+# Permits to specify explicit prefix-length to use for the DHCPv6 address,
+# e.g. 64 to use address as 2001:db8::1/64 or 80 for 2001:db8::1/80.
+# When 0 or unspecified (default), prefix-length of the smallest on-link
+# prefix (highest /length number) in the IPv6 router advertisement matching
+# the address is used or 128 (see also rfc5942).
+#
+DHCLIENT6_ADDRESS_LENGTH=""

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -95,6 +95,7 @@ typedef struct ni_compat_netdev {
 
 		unsigned int	mode;
 		ni_bool_t	rapid_commit;
+		unsigned int	address_len;
 
 		ni_dhcp_fqdn_t  fqdn;
 		char *		hostname;

--- a/dhcp6/dbus-api.c
+++ b/dhcp6/dbus-api.c
@@ -384,6 +384,7 @@ static ni_dbus_property_t	dhcp6_request_properties[] = {
 	DHCP6REQ_UINT_PROPERTY(flags, flags, RO),
 	DHCP6REQ_UINT_PROPERTY(mode, mode, RO),
 	DHCP6REQ_BOOL_PROPERTY(rapid-commit, rapid_commit, RO),
+	DHCP6REQ_UINT_PROPERTY(address-length, address_len, RO),
 	DHCP6REQ_STRING_PROPERTY(client-id, clientid, RO),
 	//DHCP6REQ_STRING_PROPERTY(vendor-class, vendor_class, RO),
 	DHCP6REQ_UINT_PROPERTY(start-delay, start_delay, RO),

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -243,6 +243,7 @@
 
     <mode type="builtin-dhcp6-mode"/>
     <rapid-commit type="boolean"/>
+    <address-length type="uint32"/>
 
     <client-id type="string" />
     <!-- vendor-class type="string" / -->

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -892,6 +892,9 @@ ni_dhcp6_acquire(ni_dhcp6_device_t *dev, const ni_dhcp6_request_t *req, char **e
 	}
 	config->dry_run	= req->dry_run;
 
+	if (req->address_len <= ni_af_address_prefixlen(AF_INET6))
+		config->address_len = req->address_len;
+
 	ni_timer_get_time(&dev->start_time);
 	config->start_delay	= __nondefault(req->start_delay,
 					NI_DHCP6_START_DELAY);

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -67,6 +67,7 @@ struct ni_dhcp6_request {
 	ni_dhcp6_run_t		dry_run;         /* normal run or get offer/lease only	*/
 	ni_dhcp6_mode_t		mode;		 /* follow ra, request info/addr	*/
 	ni_bool_t		rapid_commit;	 /* try to use rapid commit flow	*/
+	unsigned int		address_len;	/* address prefix length to use         */
 
 	unsigned int		start_delay;	/* how long to delay start */
 	unsigned int		defer_timeout;	/* how long we try before we defer	*/
@@ -130,6 +131,7 @@ struct ni_dhcp6_config {
 	ni_dhcp6_mode_t		mode;
 	ni_dhcp6_run_t		dry_run;
 	ni_bool_t		rapid_commit;
+	unsigned int		address_len;
 
 	unsigned int		start_delay;
 	unsigned int		defer_timeout;

--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -2661,6 +2661,10 @@ ni_dhcp6_find_pinfo_prefixlen(const ni_dhcp6_device_t *dev, const ni_sockaddr_t 
 
 	pinfo = ni_dhcp6_device_ra_pinfo(dev, NULL);
 	for ( ; pinfo; pinfo = pinfo->next) {
+		/* asured on-link prefixes only */
+		if (!pinfo->on_link)
+			continue;
+
 		/* find highest matching prefix */
 		if (!ni_sockaddr_prefix_match(pinfo->length, &pinfo->prefix, addr))
 			continue;
@@ -2701,16 +2705,18 @@ ni_dhcp6_ia_copy_to_lease_addrs(const ni_dhcp6_device_t *dev, ni_addrconf_lease_
 
 			ni_sockaddr_set_ipv6(&sadr, iadr->addr, 0);
 
-			plen = ni_dhcp6_find_pinfo_prefixlen(dev, &sadr);
-			if (plen >= 4 && plen <= 128) {
-				ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
-						"%s: using RA prefix info length %u",
-						dev->ifname, plen);
-			} else {
-				plen = 64;
-				ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
-						"%s: using default prefix length %u",
-						dev->ifname, plen);
+			if (!(plen = dev->config->address_len)) {
+				plen = ni_dhcp6_find_pinfo_prefixlen(dev, &sadr);
+				if (plen >= 4 && plen <= ni_af_address_prefixlen(AF_INET6)) {
+					ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
+							"%s: using RA prefix info length %u",
+							dev->ifname, plen);
+				} else {
+					plen = ni_af_address_prefixlen(AF_INET6);
+					ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
+							"%s: using default prefix length %u",
+							dev->ifname, plen);
+				}
 			}
 
 			ap = ni_address_new(AF_INET6, plen, &sadr, &lease->addrs);


### PR DESCRIPTION
Add an address-length aka DHCLIENT6_ADDRESS_LENGTH ifcfg option, which
permits to specify explicit prefix-length to use for the DHCPv6 address,
e.g. 64 to use address as 2001:db8::1/64 or 80 for 2001:db8::1/80.
When 0 or unspecified (default), prefix-length of the smallest on-link
prefix (highest /length number) in the IPv6 router advertisement matching
the address is used or 128 (see also rfc5942).