### PR TITLE
misc. bug fixes

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -1488,6 +1488,7 @@ do_check(int argc, char **argv)
 				if (opt_dbus_error_file) {
 					write_dbus_error(opt_dbus_error_file,
 							NI_DBUS_ERROR_UNRESOLVABLE_HOSTNAME,
+							"%s",
 							hostname);
 					opt_dbus_error_file = NULL;
 				}
@@ -1509,6 +1510,7 @@ do_check(int argc, char **argv)
 					if (opt_dbus_error_file) {
 						write_dbus_error(opt_dbus_error_file,
 								NI_DBUS_ERROR_UNREACHABLE_ADDRESS,
+								"%s",
 								hostname);
 						opt_dbus_error_file = NULL;
 					}

--- a/src/auto6.c
+++ b/src/auto6.c
@@ -717,7 +717,7 @@ ni_auto6_on_nduseropt_events(ni_netdev_t *dev, ni_event_t event)
 	ni_addrconf_lease_t *lease;
 	unsigned int lifetime;
 	struct timeval now;
-	ni_bool_t changed;
+	ni_bool_t changed = FALSE;
 
 	if (!dev)
 		return;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -25,7 +25,8 @@ ni_buffer_ensure_tailroom(ni_buffer_t *bp, unsigned int min_room)
 		unsigned char *new_base;
 
 		new_base = xmalloc(new_size);
-		memcpy(new_base, bp->base, bp->size);
+		if (bp->size)
+			memcpy(new_base, bp->base, bp->size);
 		bp->base = new_base;
 		bp->allocated = 1;
 	}

--- a/src/config.c
+++ b/src/config.c
@@ -1147,7 +1147,7 @@ ni_config_parse_addrconf_dhcp6_nodes(ni_config_dhcp6_t *dhcp6, xml_node_t *node)
 				int len;
 
 				/* DUID is "opaque", but has 2 bytes type + up to 128 bytes */
-				if ((len = sizeof(pref->serverid.data)) > 130)
+				if ((len = pref->serverid.len) > 130)
 					len = 130;
 
 				 /* DUID-LL has 2+2 fixed bytes + variable length hwaddress

--- a/src/dbus-objects/misc.c
+++ b/src/dbus-objects/misc.c
@@ -1058,7 +1058,7 @@ __ni_objectmodel_route_nexthop_from_dict(ni_route_nexthop_t *nh, const ni_dbus_v
 	 */
 	if (ni_dbus_dict_get(nhdict, "gateway")) {
 		if (!__ni_objectmodel_dict_get_sockaddr(nhdict, "gateway", &nh->gateway)) {
-			ni_debug_dbus("%s: invalid route hop gateway %u", __func__, value);
+			ni_debug_dbus("%s: invalid route hop gateway", __func__);
 			return FALSE;
 		}
 	}

--- a/src/dbus-xml.c
+++ b/src/dbus-xml.c
@@ -610,7 +610,7 @@ ni_dbus_serialize_xml_bitmap(const xml_node_t *node, const ni_xs_scalar_info_t *
 
 		/* May left shift past width of value if bb >= 32, but as ret
 		 * will be FALSE assignment to result will not happen. */
-		value |= 1 << bb;
+		value |= NI_BIT(bb);
 	}
 
 	ni_string_array_destroy(&bit_name_arr);

--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -1070,7 +1070,7 @@ ni_dhcp4_fsm_arp_validate(ni_dhcp4_device_t *dev)
 	if (dev->arp.handle == NULL) {
 		dev->arp.handle = ni_arp_socket_open(&dev->system,
 				ni_dhcp4_fsm_process_arp_packet, dev);
-		if (!dev->arp.handle->user_data) {
+		if (!dev->arp.handle || !dev->arp.handle->user_data) {
 			ni_error("%s: unable to create ARP handle", dev->ifname);
 			return -1;
 		}

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -3688,7 +3688,7 @@ ni_ifworker_netif_resolve_cb(xml_node_t *node, const ni_xs_type_t *type, const x
 	ni_ifworker_t *w = closure->worker;
 	ni_ifworker_t *cw = NULL;
 	xml_node_t *cwmeta = NULL;
-	ni_ifworker_type_t cwtype;
+	ni_ifworker_type_t cwtype = NI_IFWORKER_TYPE_NONE;
 	unsigned int requires = 0;
 	xml_node_t *mchild;
 

--- a/src/iaid.c
+++ b/src/iaid.c
@@ -445,7 +445,6 @@ ni_iaid_map_del_iaid(ni_iaid_map_t *map, unsigned int iaid)
 ni_bool_t
 ni_iaid_create_hwaddr(unsigned int *iaid, const ni_hwaddr_t *hwa)
 {
-	uint32_t *ptr;
 	size_t off;
 
 	if (!iaid || !hwa)
@@ -458,8 +457,8 @@ ni_iaid_create_hwaddr(unsigned int *iaid, const ni_hwaddr_t *hwa)
 		return FALSE;
 
 	off = hwa->len - sizeof(*iaid);
-	ptr = (uint32_t *)(hwa->data + off);
-	*iaid = ntohl(*ptr);
+	memcpy(iaid, hwa->data + off, sizeof(uint32_t));
+	*iaid = ntohl(*iaid);
 	return TRUE;
 }
 

--- a/src/macvlan.c
+++ b/src/macvlan.c
@@ -119,7 +119,7 @@ ni_macvlan_name_to_flag(const char *name, unsigned int *flag)
 const char *
 ni_macvlan_flag_bit_name(unsigned int bit)
 {
-	return bit < 32 ? ni_macvlan_flag_to_name(1 << bit) : NULL;
+	return bit < 32 ? ni_macvlan_flag_to_name(NI_BIT(bit)) : NULL;
 }
 
 ni_bool_t

--- a/src/names.c
+++ b/src/names.c
@@ -226,16 +226,16 @@ ni_addrconf_flag_bit_set(unsigned int *mask, unsigned int flag, ni_bool_t enable
 {
 	if (mask) {
 		if (enable)
-			*mask |=  (1U << flag);
+			*mask |=  NI_BIT(flag);
 		else
-			*mask &= ~(1U << flag);
+			*mask &= ~NI_BIT(flag);
 	}
 }
 
 ni_bool_t
 ni_addrconf_flag_bit_is_set(unsigned int flags, unsigned int flag)
 {
-	return flags & (1 << flag);
+	return flags & NI_BIT(flag);
 }
 
 const char *
@@ -288,9 +288,9 @@ ni_addrconf_update_set(unsigned int *mask, unsigned int flag, ni_bool_t enable)
 {
 	if (mask) {
 		if (enable)
-			*mask |= (1 << flag);
+			*mask |= NI_BIT(flag);
 		else
-			*mask &= ~(1 << flag);
+			*mask &= ~NI_BIT(flag);
 	}
 }
 
@@ -690,7 +690,7 @@ ni_linkflags_bit_to_name(unsigned int bit)
 {
 	if (bit >= 32)
 		return NULL;
-	return ni_format_uint_mapped(1 << bit, __ni_linkifflag_names);
+	return ni_format_uint_mapped(NI_BIT(bit), __ni_linkifflag_names);
 }
 
 const char *

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -122,7 +122,7 @@ extern int		__ni_wireless_link_event(ni_netconfig_t *, ni_netdev_t *, void *, si
 
 static inline ni_bool_t	__ni_addrconf_should_update(unsigned int mask, unsigned int bit)
 {
-	return !!(mask & (1 << bit));
+	return !!(mask & NI_BIT(bit));
 }
 
 /*

--- a/src/process.c
+++ b/src/process.c
@@ -402,7 +402,7 @@ __ni_process_run_info(ni_process_t *pi)
 				pi->pid, pi->process->command, rv, runtime);
 		return rv;
 	} else
-	if ((rv = ni_process_signaled(pi)) != NI_PROCESS_FAILURE) {
+	if ((rv = ni_process_term_signal(pi)) != NI_PROCESS_FAILURE) {
 		ni_debug_extension("subprocess %d (%s) died with signal %d%s%s",
 				pi->pid, pi->process->command, rv,
 				ni_process_core_dumped(pi) ? " (core dumped)" : "",

--- a/src/route.c
+++ b/src/route.c
@@ -2197,7 +2197,7 @@ ni_rule_print(ni_stringbuf_t *out, const ni_rule_t *rule)
 		ni_stringbuf_printf(out, " pref auto");
 
 	if (rule->flags & NI_BIT(NI_RULE_INVERT))
-		ni_stringbuf_printf(out, " not", rule->pref);
+		ni_stringbuf_printf(out, " not");
 
 	if (rule->src.len)
 		ni_stringbuf_printf(out, " from %s/%u",

--- a/src/timer.c
+++ b/src/timer.c
@@ -52,9 +52,9 @@ ni_timer_cancel(const ni_timer_t *handle)
 
 	if ((timer = __ni_timer_disarm(handle)) != NULL) {
 		user_data = timer->user_data;
-		free(timer);
 		ni_debug_verbose(NI_LOG_DEBUG2, NI_TRACE_TIMER,
 				"%s: released timer %p", __func__, timer);
+		free(timer);
 	} else {
 		ni_debug_verbose(NI_LOG_DEBUG2, NI_TRACE_TIMER,
 				"%s: timer %p NOT found", __func__, handle);

--- a/src/update.c
+++ b/src/update.c
@@ -1528,7 +1528,7 @@ ni_system_updater_hostname_lookup_call(ni_updater_t *updater, ni_updater_job_t *
 				ni_addrconf_type_to_name(job->lease->type),
 				ni_addrconf_state_to_name(job->lease->state),
 				ni_updater_name(job->kind),
-				ni_basename(shellcmd->command), pi->pid);
+				ni_basename(pi->process->command), pi->pid);
 	} else {
 		ni_process_free(pi);
 	}

--- a/src/util.c
+++ b/src/util.c
@@ -1030,7 +1030,7 @@ ni_bitfield_setbit(ni_bitfield_t *bf, unsigned int bit)
 {
 	if (!bf || !ni_bitfield_grow(bf, bit))
 		return FALSE;
-	bf->field[bit / 32] |= (1 << (bit % 32));
+	bf->field[bit / 32] |= NI_BIT(bit % 32u);
 	return TRUE;
 }
 
@@ -1039,7 +1039,7 @@ ni_bitfield_clearbit(ni_bitfield_t *bf, unsigned int bit)
 {
 	if (!bf || !ni_bitfield_grow(bf, bit))
 		return FALSE;
-	bf->field[bit / 32] &= ~(1 << (bit % 32));
+	bf->field[bit / 32] &= ~NI_BIT(bit % 32u);
 	return TRUE;
 }
 
@@ -1057,7 +1057,7 @@ ni_bitfield_testbit(const ni_bitfield_t *bf, unsigned int bit)
 {
 	if (!bf || bit / 32 >= bf->size)
 		return FALSE;
-	return !!(bf->field[bit / 32] & (1 << (bit % 32)));
+	return !!(bf->field[bit / 32] & NI_BIT(bit % 32u));
 }
 
 ni_bool_t
@@ -2032,7 +2032,7 @@ ni_format_bitmap(ni_stringbuf_t *buf, const ni_intmap_t *map,
 		sep = "|";
 
 	for (i = 0; map->name; ++map) {
-		flag = (1 << map->value);
+		flag = NI_BIT(map->value);
 		if (flags & flag) {
 			flags &= ~flag;
 			if (i++)


### PR DESCRIPTION
Fix a bunch of issues found through fuzzing and static analysis. Most should be self-explanatory.

The UAFs may sound bad at first, but can't be triggered by attackers according to my best judgement.

The weirder things are probably the fixes for undefined behavior: the standard is quite stupid there, but `memcpy` may not be called with a `NULL` parameter even if the length is `0`.

The most controversial change are probably those about alignment. I believe they are correct because the buffer API gives no alignment guarantees. However, in my fuzzer I initialized these buffers with memory that wasn't aligned to those types. It's quite possible that the buffers used by the actual network code are aligned in practice (thanks to malloc's alignment guarantees). If only for robustness reasons, I think these changes still make sense.