### PR TITLE
Packaging: BuildRequire pkgconfig(libsystemd) instead of systemd-devel

### DIFF
--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -84,7 +84,7 @@ Requires(pre):       util-linux
 %endif
 
 %if %{with systemd}
-BuildRequires:  systemd-devel
+BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
 %if 0%{?suse_version:1}


### PR DESCRIPTION
On OBS/openSUSE this has the positive side-effect of using the -mini
flavors, meaning we can move up in fhe build queue and not be
blocked behind the 'full featured systemd package'. There is no
difference for the consumers.