### PR TITLE
client: parse sysctl files in the correct order (bsc#1181186)

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -319,6 +319,12 @@ __ni_suse_read_default_hostname(const char *root, char **hostname)
 	return *hostname;
 }
 
+static int
+__ni_suse_string_compare(const void *lhs, const void *rhs)
+{
+	return strcmp(*(const char **)lhs, *(const char **)rhs);
+}
+
 static ni_bool_t
 __ni_suse_read_global_ifsysctl(const char *root, const char *path)
 {
@@ -357,6 +363,14 @@ __ni_suse_read_global_ifsysctl(const char *root, const char *path)
 			continue;
 
 		if (ni_scandir(dirname, "*"__NI_SUSE_SYSCTL_SUFFIX, &names)) {
+
+			/*
+			 * config files in sysctl.d directories are often prefixed with
+			 * numbers determining an order, so we should preserve that order
+			 */
+			qsort(names.data, names.count, sizeof(char *),
+					__ni_suse_string_compare);
+
 			for (i = 0; i < names.count; ++i) {
 				snprintf(pathbuf, sizeof(pathbuf), "%s/%s",
 						dirname, names.data[i]);


### PR DESCRIPTION
The files in sysconfig directories are often prefixed with numbers to indicate an order. Presently, wicked ignores that order and so some settings that are expected to be applied last may be applied early and then overriden (e.g. by some default).

This PR adds sorting to the list of sysconfig files, fixes bsc#1181186.