### PR TITLE
utils: don't reject NULL var array names/keys

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -652,7 +652,7 @@ ni_var_array_insert(ni_var_array_t *nva, unsigned int pos, const char *name, con
 {
 	ni_var_t *var, tmp = NI_VAR_INIT;
 
-	if (!nva || !name)
+	if (!nva)
 		return FALSE;
 
 	if (!ni_var_set(&tmp, name, value))
@@ -857,7 +857,7 @@ ni_var_array_set(ni_var_array_t *nva, const char *name, const char *value)
 {
 	ni_var_t *var;
 
-	if (!nva || !name)
+	if (!nva)
 		return FALSE;
 
 	if ((var = ni_var_array_get(nva, name))) {


### PR DESCRIPTION
The change to reject NULL var array names in wicked-0.6.61 (commit bfb763c) caused a  regression with default duid map file handling, e.g. `wicked duid dump` does not show the default duid any more.