### PR TITLE
teamd: fix schema to use correct hwaddr_policy property (boo#1171234)

### DIFF
--- a/schema/team.xml
+++ b/schema/team.xml
@@ -15,7 +15,7 @@
   </define>
 
   <define name="activebackup-runner" class="dict">
-    <hwaddr-policy     type="builtin-team-ab-hwaddr-policy" />
+    <hwaddr_policy     type="builtin-team-ab-hwaddr-policy" />
   </define>
 
   <define name="loadbalance-runner" class="dict">


### PR DESCRIPTION
Schema defines that `hwaddr-policy` is where we store `TEAM_AB_HWADDR_POLICY` but client/compat.c is using `hwaddr_policy` instead, resulting in:

`"wickedd-nanny[710]: ni_dbus_serialize_xml_dict: ignoring unknown dict element "hwaddr_policy"`

This PR fixes the schema to use hwaddr_policy as in src/dbus-objects/team.c, client/compat.c and teamd.conf(5).