### PR TITLE
dhcp4: add DHCLIENT_CREATE_CID to ifcfg (jsc#SLE-15770)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -2236,6 +2236,9 @@ __ni_compat_generate_dhcp4_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 
 	if (compat->dhcp4.client_id)
 		xml_node_dict_set(dhcp, "client-id", compat->dhcp4.client_id);
+	else
+	if (compat->dhcp4.create_cid)
+		xml_node_dict_set(dhcp, "create-cid", ni_config_dhcp4_cid_type_format(compat->dhcp4.create_cid));
 	if (compat->dhcp4.vendor_class)
 		xml_node_dict_set(dhcp, "vendor-class", compat->dhcp4.vendor_class);
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5262,6 +5262,13 @@ __ni_suse_addrconf_dhcp4_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_CLIENT_ID")) != NULL)
 		ni_string_dup(&compat->dhcp4.client_id, string);
+	else
+	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_CREATE_CID")) != NULL) {
+		if (!ni_config_dhcp4_cid_type_parse(&compat->dhcp4.create_cid, string))
+			ni_warn("%s: Cannot parse DHCLIENT_CREATE_CID='%s' option",
+					ni_basename(sc->pathname),
+					ni_print_suspect(string, ni_string_len(string)));
+	}
 
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_VENDOR_CLASS_ID")) != NULL)
 		ni_string_dup(&compat->dhcp4.vendor_class, string);

--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -67,6 +67,15 @@ DHCLIENT_UPDATE=""
 #
 DHCLIENT_BROADCAST=""
 
+## Type:        list(,rfc4361,dhcpv6,dhcp6,rfc2132,hwaddr,none,disable)
+#
+# Overrides the DHCPv4 client-identifier type to use specified in the
+# wicked-config(5) `create-cid` option, the interface type specific
+# client-id type and compile time defaults.
+# Note: e.g. DHCP over Infiniband (IPoIB) mandates an rfc4361 client-id.
+#
+DHCLIENT_CREATE_CID=""
+
 ## Type:        list(enabled,disabled,default,)
 ## Default:     ""
 #

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -68,6 +68,7 @@ typedef struct ni_compat_netdev {
 		ni_dhcp_fqdn_t  fqdn;
 		char *		hostname;
 		char *		client_id;
+		unsigned int	create_cid;
 		char *		vendor_class;
 		ni_dhcp4_user_class_t user_class;
 

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -466,6 +466,7 @@ static ni_dbus_property_t	dhcp4_request_properties[] = {
 	DHCP4REQ_UUID_PROPERTY(uuid, uuid, RO),
 	DHCP4REQ_UINT_PROPERTY(flags, flags, RO),
 	DHCP4REQ_STRING_PROPERTY(client-id, clientid, RO),
+	DHCP4REQ_UINT_PROPERTY(create-cid, create_cid, RO),
 	DHCP4REQ_STRING_PROPERTY(vendor-class, vendor_class, RO),
 	DHCP4REQ_DICT_PROPERTY(user-class, user_class, RO),
 	DHCP4REQ_UINT_PROPERTY(start-delay, start_delay, RO),

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -74,6 +74,12 @@ This option allows to set a metric/priority for DHCPv4 routes. Default is 0.
 .BR DHCLIENT_CLIENT_ID
 Specifies a client identifier string. By default an id derived from the
 hardware address of the network interface is sent as client identifier.
+.TP
+.BR DHCLIENT_CREATE_CID\ { | rfc4361 | dhcpv6 | dhcp6 | rfc2132 | hwaddr | none | disable }
+Overrides the DHCPv4 client-identifier type to use specified in the
+wicked-config(5) `create-cid` option, the interface type specific
+client-id type and compile time defaults.
+Note: e.g. DHCP over Infiniband (IPoIB) mandates an rfc4361 client-id.
 .\" .TP
 .\" .BR DHCLIENT_VENDOR_CLASS_ID
 .\" Specifies the vendor class identifier string. The default is DHCP client

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -178,6 +178,15 @@
     <flags type="builtin-addrconf-flags" />
 
     <client-id type="string" />
+    <create-cid type="uint32" constraint="enum">
+      <rfc2132  value="1"/>
+      <hwaddr   value="1"/>
+      <rfc4361  value="2"/>
+      <dhcpv6   value="2"/>
+      <dhcp6    value="2"/>
+      <disable  value="3"/>
+      <none     value="3"/>
+    </create-cid>
     <vendor-class type="string" />
     <user-class class="dict">
       <format type="uint32" constraint="enum">

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -102,7 +102,8 @@ typedef enum {
 } ni_config_dhcp4_routes_t;
 
 typedef enum {
-	NI_CONFIG_DHCP4_CID_TYPE_HWADDR = 1U,
+	NI_CONFIG_DHCP4_CID_TYPE_AUTO = 0U,
+	NI_CONFIG_DHCP4_CID_TYPE_HWADDR,
 	NI_CONFIG_DHCP4_CID_TYPE_DHCPv6,
 	NI_CONFIG_DHCP4_CID_TYPE_DISABLE,
 } ni_config_dhcp4_cid_type_t;
@@ -209,6 +210,8 @@ extern unsigned int	ni_config_addrconf_update(const char *, ni_addrconf_mode_t, 
 extern ni_bool_t	ni_config_use_nanny(void);
 
 extern const ni_config_dhcp4_t *	ni_config_dhcp4_find_device(const char *);
+extern const char *			ni_config_dhcp4_cid_type_format(ni_config_dhcp4_cid_type_t);
+extern ni_bool_t			ni_config_dhcp4_cid_type_parse(ni_config_dhcp4_cid_type_t *, const char *);
 extern const ni_config_dhcp6_t *	ni_config_dhcp6_find_device(const char *);
 
 extern ni_config_bonding_ctl_t	ni_config_bonding_ctl(void);

--- a/src/config.c
+++ b/src/config.c
@@ -509,13 +509,18 @@ static const ni_intmap_t	config_dhcp6_cid_type_names[] = {
 	{ "disable",		NI_CONFIG_DHCP4_CID_TYPE_DISABLE},
 	{ "none",		NI_CONFIG_DHCP4_CID_TYPE_DISABLE},
 
-	{ NULL,			-1U				}
+	{ NULL,			NI_CONFIG_DHCP4_CID_TYPE_AUTO	}
 };
 
-static ni_bool_t
+const char *
+ni_config_dhcp4_cid_type_format(ni_config_dhcp4_cid_type_t type)
+{
+	return ni_format_uint_mapped(type, config_dhcp6_cid_type_names);
+}
+ni_bool_t
 ni_config_dhcp4_cid_type_parse(ni_config_dhcp4_cid_type_t *type, const char *name)
 {
-	return ni_parse_uint_mapped(name, config_dhcp6_cid_type_names, type);
+	return ni_parse_uint_mapped(name, config_dhcp6_cid_type_names, type) == 0;
 }
 
 static ni_bool_t

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -146,6 +146,7 @@ struct ni_dhcp4_request {
 
 	/* Options controlling what to put into the lease request */
 	char *			clientid;
+	unsigned int		create_cid;
 	char *			vendor_class;
 	ni_dhcp4_user_class_t	user_class;
 
@@ -261,7 +262,7 @@ extern void		ni_dhcp4_device_retransmit(ni_dhcp4_device_t *);
 extern void		ni_dhcp4_device_force_retransmit(ni_dhcp4_device_t *, unsigned int);
 extern void		ni_dhcp4_device_arp_close(ni_dhcp4_device_t *);
 extern ni_bool_t	ni_dhcp4_parse_client_id(ni_opaque_t *, unsigned short, const char *);
-extern ni_bool_t	ni_dhcp4_set_config_client_id(ni_opaque_t *, const ni_dhcp4_device_t *);
+extern ni_bool_t	ni_dhcp4_set_config_client_id(ni_opaque_t *, const ni_dhcp4_device_t *, unsigned int);
 extern void		ni_dhcp4_new_xid(ni_dhcp4_device_t *);
 extern void		ni_dhcp4_device_set_best_offer(ni_dhcp4_device_t *, ni_addrconf_lease_t *, int);
 extern void		ni_dhcp4_device_drop_best_offer(ni_dhcp4_device_t *);

--- a/src/dhcp4/tester.c
+++ b/src/dhcp4/tester.c
@@ -185,7 +185,7 @@ ni_dhcp4_tester_req_xml_init(ni_dhcp4_request_t *req, xml_document_t *doc)
 				}
 			}
 		} else
-		if (ni_string_eq(child->name, "clientid")) {
+		if (ni_string_eq(child->name, "client-id")) {
 			ni_opaque_t duid;
 
 			if (ni_parse_hex(child->cdata, duid.data, sizeof(duid.data)) <= 0)

--- a/src/dhcp4/tester.c
+++ b/src/dhcp4/tester.c
@@ -192,6 +192,10 @@ ni_dhcp4_tester_req_xml_init(ni_dhcp4_request_t *req, xml_document_t *doc)
 				goto failure;
 			ni_string_dup(&req->clientid, child->cdata);
 		} else
+		if (ni_string_eq(child->name, "create-cid")) {
+			if (!ni_config_dhcp4_cid_type_parse(&req->create_cid, child->cdata))
+				goto failure;
+		} else
 		if(ni_string_eq(child->name, "start-delay")) {
 			if (ni_parse_uint(child->cdata, &req->start_delay, 10) != 0)
 				goto failure;

--- a/src/dhcp6/tester.c
+++ b/src/dhcp6/tester.c
@@ -226,7 +226,7 @@ ni_dhcp6_tester_req_xml_init(ni_dhcp6_request_t *req, xml_document_t *doc)
 				}
 			}
 		} else
-		if (ni_string_eq(child->name, "clientid")) {
+		if (ni_string_eq(child->name, "client-id")) {
 			ni_opaque_t duid;
 
 			ni_duid_clear(&duid);


### PR DESCRIPTION
Overrides the DHCPv4 client-identifier type to use specified in the
wicked-config(5) `create-cid` option, the interface type specific
client-id type and compile time defaults.
Note: DHCP over Infiniband (IPoIB) mandates an rfc4361 client-id.