### PR TITLE
xml-schema: Do not allow anon types for union and struct

### DIFF
--- a/src/xml-schema.c
+++ b/src/xml-schema.c
@@ -1136,7 +1136,7 @@ ni_xs_build_complex_type(xml_node_t *node, const char *className, ni_xs_scope_t 
 			type = ni_xs_struct_new(NULL);
 		}
 
-		if (ni_xs_build_typelist(node, &type->u.struct_info->children, scope, TRUE, NULL) < 0) {
+		if (ni_xs_build_typelist(node, &type->u.struct_info->children, scope, FALSE, NULL) < 0) {
 			ni_xs_type_free(type);
 			return NULL;
 		}
@@ -1150,7 +1150,7 @@ ni_xs_build_complex_type(xml_node_t *node, const char *className, ni_xs_scope_t 
 			return NULL;
 		}
 		type = ni_xs_union_new(NULL, disc_name);
-		if (ni_xs_build_typelist(node, &type->u.union_info->children, scope, TRUE, NULL) < 0) {
+		if (ni_xs_build_typelist(node, &type->u.union_info->children, scope, FALSE, NULL) < 0) {
 			ni_xs_type_free(type);
 			return NULL;
 		}

--- a/src/xml-schema.c
+++ b/src/xml-schema.c
@@ -365,8 +365,11 @@ ni_xs_name_type_array_find_local(const ni_xs_name_type_array_t *array, const cha
 	ni_xs_name_type_t *def;
 	unsigned int i;
 
+	if (!name || !array)
+		return NULL;
+
 	for (i = 0, def = array->data; i < array->count; ++i, ++def) {
-		if (!strcmp(def->name, name))
+		if (ni_string_eq(def->name, name))
 			return def->type;
 	}
 	return NULL;


### PR DESCRIPTION
We do not allow anon types in `union` or `struct`, as we already to with
`dict`.

This is forbidden after this commit:
```xml
<define name="certificate" class="union" switch="type">
  <path type="string"/>
  <external-file/>
  <hex-string/>
</define>
```

Each child element of a union or a struct need to be defined in the
"complex" way like:
```xml
<define name="certificate" class="union" switch="type">
  <path type="string"/>
  <file type="external-file"/>
  <hex  type="hex-string"/>
</define>
```

---

Also make the `ni_xs_name_type_array_find_local()` a bit more robust for anon types!