### PR TITLE
Remove systemd-udev-settle

### DIFF
--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service systemd-udev-settle.service
-After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service systemd-udev-settle.service openvswitch.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service 
+After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service openvswitch.service
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]


### PR DESCRIPTION
According to udevadm systemd-udev-settle.service is deprecated. Hence removed from Wants and and After