### PR TITLE
schema: change rto_min key to avoid not applying it (bsc#1160939)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1801,7 +1801,7 @@ __ni_compat_generate_static_route_metrics(xml_node_t *mnode, const ni_route_t *r
 		xml_node_new_element("features", mnode, ni_sprint_uint(rp->features));
 	}
 	if (rp->rto_min > 0) {
-		xml_node_new_element("rto-min", mnode, ni_sprint_uint(rp->rto_min));
+		xml_node_new_element("rto_min", mnode, ni_sprint_uint(rp->rto_min));
 	}
 	if (rp->initrwnd > 0) {
 		xml_node_new_element("initrwnd", mnode, ni_sprint_uint(rp->initrwnd));
@@ -3071,4 +3071,3 @@ ni_compat_generate_policies(xml_document_array_t *array, ni_compat_ifconfig_t *i
 
 	return count - array->count;
 }
-

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -602,6 +602,43 @@ __ni_suse_parse_route_hops(ni_route_nexthop_t *nh, ni_string_array_t *opts,
 }
 
 int
+ni_suse_route_parse_time(const char *input, unsigned int *result)
+{
+        static const ni_intmap_t        time_map[] = {
+                { "msecs",              0               },
+                { "msec",               0               },
+                { "ms",                 0               },
+                { "secs",               1000            },
+                { "sec",                1000            },
+                { "s",                  1000            },
+                { NULL,                 0               }
+        };
+        unsigned int factor = 0;
+        unsigned long value;
+        char *end = NULL;
+
+        if (!result || !input || !*input || *input == '-') {
+                errno = EINVAL;
+                return -1;
+        }
+
+        errno = 0;
+        value = strtoul(input, (char **) &end, 10);
+        if (errno)
+                return -1;
+        if (*end && ni_parse_uint_mapped(end, time_map, &factor) < 0) {
+                errno = EINVAL;
+                return -1;
+        }
+
+        if (factor)
+                value *= factor;
+
+        *result = value;
+        return 0;
+}
+
+int
 __ni_suse_route_parse_opts(ni_route_t *rp, ni_string_array_t *opts,
 				unsigned int *pos, const char *ifname,
 				const char *filename, unsigned int line)
@@ -701,7 +738,7 @@ __ni_suse_route_parse_opts(ni_route_t *rp, ni_string_array_t *opts,
 					return -1;
 				val = ni_string_array_at(opts, (*pos)++);
 			}
-			if (ni_parse_uint(val, &tmp, 10) < 0)
+			if (ni_suse_route_parse_time(val, &tmp) < 0)
 				return -1;
 			rp->rtt = tmp;
 		} else
@@ -712,7 +749,7 @@ __ni_suse_route_parse_opts(ni_route_t *rp, ni_string_array_t *opts,
 					return -1;
 				val = ni_string_array_at(opts, (*pos)++);
 			}
-			if (ni_parse_uint(val, &tmp, 10) < 0)
+			if (ni_suse_route_parse_time(val, &tmp) < 0)
 				return -1;
 			rp->rttvar = tmp;
 		} else
@@ -802,7 +839,7 @@ __ni_suse_route_parse_opts(ni_route_t *rp, ni_string_array_t *opts,
 					return -1;
 				val = ni_string_array_at(opts, (*pos)++);
 			}
-			if (ni_parse_uint(val, &tmp, 10) < 0)
+			if (ni_suse_route_parse_time(val, &tmp) < 0)
 				return -1;
 			rp->rto_min = tmp;
 		} else

--- a/schema/interface.xml
+++ b/schema/interface.xml
@@ -65,7 +65,7 @@
      <hoplimit   type="uint32" />
      <initcwnd   type="uint32" />
      <features   type="uint32" />
-     <rto-min    type="uint32" />
+     <rto_min    type="uint32" />
      <initrwnd   type="uint32" />
    </metrics>
 


### PR DESCRIPTION
Two issues prevent the `rto_min` value from being applied on a route when following the `ip route` syntax, e.g.:

`ip route add 172.22.151.0/24 via 172.22.99.3 dev enp1s0 rto_min 20ms`

which in our `ifroute-xxx` syntax means:
```
localhost:~ # cat /etc/sysconfig/network/ifroute-enp8s0 
default	172.22.100.1	-	-	rto_min 20ms
```

1) we expect `rto_min` value to be an int, so the `ms` (as in the default `ip` syntax) causes that it doesn't get read correctly.

2) when it is just the numeric value, we parse it and store it in our schema as `rto-min`. In our dbus layer, before sending it to the kernel, we instead attempt to load `rto_min`, resulting in the setting never being applied.

This PR fixes the latter.