### PR TITLE
gitlab-ci: load external templates for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,3 @@
+include:
+  - project: 'wicked-maintainers/wicked-ci'
+    file: '/wicked-ci.yml'


### PR DESCRIPTION
Add .gitlab-ci.yml file for GitLab CI automation through includes. This should have no effect on our GitHub repo.