### PR TITLE
dbus: add initial variant container type handling

### DIFF
--- a/include/wicked/dbus.h
+++ b/include/wicked/dbus.h
@@ -224,6 +224,7 @@ extern dbus_bool_t		ni_dbus_variant_init_signature(ni_dbus_variant_t *, const ch
 extern void			ni_dbus_variant_copy(ni_dbus_variant_t *dst,
 					const ni_dbus_variant_t *src);
 extern void			ni_dbus_variant_destroy(ni_dbus_variant_t *);
+extern const char *		ni_dbus_variant_print(ni_stringbuf_t *, const ni_dbus_variant_t *);
 extern const char *		ni_dbus_variant_sprint(const ni_dbus_variant_t *);
 extern const char *		ni_dbus_variant_signature(const ni_dbus_variant_t *);
 extern void			ni_dbus_variant_set_string(ni_dbus_variant_t *, const char *);

--- a/include/wicked/dbus.h
+++ b/include/wicked/dbus.h
@@ -56,6 +56,7 @@ struct ni_dbus_variant {
 		ni_dbus_dict_entry_t *dict_array_value;
 		ni_dbus_variant_t *variant_array_value;
 		ni_dbus_variant_t *struct_value;
+		ni_dbus_variant_t *variant_value;
 	};
 
 	ni_dbus_message_t *	__message;
@@ -285,6 +286,7 @@ extern dbus_bool_t		ni_dbus_variant_is_variant_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_dict_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_dict(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_struct(const ni_dbus_variant_t *);
+extern dbus_bool_t		ni_dbus_variant_is_variant(const ni_dbus_variant_t *);
 
 extern dbus_bool_t		ni_dbus_variant_array_parse_and_append_string(ni_dbus_variant_t *, const char *);
 
@@ -333,6 +335,9 @@ extern ni_dbus_variant_t *	ni_dbus_struct_add(ni_dbus_variant_t *);
 extern ni_bool_t		ni_dbus_struct_add_string(ni_dbus_variant_t *, const char *);
 extern ni_dbus_variant_t *	ni_dbus_struct_get(const ni_dbus_variant_t *, unsigned int);
 extern dbus_bool_t		ni_dbus_struct_get_string(const ni_dbus_variant_t *, unsigned int, const char **);
+
+extern ni_dbus_variant_t *	ni_dbus_variant_init_variant(ni_dbus_variant_t *);
+extern dbus_bool_t		ni_dbus_variant_get_variant(const ni_dbus_variant_t *, const ni_dbus_variant_t **);
 
 /*
  * Client side functions

--- a/src/dbus-common.c
+++ b/src/dbus-common.c
@@ -801,60 +801,81 @@ ni_dbus_variant_destroy(ni_dbus_variant_t *var)
 }
 
 const char *
-ni_dbus_variant_sprint(const ni_dbus_variant_t *var)
+ni_dbus_variant_print(ni_stringbuf_t *sb, const ni_dbus_variant_t *var)
 {
-	static char buffer[256];
-
 	switch (var->type) {
 	case DBUS_TYPE_STRING:
 	case DBUS_TYPE_OBJECT_PATH:
-		return var->string_value;
+		ni_stringbuf_printf(sb, "%s", var->string_value);
+		break;
 
 	case DBUS_TYPE_BYTE:
-		snprintf(buffer, sizeof(buffer), "0x%02x", var->byte_value);
+		ni_stringbuf_printf(sb, "0x%02x", var->byte_value);
 		break;
 
 	case DBUS_TYPE_BOOLEAN:
-		return var->bool_value? "true" : "false";
+		ni_stringbuf_printf(sb, "%s", var->bool_value? "true" : "false");
 		break;
 
 	case DBUS_TYPE_INT16:
-		snprintf(buffer, sizeof(buffer), "%d", var->int16_value);
+		ni_stringbuf_printf(sb, "%d", var->int16_value);
 		break;
 
 	case DBUS_TYPE_UINT16:
-		snprintf(buffer, sizeof(buffer), "%u", var->uint16_value);
+		ni_stringbuf_printf(sb, "%u", var->uint16_value);
 		break;
 
 	case DBUS_TYPE_INT32:
-		snprintf(buffer, sizeof(buffer), "%d", var->int32_value);
+		ni_stringbuf_printf(sb, "%d", var->int32_value);
 		break;
 
 	case DBUS_TYPE_UINT32:
-		snprintf(buffer, sizeof(buffer), "%u", var->uint32_value);
+		ni_stringbuf_printf(sb, "%u", var->uint32_value);
 		break;
 
 	case DBUS_TYPE_INT64:
-		snprintf(buffer, sizeof(buffer), "%lld", (long long) var->int64_value);
+		ni_stringbuf_printf(sb, "%lld", (long long) var->int64_value);
 		break;
 
 	case DBUS_TYPE_UINT64:
-		snprintf(buffer, sizeof(buffer), "%llu", (unsigned long long) var->uint64_value);
+		ni_stringbuf_printf(sb, "%llu", (unsigned long long) var->uint64_value);
 		break;
 
 	case DBUS_TYPE_DOUBLE:
-		snprintf(buffer, sizeof(buffer), "%f", var->double_value);
+		ni_stringbuf_printf(sb, "%f", var->double_value);
+		break;
+
+	case DBUS_TYPE_VARIANT:
+		ni_stringbuf_printf(sb, "v{");
+		if (var->variant_value)
+			ni_dbus_variant_print(sb, var->variant_value);
+		else
+			ni_stringbuf_printf(sb, "<NULL>");
+		ni_stringbuf_printf(sb, "}");
 		break;
 
 	case DBUS_TYPE_STRUCT:
-		return "<struct>";
+		ni_stringbuf_printf(sb, "<struct>");
+		break;
+
+	case DBUS_TYPE_ARRAY:
+		ni_stringbuf_printf(sb, "<array>");
+		break;
 
 	default:
-		return "<unknown type>";
+		ni_stringbuf_printf(sb, "<unknown type (%d)>", var->type);
 	}
+	return sb->string;
+}
 
+const char *
+ni_dbus_variant_sprint(const ni_dbus_variant_t *var)
+{
+	static char buffer[256];
+	ni_stringbuf_t sbuf = NI_STRINGBUF_INIT_BUFFER(buffer);
 
-	return buffer;
+	ni_stringbuf_truncate(&sbuf, 0);
+	return ni_dbus_variant_print(&sbuf, var);
 }
 
 dbus_bool_t

--- a/src/dbus-message.c
+++ b/src/dbus-message.c
@@ -279,6 +279,9 @@ ni_dbus_message_iter_append_value(DBusMessageIter *iter, const ni_dbus_variant_t
 	} else
 	if (variant->type == DBUS_TYPE_STRUCT) {
 		rv = ni_dbus_message_iter_append_struct(iter_val, variant->struct_value, variant->array.len);
+	} else
+	if (variant->type == DBUS_TYPE_VARIANT) {
+		rv = ni_dbus_message_iter_append_variant(iter_val, variant->variant_value);
 	} else {
 		ni_warn("%s: variant type %s not supported", __FUNCTION__, signature);
 	}
@@ -539,7 +542,8 @@ ni_dbus_message_serialize_variants(ni_dbus_message_t *msg,
 				ni_dbus_variant_sprint(&argv[i]));
 #endif
 		if (!ni_dbus_message_iter_append_value(&iter, &argv[i], NULL)) {
-			ni_error("error marshalling message, type=%s, value=\"%s\"",
+			ni_error("error marshalling message arg[%u]: type=%s, value=\"%s\"",
+					i,
 					ni_dbus_variant_signature(&argv[i]),
 					ni_dbus_variant_sprint(&argv[i]));
 			dbus_set_error(error,


### PR DESCRIPTION
A dbus variant container with inner (typed) variant is required for migration to wpa_supplicant WPA1 dbus API.