### PR TITLE
Fixes for startup order with systemd

### DIFF
--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked AutoIPv4 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked DHCPv4 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked DHCPv6 supplicant service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service
+After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=wicked network nanny service
 Requisite=dbus.service
-After=local-fs.target dbus.service SuSEfirewall2_init.service wickedd.service
+After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service wickedd.service
 Before=wicked.service network.target
 PartOf=wickedd.service
 

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -2,7 +2,7 @@
 Description=wicked network management service daemon
 Requisite=dbus.service
 Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service systemd-udev-settle.service
-After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service systemd-udev-settle.service
+After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service systemd-udev-settle.service openvswitch.service
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -2,7 +2,7 @@
 Description=wicked network management service daemon
 Requisite=dbus.service
 Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service systemd-udev-settle.service
-After=local-fs.target dbus.service isdn.service rdma.service SuSEfirewall2_init.service systemd-udev-settle.service openvswitch.service
+After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service systemd-udev-settle.service openvswitch.service
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]


### PR DESCRIPTION
Order wickedd After Open vSwitch on startup

Otherwise these are treading on each other while bringing up interfaces
which results in failures. Ordering Open vSwitch Before network.service
isn't suficient as wickedd and wickedd-nanny may start before that.

Fixes #822

---

Order After network-pre on startup

Add network-pre.target where ordering is already After
SuSEfirewall2_init.service.

SuSEfirewall2_init.service is also missing a Before on network-pre.
After that is done in SuSEfirewall2 it can be removed here.

Quote about network-pre from man systemd.special:
This passive target unit may be pulled in by services that want to run
before any network is set up, for example for the purpose of setting up
a firewall. All network management software orders itself after this
target, but does not pull it in.

