### PR TITLE
Avoid incomplete ifdown/timeout on route deletion error (bsc#1174099)

### DIFF
--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -4821,6 +4821,7 @@ __ni_rtnl_send_delroute(ni_netdev_t *dev, ni_route_t *rp)
 	ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 	struct rtmsg rt;
 	struct nl_msg *msg;
+	int err;
 
 	ni_debug_ifconfig("%s(%s)", __FUNCTION__, ni_route_print(&buf, rp));
 	ni_stringbuf_destroy(&buf);
@@ -4850,8 +4851,10 @@ __ni_rtnl_send_delroute(ni_netdev_t *dev, ni_route_t *rp)
 
 	NLA_PUT_U32(msg, RTA_OIF, dev->link.ifindex);
 
-	if (ni_nl_talk(msg, NULL) < 0) {
-		ni_error("%s(%s): rtnl_talk failed", __FUNCTION__, ni_route_print(&buf, rp));
+	if ((err = ni_nl_talk(msg, NULL)) < 0) {
+		ni_error("%s(%s): rtnl_talk failed[%d]: %s", __func__,
+				ni_route_print(&buf, rp),
+				err, nl_geterror(err));
 		ni_stringbuf_destroy(&buf);
 		goto failed;
 	}
@@ -5674,8 +5677,9 @@ __ni_netdev_update_routes(ni_netconfig_t *nc, ni_netdev_t *dev,
 					dev->name, ni_route_print(&buf, rp));
 			ni_stringbuf_destroy(&buf);
 
-			if ((rv = __ni_rtnl_send_delroute(dev, rp)) < 0)
-				return rv;
+			if ((__ni_rtnl_send_delroute(dev, rp)) < 0) {
+				continue;
+			}
 		}
 	}
 


### PR DESCRIPTION
This MR bsc#1174099 by allowing an ifdown to continue when the route marked for deletion was already deleted.