### PR TITLE
Introduce .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = tab
+indent_size = 8
+
+[**{.xml.in,.xml,.conf}]
+indent_style = space
+indent_size = 2
+
+[man/*.{0..9}.in]
+indent_style = space
+indent_size = 3
+
+[man/*.{0..9}]
+indent_style = space
+indent_size = 3
+
+[doc/schema/*.html]
+indent_style = space
+indent_size = 1
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.diff
 *.patch
 .*
+!.editorconfig
 compile
 core
 cscope.*


### PR DESCRIPTION
Convenient way to have project based editor config, see http://EditorConfig.org

I walked through the project and tried to identify the most common used
ways for different file types.

Following four types:

  * xml and .conf files
    => 2 spaces
  * manpages
    => 3 spaces
  * doc/html
    => 1 space
  * all others
    => tab with 8