### PR TITLE
Let wicked-service also provide service(network)

### DIFF
--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -123,6 +123,7 @@ Group:          System/Management
 Requires(pre):  %name = %{version}
 Requires:       sysconfig >= 0.81.0
 Provides:       /sbin/ifup
+Provides:       service(network)
 Provides:       sysvinit(network)
 Conflicts:      otherproviders(/sbin/ifup)
 Obsoletes:      sysconfig-network


### PR DESCRIPTION
The old provides is kept for compatibility for now.

On a related note, `Requires(pre): %name` looks wrong here. It means that `wicked` can be removed while `wicked-service` is still happily installed.