### PR TITLE
ifconfig: differentiate if to re-trigger dad on address updates (bsc#1177215)

### DIFF
--- a/include/wicked/addrconf.h
+++ b/include/wicked/addrconf.h
@@ -261,6 +261,7 @@ extern const char *	ni_netbios_node_type_to_name(unsigned int);
 extern ni_bool_t	ni_netbios_node_type_to_code(const char *, unsigned int *);
 
 extern unsigned int	ni_addrconf_lease_get_priority(const ni_addrconf_lease_t *);
+extern unsigned int	ni_addrconf_lease_addrs_set_tentative(ni_addrconf_lease_t *, ni_bool_t);
 
 struct ni_auto4_request {
 	ni_bool_t	enabled;

--- a/include/wicked/address.h
+++ b/include/wicked/address.h
@@ -129,12 +129,14 @@ extern ni_bool_t	ni_address_is_temporary(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_permanent(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_deprecated(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_mngtmpaddr(const ni_address_t *laddr);
+extern ni_bool_t	ni_address_is_nodad(const ni_address_t *laddr);
 extern ni_bool_t	ni_address_is_noprefixroute(const ni_address_t *laddr);
 
 extern void		ni_address_set_temporary(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_mngtmpaddr(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_tentative(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_duplicate(ni_address_t *, ni_bool_t);
+extern void		ni_address_set_nodad(ni_address_t *, ni_bool_t);
 extern void		ni_address_set_noprefixroute(ni_address_t *, ni_bool_t);
 
 extern unsigned int	ni_address_valid_lft(const ni_address_t *, const struct timeval *);

--- a/src/address.c
+++ b/src/address.c
@@ -320,6 +320,12 @@ ni_address_is_mngtmpaddr(const ni_address_t *laddr)
 }
 
 ni_bool_t
+ni_address_is_nodad(const ni_address_t *laddr)
+{
+	return laddr->flags & IFA_F_NODAD;
+}
+
+ni_bool_t
 ni_address_is_noprefixroute(const ni_address_t *laddr)
 {
 	return laddr->flags & IFA_F_NOPREFIXROUTE;
@@ -369,6 +375,15 @@ ni_address_set_mngtmpaddr(ni_address_t *laddr, ni_bool_t temporary)
 		laddr->flags |= IFA_F_MANAGETEMPADDR;
 	else
 		laddr->flags &= ~IFA_F_MANAGETEMPADDR;
+}
+
+void
+ni_address_set_nodad(ni_address_t *laddr, ni_bool_t nodad)
+{
+	if (nodad)
+		laddr->flags |= IFA_F_NODAD;
+	else
+		laddr->flags &= ~IFA_F_NODAD;
 }
 
 void

--- a/src/dbus-objects/addrconf.c
+++ b/src/dbus-objects/addrconf.c
@@ -359,7 +359,6 @@ ni_objectmodel_addrconf_static_request(ni_dbus_object_t *object, unsigned int ad
 	const ni_dbus_variant_t *dict;
 	const char *string_value;
 	ni_netdev_t *dev;
-	ni_address_t *ap;
 	int rv;
 
 	if (!(dev = ni_objectmodel_unwrap_netif(object, error)))
@@ -415,8 +414,7 @@ ni_objectmodel_addrconf_static_request(ni_dbus_object_t *object, unsigned int ad
 		ni_string_dup(&lease->hostname, string_value);
 
 	/* mark all addresses tentative, causing to verify them */
-	for (ap = lease->addrs; ap; ap = ap->next)
-		ni_address_set_tentative(ap, TRUE);
+	ni_addrconf_lease_addrs_set_tentative(lease, TRUE);
 
 	rv = __ni_system_interface_update_lease(dev, &lease, NI_EVENT_ADDRESS_ACQUIRED);
 	if (lease)

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -65,12 +65,12 @@ struct ni_dhcp6_request {
 	unsigned int		flags;
 
 	/* Options controlling which and how to make the requests */
-	ni_dhcp6_run_t		dry_run;         /* normal run or get offer/lease only	*/
-	unsigned int		mode;		 /* follow ra, request info/addr/prefix */
-	ni_bool_t		rapid_commit;	 /* try to use rapid commit flow	*/
-	unsigned int		address_len;	/* address prefix length to use         */
+	ni_dhcp6_run_t		dry_run;	/* normal run or get offer/lease only	*/
+	unsigned int		mode;		/* follow ra, request info/addr/prefix	*/
+	ni_bool_t		rapid_commit;	/* try to use rapid commit flow		*/
+	unsigned int		address_len;	/* address prefix length to use		*/
 
-	unsigned int		start_delay;	/* how long to delay start */
+	unsigned int		start_delay;	/* how long to delay start		*/
 	unsigned int		defer_timeout;	/* how long we try before we defer	*/
 	unsigned int		acquire_timeout;/* how long we try before we give up	*/
 
@@ -175,7 +175,7 @@ struct ni_dhcp6_device {
 	struct ni_dhcp6_link {
 	    unsigned int	ifindex;	/* interface index		*/
 	    ni_sockaddr_t	addr;		/* cached link-local address	*/
-	    //ni_bool_t		ready;		/* device,link,network are up	*/
+	    ni_bool_t		reconnect;	/* may have moved to a new link */
 	}			link;
 
 	uint32_t		iaid;		/* default IA interface-id	*/

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -1241,3 +1241,16 @@ ni_addrconf_lease_get_priority(const ni_addrconf_lease_t *lease)
 		return 0;
 	}
 }
+
+unsigned int
+ni_addrconf_lease_addrs_set_tentative(ni_addrconf_lease_t *lease, ni_bool_t tentative)
+{
+	unsigned int count = 0;
+	ni_address_t * ap;
+
+	for (ap = lease ? lease->addrs : NULL; ap; ap = ap->next) {
+		ni_address_set_tentative(ap, tentative);
+		count++;
+	}
+	return count;
+}


### PR DESCRIPTION
Re-trigger duplicate address detection when we may have moved to a new link, but skip it on
normal lifetime update / renew when it has been already performed (RFC8415, 18.2.10.1) to
not cause 1s packet loss during the detection.