### PR TITLE
libwicked: fix versioning and packaging (bsc#1143182,bsc#1132977)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,20 +9,16 @@ AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip subdir-objects])
 #
 # Note: We consider libwicked as an internal helper library,
 # rather than a general purporse library with rock solid ABI.
-# The program/package version and the library version do not
-# correspond 1:1 with each other, the version is encoded.
-# We intentionally break binary compatibility at minor level.
+# We intentionally break binary compatibility at rev level.
 #
 set -- ${VERSION//./ }
 MAJ=$(($1))
 MIN=$(($2))
 REV=$(($3))
-# optional fix/patch level
-FIX=0
 
 # Calculate package (soname version) suffix for the spec file.
-AC_SUBST(LIBWICKED_PACKAGE_SUFFIX, "-${MAJ}-${MIN}")
-AC_SUBST(LIBWICKED_LTLINK_VERSION, "-release ${MAJ} -version-number ${MIN}:${REV}:${FIX}")
+AC_SUBST(LIBWICKED_PACKAGE_SUFFIX, "-${MAJ}_${MIN}_${REV}")
+AC_SUBST(LIBWICKED_LTLINK_VERSION, "-release ${MAJ}.${MIN}.${REV}")
 
 #AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/config.c])

--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -239,7 +239,7 @@ ln -sf %_sysconfdir/init.d/network ${RPM_BUILD_ROOT}%_sbindir/rcnetwork
 %if %{without wicked_devel}
 pushd $RPM_BUILD_ROOT
 rm -rfv \
-	.%_libdir/libwicked*.so \
+	.%_libdir/libwicked.so \
 	.%_datadir/pkgconfig/wicked.pc \
 	.%_mandir/man7/wicked.7* \
 	.%_includedir/wicked
@@ -437,6 +437,6 @@ fi
 
 %files -n libwicked@LIBWICKED_PACKAGE_SUFFIX@
 %defattr (-,root,root)
-%_libdir/libwicked*.so.*
+%_libdir/libwicked-*.so*
 
 %changelog

--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package wicked
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -39,7 +39,8 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  make
-Requires(pre):  libwicked@LIBWICKED_PACKAGE_SUFFIX@ = %{version}
+Provides:       libwicked@LIBWICKED_PACKAGE_SUFFIX@ = %{version}
+Obsoletes:      libwicked-0-6 <= %{version}
 
 %if 0%{?suse_version} >= 1500
 %bcond_without  rfc4361_cid
@@ -83,8 +84,8 @@ Requires(pre):       util-linux
 %endif
 
 %if %{with systemd}
-BuildRequires: systemd-devel
-BuildRequires: systemd-rpm-macros
+BuildRequires:  systemd-devel
+BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
 %if 0%{?suse_version:1}
 Requires(pre):  %fillup_prereq
@@ -163,19 +164,6 @@ interface to network configuration.
 
 This package provides the wicked development files.
 %endif
-
-%package -n     libwicked@LIBWICKED_PACKAGE_SUFFIX@
-Summary:        Network configuration infrastructure - Shared library
-Group:          System/Management
-Obsoletes:      libwicked0 < %{version}
-
-%description -n libwicked@LIBWICKED_PACKAGE_SUFFIX@
-Wicked is a network configuration infrastructure incorporating a number
-of existing frameworks into a unified architecture, providing a DBUS
-interface to network configuration.
-
-This package provides the wicked shared library.
-
 
 %prep
 %setup
@@ -297,19 +285,15 @@ fi
 
 %endif
 
-%post -n libwicked@LIBWICKED_PACKAGE_SUFFIX@
-/sbin/ldconfig
-
-%postun -n libwicked@LIBWICKED_PACKAGE_SUFFIX@
-/sbin/ldconfig
-
 %post
+/sbin/ldconfig
 %{fillup_only -dns config wicked network}
 %{fillup_only -dns dhcp wicked network}
 # reload dbus after install or upgrade to apply new policies
 /usr/bin/systemctl reload dbus.service 2>/dev/null || :
 
 %postun
+/sbin/ldconfig
 # reload dbus after uninstall, our policies are gone again
 if [ ${FIRST_ARG:-$1} -eq 0 ]; then
 	/usr/bin/systemctl reload dbus.service 2>/dev/null || :
@@ -321,6 +305,7 @@ fi
 %_sbindir/wicked
 %_sbindir/wickedd
 %_sbindir/wickedd-nanny
+%_libdir/libwicked-*.so*
 %dir %_libexecdir/%{name}
 %dir %_libexecdir/%{name}/bin
 %_libexecdir/%{name}/bin/wickedd-auto4
@@ -430,13 +415,10 @@ fi
 %defattr (-,root,root)
 %dir %_includedir/wicked
 %_includedir/wicked/*
-%_libdir/libwicked*.so
+%_libdir/libwicked.so
 %_datadir/pkgconfig/wicked.pc
 %_mandir/man7/wicked.7*
 %endif
 
-%files -n libwicked@LIBWICKED_PACKAGE_SUFFIX@
-%defattr (-,root,root)
-%_libdir/libwicked-*.so*
 
 %changelog


### PR DESCRIPTION
Summary:
  - Ship libwicked inside wicked rpm rather than as a separate sub-package
  - Prevent library versioning from causing a crash when allowing (wrongly) to use an incompatible .so