### PR TITLE
dbus: Add ni_dbus_variant_t of type UINT32_ARRAY

### DIFF
--- a/include/wicked/dbus.h
+++ b/include/wicked/dbus.h
@@ -284,6 +284,7 @@ extern dbus_bool_t		ni_dbus_variant_is_array_of(const ni_dbus_variant_t *, const
 extern dbus_bool_t		ni_dbus_variant_is_byte_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_string_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_variant_array(const ni_dbus_variant_t *);
+extern dbus_bool_t		ni_dbus_variant_is_object_path_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_dict_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_dict(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_struct(const ni_dbus_variant_t *);
@@ -498,6 +499,8 @@ ni_dbus_variant_datum_const_ptr(const ni_dbus_variant_t *variant)
 		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING
 #define NI_DBUS_STRING_ARRAY_SIGNATURE \
 		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING
+#define NI_DBUS_OBJECT_PATH_ARRAY_SIGNATURE \
+		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_OBJECT_PATH_AS_STRING
 
 
 #define NI_DBUS_SIGNATURE(type)		NI_DBUS_##type##_SIGNATURE

--- a/include/wicked/dbus.h
+++ b/include/wicked/dbus.h
@@ -52,6 +52,7 @@ struct ni_dbus_variant {
 		dbus_uint64_t	uint64_value;
 		double		double_value;
 		unsigned char *	byte_array_value;
+		uint32_t *	uint32_array_value;
 		char **		string_array_value;
 		ni_dbus_dict_entry_t *dict_array_value;
 		ni_dbus_variant_t *variant_array_value;
@@ -270,6 +271,8 @@ extern void			ni_dbus_variant_init_byte_array(ni_dbus_variant_t *);
 extern void			ni_dbus_variant_set_byte_array(ni_dbus_variant_t *,
 					const unsigned char *, unsigned int len);
 extern dbus_bool_t		ni_dbus_variant_append_byte_array(ni_dbus_variant_t *, unsigned char);
+extern void			ni_dbus_variant_init_uint32_array(ni_dbus_variant_t *);
+extern dbus_bool_t		ni_dbus_variant_append_uint32_array(ni_dbus_variant_t *, uint32_t);
 extern void			ni_dbus_variant_init_string_array(ni_dbus_variant_t *);
 extern void			ni_dbus_variant_set_string_array(ni_dbus_variant_t *,
 					const char **, unsigned int len);
@@ -282,6 +285,7 @@ extern const char *		ni_dbus_variant_array_print_element(const ni_dbus_variant_t
 
 extern dbus_bool_t		ni_dbus_variant_is_array_of(const ni_dbus_variant_t *, const char *signature);
 extern dbus_bool_t		ni_dbus_variant_is_byte_array(const ni_dbus_variant_t *);
+extern dbus_bool_t		ni_dbus_variant_is_uint32_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_string_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_variant_array(const ni_dbus_variant_t *);
 extern dbus_bool_t		ni_dbus_variant_is_object_path_array(const ni_dbus_variant_t *);
@@ -501,6 +505,8 @@ ni_dbus_variant_datum_const_ptr(const ni_dbus_variant_t *variant)
 		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING
 #define NI_DBUS_OBJECT_PATH_ARRAY_SIGNATURE \
 		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_OBJECT_PATH_AS_STRING
+#define NI_DBUS_UINT32_ARRAY_SIGNATURE \
+		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING
 
 
 #define NI_DBUS_SIGNATURE(type)		NI_DBUS_##type##_SIGNATURE

--- a/src/dbus-common.c
+++ b/src/dbus-common.c
@@ -576,6 +576,12 @@ ni_dbus_variant_is_byte_array(const ni_dbus_variant_t *var)
 	return __ni_dbus_is_array(var, DBUS_TYPE_BYTE_AS_STRING);
 }
 
+dbus_bool_t
+ni_dbus_variant_is_uint32_array(const ni_dbus_variant_t *var)
+{
+	return __ni_dbus_is_array(var, DBUS_TYPE_UINT32_AS_STRING);
+}
+
 /*
  * Helper function for handling arrays
  */
@@ -631,6 +637,24 @@ ni_dbus_variant_append_byte_array(ni_dbus_variant_t *var, unsigned char byte)
 
 	__ni_dbus_array_grow(var, sizeof(unsigned char), 1);
 	var->byte_array_value[var->array.len++] = byte;
+	return TRUE;
+}
+
+void
+ni_dbus_variant_init_uint32_array(ni_dbus_variant_t *var)
+{
+	ni_dbus_variant_destroy(var);
+	__ni_dbus_init_array(var, DBUS_TYPE_UINT32);
+}
+
+dbus_bool_t
+ni_dbus_variant_append_uint32_array(ni_dbus_variant_t *var, uint32_t u)
+{
+	if (!__ni_dbus_is_array(var, DBUS_TYPE_UINT32_AS_STRING))
+		return FALSE;
+
+	__ni_dbus_array_grow(var, sizeof(uint32_t), 1);
+	var->uint32_array_value[var->array.len++] = u;
 	return TRUE;
 }
 
@@ -763,6 +787,7 @@ ni_dbus_variant_destroy(ni_dbus_variant_t *var)
 		unsigned int i;
 
 		switch (var->array.element_type) {
+		case DBUS_TYPE_UINT32:
 		case DBUS_TYPE_BYTE:
 			free(var->byte_array_value);
 			break;
@@ -1148,6 +1173,8 @@ ni_dbus_variant_signature(const ni_dbus_variant_t *var)
 		switch (var->array.element_type) {
 		case DBUS_TYPE_BYTE:
 			return DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING;
+		case DBUS_TYPE_UINT32:
+			return NI_DBUS_UINT32_ARRAY_SIGNATURE;
 		case DBUS_TYPE_STRING:
 			return DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING;
 		case DBUS_TYPE_VARIANT:

--- a/src/dbus-common.c
+++ b/src/dbus-common.c
@@ -166,6 +166,12 @@ ni_dbus_variant_is_string_array(const ni_dbus_variant_t *var)
 	return __ni_dbus_is_array(var, DBUS_TYPE_STRING_AS_STRING);
 }
 
+dbus_bool_t
+ni_dbus_variant_is_object_path_array(const ni_dbus_variant_t *var)
+{
+	return __ni_dbus_is_array(var, DBUS_TYPE_OBJECT_PATH_AS_STRING);
+}
+
 /*
  * Get/set functions for variant values
  */

--- a/src/dbus-common.h
+++ b/src/dbus-common.h
@@ -33,6 +33,8 @@ extern dbus_bool_t		ni_dbus_message_iter_get_variant(DBusMessageIter *iter,
 					ni_dbus_variant_t *variant);
 extern dbus_bool_t		ni_dbus_message_iter_append_byte_array(DBusMessageIter *iter,
 						const unsigned char *value, unsigned int len);
+extern dbus_bool_t		ni_dbus_message_iter_append_uint32_array(DBusMessageIter *iter,
+					const uint32_t *value, unsigned int len);
 
 extern const ni_dbus_property_t *__ni_dbus_service_get_property(const ni_dbus_property_t *, const char *);
 


### PR DESCRIPTION
This allow sending and receiving of DBus types like 'au'
(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING).


Also adding some common signature utility macros and a check something to check for object_path_array.