### PR TITLE
dhcp6: differentiated mode=auto resolving from RA (bsc#1150183)

### DIFF
--- a/include/wicked/ipv6.h
+++ b/include/wicked/ipv6.h
@@ -38,6 +38,12 @@ enum {
 	NI_IPV6_ACCEPT_DAD_FAIL_PROTOCOL=  2,
 };
 
+enum {
+	NI_IPV6_READY			= 0U,
+	NI_IPV6_RS_SENT			= 1,
+	NI_IPV6_RA_RCVD			= 2,
+};
+
 struct ni_ipv6_devconf {
 	ni_tristate_t		enabled;
 	ni_tristate_t		forwarding;
@@ -91,17 +97,24 @@ struct ni_ipv6_ra_info {
 };
 
 struct ni_ipv6_devinfo {
+	unsigned int		flags;
+
 	ni_ipv6_devconf_t	conf;
 	ni_ipv6_ra_info_t	radv;
 };
 
 extern ni_bool_t		ni_ipv6_supported(void);
-
 extern ni_ipv6_devinfo_t *	ni_netdev_get_ipv6(ni_netdev_t *);
 extern void			ni_netdev_set_ipv6(ni_netdev_t *, ni_ipv6_devconf_t *);
+extern ni_bool_t		ni_netdev_ipv6_is_ready(const ni_netdev_t *);
+extern ni_bool_t		ni_netdev_ipv6_ra_received(const ni_netdev_t *);
+extern ni_bool_t		ni_netdev_ipv6_ra_requested(const ni_netdev_t *);
 
 extern ni_ipv6_devinfo_t *	ni_ipv6_devinfo_new(void);
 extern void			ni_ipv6_devinfo_free(ni_ipv6_devinfo_t *);
+extern ni_bool_t		ni_ipv6_devinfo_is_ready(const ni_ipv6_devinfo_t *);
+extern ni_bool_t		ni_ipv6_devinfo_ra_received(const ni_ipv6_devinfo_t *);
+extern ni_bool_t		ni_ipv6_devinfo_ra_requested(const ni_ipv6_devinfo_t *);
 
 extern int			ni_system_ipv6_devinfo_get(ni_netdev_t *, ni_ipv6_devinfo_t *);
 extern int			ni_system_ipv6_devinfo_set(ni_netdev_t *, const ni_ipv6_devconf_t *);

--- a/src/dhcp6/device.h
+++ b/src/dhcp6/device.h
@@ -32,7 +32,7 @@ extern int		ni_dhcp6_device_retransmit(ni_dhcp6_device_t *);
 extern void		ni_dhcp6_device_retransmit_disarm(ni_dhcp6_device_t *);
 
 extern ni_bool_t	ni_dhcp6_device_is_ready(const ni_dhcp6_device_t *, const ni_netdev_t *);
-extern void		ni_dhcp6_device_update_mode(ni_dhcp6_device_t *, const ni_netdev_t *);
+extern ni_bool_t	ni_dhcp6_device_update_mode(ni_dhcp6_device_t *, const ni_netdev_t *);
 extern const ni_ipv6_ra_info_t  *ni_dhcp6_device_ra_info(const ni_dhcp6_device_t *, const ni_netdev_t *);
 extern const ni_ipv6_ra_pinfo_t *ni_dhcp6_device_ra_pinfo(const ni_dhcp6_device_t *, const ni_netdev_t *);
 extern int		ni_dhcp6_device_start(ni_dhcp6_device_t *);

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -66,7 +66,7 @@ struct ni_dhcp6_request {
 
 	/* Options controlling which and how to make the requests */
 	ni_dhcp6_run_t		dry_run;         /* normal run or get offer/lease only	*/
-	ni_dhcp6_mode_t		mode;		 /* follow ra, request info/addr	*/
+	unsigned int		mode;		 /* follow ra, request info/addr/prefix */
 	ni_bool_t		rapid_commit;	 /* try to use rapid commit flow	*/
 	unsigned int		address_len;	/* address prefix length to use         */
 
@@ -125,7 +125,7 @@ struct ni_dhcp6_config {
 	ni_uuid_t		uuid;
 	unsigned int		flags;
 
-	ni_dhcp6_mode_t		mode;
+	unsigned int		mode;		/* auto,info,managed,prefix mask */
 	ni_dhcp6_run_t		dry_run;
 	ni_bool_t		rapid_commit;
 	unsigned int		address_len;
@@ -186,6 +186,8 @@ struct ni_dhcp6_device {
 	} mcast;
 
 	struct timeval		start_time;	/* when we started managing     */
+	const ni_timer_t *	start_timer;	/* for ready and auto/follow-ra */
+	ni_timeout_param_t	start_params;	/* ready wait parameters        */
 	ni_dhcp6_request_t *	request;	/* the wicked request params	*/
 	ni_dhcp6_config_t *	config;		/* config built from request	*/
 	ni_addrconf_lease_t *	lease;		/* last acquired lease		*/

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -287,9 +287,13 @@ ni_dhcp6_fsm_start(ni_dhcp6_device_t *dev)
 {
 	ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
-	if (!dev->config || !dev->config->mode)
+	if (!dev || !dev->config)
 		return -1;
 
+	if (!dev->config->mode) {
+		ni_info("%s: dhcp6 disabled in device ipv6 ra info", dev->ifname);
+		return 1;       /* not (yet) enabled to start */
+	} else
 	if (dev->config->mode & NI_BIT(NI_DHCP6_MODE_AUTO)) {
 		/* this should not happen */
 		ni_warn("%s: fsm start in mode %s", dev->ifname,

--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -3201,9 +3201,6 @@ ni_dhcp6_message_xid(unsigned int header_xid)
 /*
  * ni_timeout_t settings we're using in the timing table
  */
-#define NI_DHCP6_EXP_BACKOFF	     -1 /* exponential increment type  */
-#define NI_DHCP6_UNLIMITED	     -1 /* unlimited number of retries */
-
 typedef struct ni_dhcp6_timing {
 	unsigned int		delay;
 	unsigned int		jitter;

--- a/src/dhcp6/protocol.h
+++ b/src/dhcp6/protocol.h
@@ -153,6 +153,12 @@ enum NI_DHCP6_MSG_TYPE {
 #define NI_DHCP6_IRT_MINIMUM	    600 /* minimum refresh time         */
 
 /*
+ * Timeout and backoff handling initializers
+ */
+#define NI_DHCP6_EXP_BACKOFF	     -1 /* exponential increment type  */
+#define NI_DHCP6_UNLIMITED	     -1 /* unlimited number of retries */
+
+/*
  * Option Format
  * http://tools.ietf.org/html/rfc3315#section-22.1
  */

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -153,6 +153,24 @@ ni_netdev_get_ipv6(ni_netdev_t *dev)
 	return dev->ipv6;
 }
 
+ni_bool_t
+ni_netdev_ipv6_is_ready(const ni_netdev_t *dev)
+{
+	return dev && ni_ipv6_devinfo_is_ready(dev->ipv6);
+}
+
+ni_bool_t
+ni_netdev_ipv6_ra_received(const ni_netdev_t *dev)
+{
+	return dev && ni_ipv6_devinfo_ra_received(dev->ipv6);
+}
+
+ni_bool_t
+ni_netdev_ipv6_ra_requested(const ni_netdev_t *dev)
+{
+	return dev && ni_ipv6_devinfo_ra_requested(dev->ipv6);
+}
+
 void
 ni_netdev_set_ipv6(ni_netdev_t *dev, ni_ipv6_devconf_t *conf)
 {
@@ -182,6 +200,24 @@ ni_ipv6_devinfo_free(ni_ipv6_devinfo_t *ipv6)
 	if (ipv6)
 		ni_ipv6_ra_info_reset(&ipv6->radv);
 	free(ipv6);
+}
+
+ni_bool_t
+ni_ipv6_devinfo_is_ready(const ni_ipv6_devinfo_t *ipv6)
+{
+	return ipv6 && (ipv6->flags & NI_BIT(NI_IPV6_READY));
+}
+
+ni_bool_t
+ni_ipv6_devinfo_ra_received(const ni_ipv6_devinfo_t *ipv6)
+{
+	return ipv6 && (ipv6->flags & NI_BIT(NI_IPV6_RA_RCVD));
+}
+
+ni_bool_t
+ni_ipv6_devinfo_ra_requested(const ni_ipv6_devinfo_t *ipv6)
+{
+	return ipv6 && (ipv6->flags & NI_BIT(NI_IPV6_RS_SENT));
 }
 
 /*

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -204,7 +204,18 @@ enum {
 
 #ifndef IF_RA_OTHERCONF
 #define IF_RA_OTHERCONF 0x80
+#endif
+#ifndef IF_RA_MANAGED
 #define IF_RA_MANAGED   0x40
+#endif
+#ifndef IF_RA_RCVD
+#define IF_RA_RCVD	0x20
+#endif
+#ifndef IF_RS_SENT
+#define IF_RS_SENT	0x10
+#endif
+#ifndef IF_READY
+#define IF_READY	0x80000000
 #endif
 
 #endif /* __NETINFO_KERNEL_H__ */

--- a/src/names.c
+++ b/src/names.c
@@ -482,7 +482,6 @@ failure:
 const char *
 ni_dhcp6_mode_format(ni_stringbuf_t *buff, unsigned int mask, const char *sep)
 {
-	mask = ni_dhcp6_mode_adjust(mask);
 	return ni_format_bitmap(buff, ni_dhcp6_mode_names, mask, sep ? sep : ",");
 }
 


### PR DESCRIPTION
Fixed to not trigger to report an error when ipv6 RA is not available
or the received RA disables dhcp while mode is set to auto, but to
deliver a 'deferred' results.