### PR TITLE
 dbus: Display element name on unknown enum value error

### DIFF
--- a/src/dbus-xml.c
+++ b/src/dbus-xml.c
@@ -626,7 +626,7 @@ ni_dbus_serialize_xml_enum(const xml_node_t *node, const ni_xs_scalar_info_t *sc
 	unsigned int value;
 
 	if (ni_parse_uint_maybe_mapped(node->cdata, names, &value, 0) < 0) {
-		ni_error("%s: unknown enum value \"%s\"", xml_node_location(node), node->cdata);
+		ni_error("%s: element <%s>: unknown enum value \"%s\"", xml_node_location(node), node->name, node->cdata);
 		return FALSE;
 	}
 

--- a/src/dbus-xml.c
+++ b/src/dbus-xml.c
@@ -1810,7 +1810,7 @@ ni_dbus_xml_expand_element_reference(xml_node_t *doc_node, const char *expr_stri
  *     <config type="...">
  *       <meta>
  *	   <mapping
- *	   	document-node="/some/xpath/expression" 
+ *	   	document-node="/some/xpath/expression"
  *		skip-unless-present="true"
  *		/>
  *       </meta>


### PR DESCRIPTION
If a enum value contain unknown things, the error message should output
also the element name which it belongs to.
New output format looks like:

```
Dec 04 13:57:54 linux-22ob wickedd-nanny[3372]: /run/wicked/nanny/policy__wlan1.xml:21: element <auth-proto>: unknown enum value "wpa1,wpa2"
```