### PR TITLE
Don't block network.target with wicked (boo#1172684)

### DIFF
--- a/etc/systemd/wicked.service.in
+++ b/etc/systemd/wicked.service.in
@@ -2,7 +2,7 @@
 Description=wicked managed network interfaces
 Wants=network.target wickedd.service wickedd-nanny.service
 After=network-pre.target wickedd.service wickedd-nanny.service
-Before=network-online.target network.target
+Before=network-online.target
 
 [Service]
 Type=oneshot
@@ -15,6 +15,4 @@ ExecReload=@wicked_sbindir@/wicked --systemd ifreload all
 
 [Install]
 WantedBy=multi-user.target network-online.target
-Alias=network.service
 Also=wickedd.service
-

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service systemd-udev-settle.service
-After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service systemd-udev-settle.service openvswitch.service
-Before=wickedd-nanny.service wicked.service network.target
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service
+After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service
+Before=wickedd-nanny.service network.target
 
 [Service]
 Type=notify
@@ -18,3 +18,4 @@ Also=wickedd-nanny.service
 Also=wickedd-auto4.service
 Also=wickedd-dhcp4.service
 Also=wickedd-dhcp6.service
+Alias=network.service


### PR DESCRIPTION
network.target is meant to activate networking daemons but not block
waiting for interfaces to come up. That's what network-online.target
is for. So adjust service files to hook wickedd.service into
network.target and wicked.service into network-online.target.