### PR TITLE
[dbus] Add generic property for `byte_array`

### DIFF
--- a/include/wicked/dbus-service.h
+++ b/include/wicked/dbus-service.h
@@ -32,20 +32,20 @@ struct ni_dbus_property	{
 	struct {
 		ni_dbus_property_get_handle_fn_t *get_handle;
 		union {
-			ni_bool_t *	bool_offset;
-			int *		int_offset;
-			unsigned int *	uint_offset;
-			int16_t *	int16_offset;
-			uint16_t *	uint16_offset;
-			int64_t *	int64_offset;
-			uint64_t *	uint64_offset;
-			double *	double_offset;
-			char **		string_offset;
-			char **		object_path_offset;
-			ni_string_array_t *string_array_offset;
-			ni_string_array_t *object_path_array_offset;
-			ni_byte_array_t *byte_array_offset;
-			ni_uuid_t *	uuid_offset;
+			ni_bool_t *		bool_offset;
+			int *			int_offset;
+			unsigned int *		uint_offset;
+			int16_t *		int16_offset;
+			uint16_t *		uint16_offset;
+			int64_t *		int64_offset;
+			uint64_t *		uint64_offset;
+			double *		double_offset;
+			char **			string_offset;
+			char **			object_path_offset;
+			ni_string_array_t *	string_array_offset;
+			ni_string_array_t *	object_path_array_offset;
+			ni_byte_array_t *	byte_array_offset;
+			ni_uuid_t *		uuid_offset;
 			const ni_dbus_property_t *dict_children;
 		} u;
 	} generic;

--- a/include/wicked/dbus-service.h
+++ b/include/wicked/dbus-service.h
@@ -44,6 +44,7 @@ struct ni_dbus_property	{
 			char **		object_path_offset;
 			ni_string_array_t *string_array_offset;
 			ni_string_array_t *object_path_array_offset;
+			ni_byte_array_t *byte_array_offset;
 			ni_uuid_t *	uuid_offset;
 			const ni_dbus_property_t *dict_children;
 		} u;
@@ -134,6 +135,12 @@ extern dbus_bool_t		ni_dbus_generic_property_get_object_path_array(const ni_dbus
 extern dbus_bool_t		ni_dbus_generic_property_set_object_path_array(ni_dbus_object_t *, const ni_dbus_property_t *,
 					const ni_dbus_variant_t *, DBusError *);
 extern dbus_bool_t		ni_dbus_generic_property_parse_object_path_array(const ni_dbus_property_t *,
+					ni_dbus_variant_t *, const char *);
+extern dbus_bool_t		ni_dbus_generic_property_get_byte_array(const ni_dbus_object_t *, const ni_dbus_property_t *,
+					ni_dbus_variant_t *r, DBusError *);
+extern dbus_bool_t		ni_dbus_generic_property_set_byte_array(ni_dbus_object_t *, const ni_dbus_property_t *,
+					const ni_dbus_variant_t *, DBusError *);
+extern dbus_bool_t		ni_dbus_generic_property_parse_byte_array(const ni_dbus_property_t *,
 					ni_dbus_variant_t *, const char *);
 
 #define __NI_DBUS_PROPERTY_RO(fstem, __name) \
@@ -227,6 +234,8 @@ extern dbus_bool_t		ni_dbus_generic_property_parse_object_path_array(const ni_db
 	__NI_DBUS_GENERIC_PROPERTY(struct_name, NI_DBUS_SIGNATURE(OBJECT_PATH), dbus_name, object_path, member_name, rw)
 #define NI_DBUS_GENERIC_OBJECT_PATH_ARRAY_PROPERTY(struct_name, dbus_name, member_name, rw) \
 	__NI_DBUS_GENERIC_PROPERTY(struct_name, NI_DBUS_SIGNATURE(OBJECT_PATH_ARRAY), dbus_name, object_path_array, member_name, rw)
+#define NI_DBUS_GENERIC_BYTE_ARRAY_PROPERTY(struct_name, dbus_name, member_name, rw) \
+	__NI_DBUS_GENERIC_PROPERTY(struct_name, NI_DBUS_SIGNATURE(BYTE_ARRAY), dbus_name, byte_array, member_name, rw)
 
 
 

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -32,6 +32,13 @@ typedef struct ni_uint_arrray {
 
 #define NI_UINT_ARRAY_INIT	{ .count = 0, .data = NULL }
 
+typedef struct ni_byte_array {
+	size_t		len;
+	unsigned char *	data;
+} ni_byte_array_t;
+
+#define NI_BYTE_ARRAY_INIT	{ .len = 0, .data = NULL }
+
 typedef struct ni_variable	ni_var_t;
 struct ni_variable {
 	char *		name;
@@ -135,6 +142,16 @@ extern unsigned int	ni_uint_array_index(ni_uint_array_t *, unsigned int);
 extern ni_bool_t	ni_uint_array_contains(ni_uint_array_t *, unsigned int);
 extern ni_bool_t	ni_uint_array_get(ni_uint_array_t *, unsigned int, unsigned int *);
 extern ni_bool_t	ni_uint_array_set(ni_uint_array_t *, unsigned int, unsigned int);
+
+extern void		ni_byte_array_init(ni_byte_array_t *);
+extern void		ni_byte_array_destroy(ni_byte_array_t *);
+extern ni_byte_array_t *ni_byte_array_new(void);
+extern void		ni_byte_array_free(ni_byte_array_t *);
+extern size_t		ni_byte_array_size(const ni_byte_array_t *);
+extern size_t		ni_byte_array_pad(ni_byte_array_t *, size_t);
+extern size_t		ni_byte_array_put(ni_byte_array_t *, const unsigned char *, size_t);
+extern size_t		ni_byte_array_putb(ni_byte_array_t *, const unsigned char);
+extern size_t		ni_byte_array_puts(ni_byte_array_t *, const char *);
 
 extern ni_bool_t	ni_var_set(ni_var_t *, const char *, const char *);
 extern int		ni_var_name_cmp(const ni_var_t *, const ni_var_t *);

--- a/src/dbus-object.c
+++ b/src/dbus-object.c
@@ -1462,7 +1462,44 @@ ni_dbus_generic_property_parse_object_path_array(const ni_dbus_property_t *prop,
 {
 	return FALSE;
 }
+dbus_bool_t
+ni_dbus_generic_property_get_byte_array(const ni_dbus_object_t *obj, const ni_dbus_property_t *prop,
+					ni_dbus_variant_t *var, DBusError *error)
+{
+	ni_byte_array_t *vptr;
+	const void *handle;
 
+	if (!(handle = ni_dbus_generic_property_read_handle(obj, prop, error)))
+		return FALSE;
+
+	vptr = __property_data(prop, handle, byte_array);
+	ni_dbus_variant_set_byte_array(var, vptr->data, vptr->len);
+	return TRUE;
+}
+
+dbus_bool_t
+ni_dbus_generic_property_set_byte_array(ni_dbus_object_t *obj, const ni_dbus_property_t *prop,
+					const ni_dbus_variant_t *var, DBusError *error)
+{
+	ni_byte_array_t *vptr;
+	void *handle;
+
+	if (!(handle = ni_dbus_generic_property_write_handle(obj, prop, error)))
+		return FALSE;
+
+	if (!ni_dbus_variant_is_byte_array(var))
+		return FALSE;
+
+	vptr = __property_data(prop, handle, byte_array);
+	ni_byte_array_destroy(vptr);
+	return ni_byte_array_put(vptr, var->byte_array_value, var->array.len) == var->array.len;
+}
+
+dbus_bool_t
+ni_dbus_generic_property_parse_byte_array(const ni_dbus_property_t *prop, ni_dbus_variant_t *var, const char *string)
+{
+	return FALSE;
+}
 
 /*
  * Build an object path from parent path + name


### PR DESCRIPTION
This add a generic property handling for the DBus type `ab` (ByteArray), the macro is `NI_DBUS_GENERIC_BYTE_ARRAY_PROPERTY`. It will be mapped to the generic `ni_byte_array_t` type.

The type `ni_byte_array_t` is added with all needed utility functions like new, init, destroy, free, size and put[sb].


