### PR TITLE
dhcp6: set the noprefixroute address option (bsc#1132280)

### DIFF
--- a/include/wicked/address.h
+++ b/include/wicked/address.h
@@ -129,11 +129,13 @@ extern ni_bool_t	ni_address_is_temporary(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_permanent(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_deprecated(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_mngtmpaddr(const ni_address_t *laddr);
+extern ni_bool_t	ni_address_is_noprefixroute(const ni_address_t *laddr);
 
 extern void		ni_address_set_temporary(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_mngtmpaddr(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_tentative(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_duplicate(ni_address_t *, ni_bool_t);
+extern void		ni_address_set_noprefixroute(ni_address_t *, ni_bool_t);
 
 extern unsigned int	ni_address_valid_lft(const ni_address_t *, const struct timeval *);
 extern unsigned int	ni_address_preferred_lft(const ni_address_t *, const struct timeval *);

--- a/src/address.c
+++ b/src/address.c
@@ -320,6 +320,12 @@ ni_address_is_mngtmpaddr(const ni_address_t *laddr)
 }
 
 ni_bool_t
+ni_address_is_noprefixroute(const ni_address_t *laddr)
+{
+	return laddr->flags & IFA_F_NOPREFIXROUTE;
+}
+
+ni_bool_t
 ni_address_can_reach(const ni_address_t *laddr, const ni_sockaddr_t *gw)
 {
 	if (laddr->family != gw->ss_family)
@@ -363,6 +369,15 @@ ni_address_set_mngtmpaddr(ni_address_t *laddr, ni_bool_t temporary)
 		laddr->flags |= IFA_F_MANAGETEMPADDR;
 	else
 		laddr->flags &= ~IFA_F_MANAGETEMPADDR;
+}
+
+void
+ni_address_set_noprefixroute(ni_address_t *laddr, ni_bool_t noprefixroute)
+{
+	if (noprefixroute)
+		laddr->flags |= IFA_F_NOPREFIXROUTE;
+	else
+		laddr->flags &= ~IFA_F_NOPREFIXROUTE;
 }
 
 unsigned int

--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -2717,6 +2717,7 @@ ni_dhcp6_ia_copy_to_lease_addrs(const ni_dhcp6_device_t *dev, ni_addrconf_lease_
 				ap->cache_info.acquired = ia->acquired;
 				ap->cache_info.preferred_lft = iadr->preferred_lft;
 				ap->cache_info.valid_lft = iadr->valid_lft;
+				ni_address_set_noprefixroute(ap, TRUE);
 
 				ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
 						"%s: added %sDHCPv6 address %s/%u to lease",


### PR DESCRIPTION
Do not create an implicit prefix (route) by adding an address with prefix
other than 128, even when we've received an on-link RA prefix.