### PR TITLE
client: add short options to actions (jsc#SLE-10403)

### DIFF
--- a/client/arputil.c
+++ b/client/arputil.c
@@ -272,7 +272,11 @@ static int
 do_arp_verify_run(struct arp_handle *handle, const char *caller, int argc, char **argv)
 {
 	enum {
-		OPT_QUIET, OPT_VERBOSE, OPT_HELP, OPT_INTERVAL, OPT_COUNT,
+		OPT_QUIET	= 'q',
+		OPT_VERBOSE	= 'v',
+		OPT_HELP	= 'h',
+		OPT_INTERVAL	= 'I',
+		OPT_COUNT	= 'C',
 	};
 	static struct option      options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
@@ -298,7 +302,7 @@ do_arp_verify_run(struct arp_handle *handle, const char *caller, int argc, char 
 
 	optind = 1;
 	ni_assert(handle && handle->ops);
-	while ((opt = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+hqvC:I:", options, NULL)) != EOF) {
 		switch (opt) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -310,17 +314,17 @@ do_arp_verify_run(struct arp_handle *handle, const char *caller, int argc, char 
 				"  %s [options ...] <ifname> <IP address>\n"
 				"\n"
 				"Supported options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Return exit status only\n"
-				"  --verbose\n"
+				"  --verbose, -v\n"
 				"      Show a result info (default)\n"
 				"\n"
-				"  --count <count>\n"
+				"  --count, -C <count>\n"
 				"      Send <count> duplicate address detection probes\n"
 				"      (default: 3). Returns 4 when address is in use.\n"
-				"  --interval <msec>\n"
+				"  --interval, -I <msec>\n"
 				"      DAD probing packet sending interval in msec\n"
 				"      (default: 1000..2000).\n"
 				, argv[0]
@@ -521,7 +525,11 @@ static int
 do_arp_notify_run(struct arp_handle *handle, const char *caller, int argc, char **argv)
 {
 	enum {
-		OPT_QUIET, OPT_VERBOSE, OPT_HELP, OPT_INTERVAL, OPT_COUNT,
+		OPT_QUIET	= 'q',
+		OPT_VERBOSE	= 'v',
+		OPT_HELP	= 'h',
+		OPT_INTERVAL	= 'I',
+		OPT_COUNT	= 'C',
 	};
 	static struct option      options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
@@ -547,7 +555,7 @@ do_arp_notify_run(struct arp_handle *handle, const char *caller, int argc, char 
 
 	optind = 1;
 	ni_assert(handle && handle->ops);
-	while ((opt = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+hqvC:I:", options, NULL)) != EOF) {
 		switch (opt) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -559,17 +567,17 @@ do_arp_notify_run(struct arp_handle *handle, const char *caller, int argc, char 
 				"  %s [options ...] <ifname> <IP address>\n"
 				"\n"
 				"Supported options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Return exit status only\n"
-				"  --verbose\n"
+				"  --verbose, -v\n"
 				"      Show a result info (default)\n"
 				"\n"
-				"  --count <count>\n"
+				"  --count, -C <count>\n"
 				"      Announce IP address use (gratuitous ARP) <count> times\n"
 				"      (default: 2).\n"
-				"  --interval <msec>\n"
+				"  --interval, -I <msec>\n"
 				"      Announcement packet sending interval in msec\n"
 				"      (default: 2000).\n"
 				, argv[0]
@@ -696,8 +704,14 @@ static int
 do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **argv)
 {
 	enum {
-		OPT_QUIET, OPT_VERBOSE, OPT_HELP, OPT_INTERVAL, OPT_COUNT,
-		OPT_TIMEOUT, OPT_REPLIES, OPT_FROM_IP
+		OPT_QUIET	= 'q',
+		OPT_VERBOSE	= 'v',
+		OPT_HELP	= 'h',
+		OPT_INTERVAL	= 'I',
+		OPT_COUNT	= 'C',
+		OPT_TIMEOUT	= 't',
+		OPT_REPLIES	= 'r',
+		OPT_FROM_IP	= 'f',
 	};
 	static struct option      options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
@@ -727,7 +741,7 @@ do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **
 
 	optind = 1;
 	ni_assert(handle && handle->ops);
-	while ((opt = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+hqvC:I:t:", options, NULL)) != EOF) {
 		switch (opt) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -739,22 +753,22 @@ do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **
 				"  %s [options ...] <ifname> <IP address>\n"
 				"\n"
 				"Supported options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Return exit status only\n"
-				"  --verbose\n"
+				"  --verbose, -v\n"
 				"      Show a result info (default)\n"
 				"\n"
-				"  --count <count> | inf\n"
+				"  --count, -C <count> | inf\n"
 				"      Ping specified IP address <count> times\n"
 				"      (default: infinite).\n"
-				"  --interval <msec>\n"
+				"  --interval, -I <msec>\n"
 				"      Packet sending interval in msec\n"
 				"      (default: 1000).\n"
 				"  --replies <count>\n"
 				"      Wait unitil specified number of ping replies\n"
-				"  --timeout <msec>\n"
+				"  --timeout, -t <msec>\n"
 				"      Wait for ping replies until given timeout in msec\n"
 				"  --from-ip <source ip>\n"
 				"      Use specified IP address as the ping source\n"
@@ -1046,8 +1060,12 @@ int
 ni_do_arp(const char *caller, int argc, char **argv)
 {
 	enum {
-		OPT_QUIET, OPT_VERBOSE, OPT_HELP, OPT_INTERVAL,
-		OPT_VERIFY, OPT_NOTIFY,
+		OPT_QUIET	= 'q',
+		OPT_VERBOSE	= 'v',
+		OPT_HELP	= 'h',
+		OPT_INTERVAL	= 'I',
+		OPT_VERIFY	= 'V',
+		OPT_NOTIFY	= 'N',
 	};
 	static struct option      options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
@@ -1071,7 +1089,7 @@ ni_do_arp(const char *caller, int argc, char **argv)
 
 	if (ni_string_printf(&command, "%s %s",
 				caller  ? caller  : "wicked",
-				argv[0] ? argv[0] : "duid")) {
+				argv[0] ? argv[0] : "arp")) {
 		caller  = argv[0];
 		argv[0] = command;
 	} else {
@@ -1079,7 +1097,7 @@ ni_do_arp(const char *caller, int argc, char **argv)
 	}
 
 	optind = 1;
-	while ((opt = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "+hqvV:N:I:", options, NULL)) != EOF) {
 		switch (opt) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -1091,11 +1109,11 @@ ni_do_arp(const char *caller, int argc, char **argv)
 				"  %s [options] <action> [action options] <ifname> <IP address>\n"
 				"\n"
 				"Common options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Return exit status only\n"
-				"  --verbose\n"
+				"  --verbose, -v\n"
 				"      Show a result info (default)\n"
 				"\n"
 				"Deprecated options:\n"
@@ -1223,4 +1241,3 @@ cleanup:
 	ni_string_free(&command);
 	return status;
 }
-

--- a/client/convert.c
+++ b/client/convert.c
@@ -315,11 +315,11 @@ ni_wicked_convert(const char *caller, int argc, char **argv)
 				"%s [options] [<ifname ...>|all]\n"
 				"\n"
 				"Options:\n"
-				"  --help, -h		show this help text and exit.\n"
+				"  --help, -h			show this help text and exit.\n"
 				"\n"
-				"  --ifconfig <path>	read config from the specified sources\n"
-				"  --output   <path>	write output to specified file or directory\n"
-				"  --raw		do not display <client-state> tags\n"
+				"  --ifconfig, -i <path>	read config from the specified sources\n"
+				"  --output, -o   <path>	write output to specified file or directory\n"
+				"  --raw, -R			do not display <client-state> tags\n"
 				"\n", program);
 			goto cleanup;
 
@@ -444,4 +444,3 @@ cleanup:
 	ni_string_array_destroy(&sources);
 	return status;
 }
-

--- a/client/duid.c
+++ b/client/duid.c
@@ -791,8 +791,7 @@ ni_do_duid(const char *caller, int argc, char **argv)
 				"  --help, -h           show this help text and exit.\n"
 				"\n"
 				"Supported commands:\n"
-				"  help                 show this help text and exit.\n"
-				"  dump, show		show the duid map contents\n"
+				"  dump, show           show the duid map contents\n"
 				"  get [options]        get current duid\n"
 				"  del [options]        delete current duid\n"
 				"  set [options] <duid> set/update the duid\n"
@@ -811,11 +810,6 @@ ni_do_duid(const char *caller, int argc, char **argv)
 	ni_string_printf(&command, "%s %s", program, cmd);
 	argv[optind] = command;
 
-	if (ni_string_eq(cmd, "help")) {
-		argv[optind] = (char *)cmd;
-		status = NI_WICKED_RC_SUCCESS;
-		goto usage;
-	} else
 	if (ni_string_eq(cmd, "dump") || ni_string_eq(cmd, "show")) {
 		status = ni_do_duid_dump(argc - optind, argv + optind);
 	} else
@@ -843,4 +837,3 @@ cleanup:
 	ni_string_free(&program);
 	return status;
 }
-

--- a/client/ethtool.c
+++ b/client/ethtool.c
@@ -1198,7 +1198,7 @@ ethtool_args_set(struct ethtool_args *args, char **argn, int argc, char *argv[])
 int
 ni_do_ethtool(const char *caller, int argc, char **argv)
 {
-	enum { OPT_HELP };
+	enum {	OPT_HELP = 'h' };
 	static struct option      options[] = {
 		{ "help",         no_argument,       NULL, OPT_HELP        },
 
@@ -1210,7 +1210,7 @@ ni_do_ethtool(const char *caller, int argc, char **argv)
 	ni_ethtool_t *ethtool = NULL;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "+", options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "+h", options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_HELP:
 			status = NI_WICKED_RC_SUCCESS;
@@ -1221,7 +1221,7 @@ ni_do_ethtool(const char *caller, int argc, char **argv)
 				"wicked %s [global options ...] <ifname> <action options [arguments] > ...\n"
 				"\n"
 				"Supported global options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
 				"\n"
 				"Supported action options:\n"
@@ -1279,4 +1279,3 @@ cleanup:
 	ni_netdev_ref_destroy(&ref);
 	return status;
 }
-

--- a/client/iaid.c
+++ b/client/iaid.c
@@ -410,7 +410,6 @@ ni_do_iaid(const char *caller, int argc, char **argv)
 				"  --help, -h           show this help text and exit.\n"
 				"\n"
 				"Supported Commands:\n"
-				"  help                 show this help text and exit.\n"
 				"  dump, show           show the iaid map contents\n"
 				"  get <ifname>         get current device iaid\n"
 				"  del <ifname>         delete current device iaid\n"
@@ -430,11 +429,6 @@ ni_do_iaid(const char *caller, int argc, char **argv)
 	ni_string_printf(&command, "%s %s", program, cmd);
 	argv[optind] = command;
 
-	if (ni_string_eq(cmd, "help")) {
-		argv[optind] = (char *)cmd;
-		status = NI_WICKED_RC_SUCCESS;
-		goto usage;
-	} else
 	if (ni_string_eq(cmd, "dump") || ni_string_eq(cmd, "show")) {
 		status = ni_do_iaid_dump(argc - optind, argv + optind);
 	} else
@@ -462,4 +456,3 @@ cleanup:
 	ni_string_free(&program);
 	return status;
 }
-

--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -203,15 +203,23 @@ set_status(int *status, unsigned int code)
 int
 ni_do_ifcheck(int argc, char **argv)
 {
-	enum { OPT_HELP, OPT_QUIET, OPT_IFCONFIG, OPT_MISSED, OPT_CHANGED, OPT_STATE, OPT_PERSISTENT };
+	enum {
+		OPT_CHANGED	= 'c',
+		OPT_IFCONFIG	= 'i',
+		OPT_HELP	= 'h',
+		OPT_MISSED	= 'm',
+		OPT_PERSISTENT	= 'P',
+		OPT_QUIET	= 'q',
+		OPT_STATE	= 's',
+	};
 	static struct option ifcheck_options[] = {
-		{ "help",	no_argument, NULL,		OPT_HELP },
-		{ "quiet",	no_argument, NULL,		OPT_QUIET },
-		{ "ifconfig",	required_argument, NULL,	OPT_IFCONFIG },
-		{ "missed",	no_argument, NULL,		OPT_MISSED },
-		{ "changed",	no_argument, NULL,		OPT_CHANGED },
-		{ "state",	required_argument, NULL,	OPT_STATE },
-		{ "persistent",	no_argument, NULL,		OPT_PERSISTENT },
+		{ "help",	no_argument,		NULL,	OPT_HELP	},
+		{ "quiet",	no_argument,		NULL,	OPT_QUIET	},
+		{ "ifconfig",	required_argument,	NULL,	OPT_IFCONFIG	},
+		{ "missed",	no_argument,		NULL,	OPT_MISSED	},
+		{ "changed",	no_argument,		NULL,	OPT_CHANGED	},
+		{ "state",	required_argument,	NULL,	OPT_STATE	},
+		{ "persistent",	no_argument,		NULL,	OPT_PERSISTENT	},
 		{ NULL }
 	};
 	static ni_ifmatcher_t ifmatch;
@@ -236,7 +244,7 @@ ni_do_ifcheck(int argc, char **argv)
 	ifmatch.require_config = FALSE;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "", ifcheck_options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "i:hPq", ifcheck_options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_IFCONFIG:
 			ni_string_array_append(&opt_ifconfig, optarg);
@@ -277,11 +285,11 @@ ni_do_ifcheck(int argc, char **argv)
 			fprintf(stderr,
 				"wicked [options] ifcheck [ifcheck-options] <ifname ...>|all\n"
 				"\nSupported ifcheck-options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --ifconfig <filename>\n"
+				"  --ifconfig, -i <filename>\n"
 				"      Read interface configuration(s) from file\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Do not print out errors, but just signal the result through exit status\n"
 				"  --missed\n"
 				"      Check if the interface is missed\n"
@@ -290,7 +298,7 @@ ni_do_ifcheck(int argc, char **argv)
 				"  --state <state-name>\n"
 				"      Check if the interface is in the given state. Possible states:\n"
 				"  %s\n"
-				"  --persistent\n"
+				"  --persistent, -P\n"
 				"      Check if the interface is in persistent mode\n"
 				, sb.string);
 			ni_stringbuf_destroy(&sb);
@@ -423,4 +431,3 @@ cleanup:
 	ni_uint_array_destroy(&checks);
 	return status;
 }
-

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -106,13 +106,19 @@ ni_ifdown_fire_nanny(ni_ifworker_array_t *array)
 int
 ni_do_ifdown(int argc, char **argv)
 {
-	enum  { OPT_HELP, OPT_FORCE, OPT_DELETE, OPT_NO_DELETE, OPT_TIMEOUT };
+	enum  {
+		OPT_DELETE	= 'd',
+		OPT_FORCE	= 'f',
+		OPT_HELP	= 'h',
+		OPT_NO_DELETE	= 'n',
+		OPT_TIMEOUT	= 't'
+	};
 	static struct option ifdown_options[] = {
-		{ "help",	no_argument, NULL,		OPT_HELP },
-		{ "force",	required_argument, NULL,	OPT_FORCE },
-		{ "delete",	no_argument, NULL,	OPT_DELETE },
-		{ "no-delete",	no_argument, NULL,	OPT_NO_DELETE },
-		{ "timeout",	required_argument, NULL,	OPT_TIMEOUT },
+		{ "help",	no_argument,		NULL,	OPT_HELP	},
+		{ "force",	required_argument,	NULL,	OPT_FORCE	},
+		{ "delete",	no_argument,		NULL,	OPT_DELETE	},
+		{ "no-delete",	no_argument,		NULL,	OPT_NO_DELETE	},
+		{ "timeout",	required_argument,	NULL,	OPT_TIMEOUT	},
 		{ NULL }
 	};
 	ni_ifmatcher_t ifmatch;
@@ -142,7 +148,7 @@ ni_do_ifdown(int argc, char **argv)
 	ifmarker.target_range.max = __NI_FSM_STATE_MAX - 2;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "", ifdown_options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "df:hnt:", ifdown_options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_FORCE:
 			if (!ni_ifworker_state_from_name(optarg, &max_state) ||
@@ -190,16 +196,16 @@ usage:
 			fprintf(stderr,
 				"wicked [options] ifdown [ifdown-options] <ifname ...>|all\n"
 				"\nSupported ifdown-options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --force <state>\n"
+				"  --force, -f <state>\n"
 				"      Force putting interface into the <state> state. Despite of persistent mode being set. Possible states:\n"
 				"  %s\n"
-				"  --delete\n"
+				"  --delete, -d\n"
 				"      Delete device. Despite of persistent mode being set\n"
-				"  --no-delete\n"
+				"  --no-delete, -n\n"
 				"      Do not attempt to delete a device, neither physical nor virtual\n"
-				"  --timeout <nsec>\n"
+				"  --timeout, -t <nsec>\n"
 				"      Timeout after <nsec> seconds\n",
 				sb.string
 				);
@@ -276,4 +282,3 @@ usage:
 	ni_ifworker_array_destroy(&ifmarked);
 	return status;
 }
-

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -130,15 +130,15 @@ usage:
 			fprintf(stderr,
 				"%s [ifreload-options] <ifname ...>|all\n"
 				"\nSupported ifreload-options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --transient\n"
+				"  --transient, -T\n"
 				"      Enable transient interface return codes\n"
-				"  --ifconfig <filename>\n"
+				"  --ifconfig, -i <filename>\n"
 				"      Read interface configuration(s) from file\n"
-				"  --timeout <sec>\n"
+				"  --timeout, -t <sec>\n"
 				"      Timeout after <sec> seconds\n"
-				"  --persistent\n"
+				"  --persistent, -P\n"
 				"      Set interface into persistent mode (no regular ifdown allowed)\n"
 				, program);
 			goto cleanup;
@@ -669,7 +669,7 @@ ni_do_ifreload_nanny(const char *caller, int argc, char **argv)
 		{ "transient",		no_argument,		NULL,	OPT_TRANSIENT },
 		{ "persistent",		no_argument,		NULL,	OPT_PERSISTENT },
 
-		{ NULL,			no_argument,		NULL,	0 }
+		{ NULL }
 	};
 	ni_ifworker_array_t up_marked = NI_IFWORKER_ARRAY_INIT;
 	ni_ifworker_array_t down_marked = NI_IFWORKER_ARRAY_INIT;
@@ -725,15 +725,15 @@ usage:
 			fprintf(stderr,
 				"%s [ifreload-options] <ifname ...>|all\n"
 				"\nSupported ifreload-options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --transient\n"
+				"  --transient, -T\n"
 				"      Enable transient interface return codes\n"
-				"  --ifconfig <filename>\n"
+				"  --ifconfig, -i <filename>\n"
 				"      Read interface configuration(s) from file\n"
-				"  --timeout <sec>\n"
+				"  --timeout, -t <sec>\n"
 				"      Timeout after <sec> seconds\n"
-				"  --persistent\n"
+				"  --persistent, -P\n"
 				"      Set interface into persistent mode (no regular ifdown allowed)\n"
 				, program);
 			goto cleanup;

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -638,17 +638,24 @@ ni_ifstatus_to_retcode(int status, ni_bool_t mandatory)
 int
 ni_do_ifstatus(int argc, char **argv)
 {
-	enum  { OPT_QUIET, OPT_BRIEF, OPT_NORMAL, OPT_VERBOSE,
-		OPT_HELP, OPT_SHOW, OPT_IFCONFIG, OPT_TRANSIENT };
+	enum {
+		OPT_NORMAL,
+		OPT_QUIET	= 'q',
+		OPT_BRIEF	= 'b',
+		OPT_VERBOSE	= 'v',
+		OPT_HELP	= 'h',
+		OPT_IFCONFIG	= 'i',
+		OPT_TRANSIENT	= 'T',
+	};
 	static struct option ifcheck_options[] = {
-		{ "help",         no_argument,       NULL, OPT_HELP        },
-		{ "quiet",        no_argument,       NULL, OPT_QUIET       },
-		{ "brief",        no_argument,       NULL, OPT_BRIEF       },
-		{ "verbose",      no_argument,       NULL, OPT_VERBOSE     },
-		{ "ifconfig",     required_argument, NULL, OPT_IFCONFIG    },
-		{ "transient",    no_argument,       NULL, OPT_TRANSIENT },
+		{ "help",	no_argument,		NULL, OPT_HELP		},
+		{ "quiet",	no_argument,		NULL, OPT_QUIET		},
+		{ "brief",	no_argument,		NULL, OPT_BRIEF		},
+		{ "verbose",	no_argument,		NULL, OPT_VERBOSE	},
+		{ "ifconfig",	required_argument,	NULL, OPT_IFCONFIG	},
+		{ "transient",	no_argument,		NULL, OPT_TRANSIENT	},
 
-		{ NULL,           no_argument,       NULL, 0               }
+		{ NULL }
 	};
 	ni_string_array_t opt_ifconfig = NI_STRING_ARRAY_INIT;
 	unsigned int      opt_verbose  = OPT_NORMAL;
@@ -677,7 +684,7 @@ ni_do_ifstatus(int argc, char **argv)
 	check_config = ni_string_eq(argv[0], "ifstatus") && geteuid() == 0;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "", ifcheck_options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "hTqbvi:", ifcheck_options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_HELP:
 			status = NI_WICKED_ST_OK;
@@ -687,18 +694,18 @@ ni_do_ifstatus(int argc, char **argv)
 			fprintf(stderr,
 				"wicked %s [options] <ifname ...>|all\n"
 				"\nSupported options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --transient\n"
+				"  --transient, -T\n"
 				"      Enable transient interface return codes\n"
-				"  --quiet\n"
+				"  --quiet, -q\n"
 				"      Return exit status only\n"
-				"  --brief\n"
+				"  --brief, -b\n"
 				"      Show only a brief status, no additional info\n"
-				"  --verbose\n"
+				"  --verbose, -v\n"
 				"      Show a more detailed information\n"
 				"\n"
-				"  --ifconfig <filename>\n"
+				"  --ifconfig, -i <filename>\n"
 				"      Read interface configuration(s) from file\n"
 				, argv[0]
 			);

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -452,27 +452,35 @@ ni_nanny_fsm_monitor_free(ni_nanny_fsm_monitor_t *monitor)
 static int
 ni_do_ifup_nanny(int argc, char **argv)
 {
-	enum  { OPT_HELP, OPT_IFCONFIG, OPT_CONTROL_MODE, OPT_STAGE, OPT_TIMEOUT,
-		OPT_SKIP_ACTIVE, OPT_SKIP_ORIGIN, OPT_PERSISTENT, OPT_TRANSIENT,
+	enum {
+		OPT_IFCONFIG		= 'i',
+		OPT_HELP		= 'h',
+		OPT_SKIP_ACTIVE		= 's',
+		OPT_CONTROL_MODE	= 'm',
+		OPT_SKIP_ORIGIN		= 'S',
+		OPT_PERSISTENT		= 'P',
+		OPT_TRANSIENT		= 'T',
+		OPT_STAGE		= 'p',
+		OPT_TIMEOUT		= 't',
 #ifdef NI_TEST_HACKS
 		OPT_IGNORE_PRIO, OPT_IGNORE_STARTMODE,
 #endif
 	};
 
 	static struct option ifup_options[] = {
-		{ "help",	no_argument,       NULL,	OPT_HELP },
-		{ "ifconfig",	required_argument, NULL,	OPT_IFCONFIG },
-		{ "mode",	required_argument, NULL,	OPT_CONTROL_MODE },
-		{ "boot-stage",	required_argument, NULL,	OPT_STAGE },
-		{ "skip-active",required_argument, NULL,	OPT_SKIP_ACTIVE },
-		{ "skip-origin",required_argument, NULL,	OPT_SKIP_ORIGIN },
-		{ "timeout",	required_argument, NULL,	OPT_TIMEOUT },
-		{ "transient", 	no_argument,		NULL,	OPT_TRANSIENT },
+		{ "help",	no_argument,		NULL,	OPT_HELP	},
+		{ "ifconfig",	required_argument,	NULL,	OPT_IFCONFIG	},
+		{ "mode",	required_argument,	NULL,	OPT_CONTROL_MODE},
+		{ "boot-stage",	required_argument,	NULL,	OPT_STAGE	},
+		{ "skip-active",no_argument,		NULL,	OPT_SKIP_ACTIVE	},
+		{ "skip-origin",required_argument,	NULL,	OPT_SKIP_ORIGIN	},
+		{ "timeout",	required_argument,	NULL,	OPT_TIMEOUT	},
+		{ "transient", 	no_argument,		NULL,	OPT_TRANSIENT	},
+		{ "persistent",	no_argument,		NULL,	OPT_PERSISTENT	},
 #ifdef NI_TEST_HACKS
 		{ "ignore-prio",no_argument, NULL,	OPT_IGNORE_PRIO },
 		{ "ignore-startmode",no_argument, NULL,	OPT_IGNORE_STARTMODE },
 #endif
-		{ "persistent",	no_argument, NULL,	OPT_PERSISTENT },
 		{ NULL }
 	};
 
@@ -500,7 +508,7 @@ ni_do_ifup_nanny(int argc, char **argv)
 	ifmatch.require_config = TRUE;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "", ifup_options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "i:hm:PTt:", ifup_options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_IFCONFIG:
 			ni_string_array_append(&opt_ifconfig, optarg);
@@ -560,13 +568,13 @@ usage:
 			fprintf(stderr,
 				"wicked [options] ifup [ifup-options] <ifname ...>|all\n"
 				"\nSupported ifup-options:\n"
-				"  --help\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
-				"  --transient\n"
+				"  --transient, -T\n"
 				"      Enable transient interface return codes\n"
-				"  --ifconfig <pathname>\n"
+				"  --ifconfig, -i <pathname>\n"
 				"      Read interface configuration(s) from file/directory rather than using system config\n"
-				"  --mode <label>\n"
+				"  --mode, -m <label>\n"
 				"      Only touch interfaces with matching control <mode>\n"
 				"  --boot-stage <label>\n"
 				"      Only touch interfaces with matching <boot-stage>\n"
@@ -576,7 +584,7 @@ usage:
 				"      Skip interfaces that have a configuration origin of <name>\n"
 				"      Usually, you would use this with the name \"firmware\" to avoid\n"
 				"      touching interfaces that have been set up via firmware (like iBFT) previously\n"
-				"  --timeout <sec>\n"
+				"  --timeout, -t <sec>\n"
 				"      Timeout after <sec> seconds\n"
 #ifdef NI_TEST_HACKS
 				"  --ignore-prio\n"
@@ -584,7 +592,7 @@ usage:
 				"  --ignore-startmode\n"
 				"      Ignore checking the STARTMODE=off and STARTMODE=manual configs\n"
 #endif
-				"  --persistent\n"
+				"  --persistent, -p\n"
 				"      Set interface into persistent mode (no regular ifdown allowed)\n"
 				);
 			goto cleanup;

--- a/client/nanny.c
+++ b/client/nanny.c
@@ -196,25 +196,29 @@ do_nanny_recheck(int argc, char **argv)
 int
 do_nanny(int argc, char **argv)
 {
-	enum  { OPT_HELP, };
+	enum { OPT_HELP = 'h' };
 	static struct option nanny_options[] = {
-		{ "help", no_argument, NULL, OPT_HELP },
+		{ "help",	no_argument,	NULL, OPT_HELP },
+
 		{ NULL }
 	};
 	const char *command;
 	int c;
 
 	optind = 1;
-	while ((c = getopt_long(argc, argv, "+", nanny_options, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "+h", nanny_options, NULL)) != EOF) {
 		switch (c) {
 		case OPT_HELP:
 		default:
 usage:
 			fprintf(stderr,
 				"wicked [options] nanny <subcommand>\n"
-				"\nSupported subcommands:\n"
-				"  --help\n"
+				"\n"
+				"Supported global options:\n"
+				"  --help, -h\n"
 				"      Show this help text.\n"
+				"\n"
+				"Supported subcommands:\n"
 				"  enable <device>\n"
 				"  disable <device>\n"
 				"  addpolicy <filename>\n"
@@ -248,7 +252,7 @@ usage:
 		return do_nanny_disable(argc, argv);
 	if (ni_string_eq(command, "addsecret"))
 		return do_nanny_addsecret(argc, argv);
-	
+
 	ni_error("Unsupported nanny subcommand \"%s\"", command);
 	goto usage;
 }
@@ -610,4 +614,3 @@ cleanup:
 	ni_dbus_variant_destroy(&call_resp);
 	return rv;
 }
-

--- a/client/tester.c
+++ b/client/tester.c
@@ -90,7 +90,7 @@ ni_do_test_dhcp4(const char *caller, int argc, char **argv)
 				"  %s [options] <ifname>\n"
 				"\n"
 				"Options:\n"
-				"  --help, -h      show this help text and exit.\n"
+				"  --help, -h		show this help text and exit.\n"
 				"\n"
 				"  --timeout, -t   	<timeout in sec> (default: 20+10)\n"
 				"  --request, -r   	<request.xml>\n"
@@ -291,7 +291,8 @@ ni_do_test(const char *caller, int argc, char **argv)
 	enum { OPT_HELP = 'h' };
 	static struct option	options[] = {
 		{ "help",	no_argument,	NULL,	'h'	},
-		{ NULL,		no_argument,	NULL,	0	}
+
+		{ NULL }
 	};
 	int opt = 0, status = NI_WICKED_RC_USAGE;
 	char *program = NULL;
@@ -336,7 +337,7 @@ ni_do_test(const char *caller, int argc, char **argv)
 	} else
 	if (ni_string_eq(cmd, "dhcp4")) {
 		status = ni_do_test_dhcp4(program, argc - optind, argv + optind);
-	} else 
+	} else
 	if (ni_string_eq(cmd, "dhcp6")) {
 		status = ni_do_test_dhcp6(program, argc - optind, argv + optind);
 	} else {
@@ -348,4 +349,3 @@ cleanup:
 	ni_string_free(&program);
 	return status;
 }
-


### PR DESCRIPTION
This PR adds support for short options (e.g. "-h" vs "--help") for most of the parameters for the wicked CLI and it's subcommands.

Please, before merging feel free to review the characters I've chosen as there might be better choices.