### PR TITLE
utils: format/parse bitmap to array and string alternatives

### DIFF
--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -265,6 +265,9 @@ extern size_t		ni_format_hex_data(const unsigned char *data, size_t data_len,
 						const char *sep, ni_bool_t upper);
 extern ssize_t		ni_parse_hex_data(const char *string, unsigned char *data,
 						size_t data_size, const char *sep);
+
+extern unsigned int	ni_parse_bitmap_array(unsigned int *, const ni_intmap_t *, const ni_string_array_t *, ni_string_array_t *);
+extern unsigned int	ni_parse_bitmap_string(unsigned int *, const ni_intmap_t *, const char *, const char *, ni_string_array_t *);
 extern const char *	ni_format_bitmap(ni_stringbuf_t *, const ni_intmap_t *, unsigned int, const char *);
 extern ni_bool_t	ni_intmap_file_get_name(const char *, unsigned int *, char **);
 extern ni_bool_t	ni_intmap_file_get_value(const char *, unsigned int *, char **);

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -210,6 +210,7 @@ extern void		ni_stringbuf_trim_head(ni_stringbuf_t *, const char *);
 extern void		ni_stringbuf_trim_tail(ni_stringbuf_t *, const char *);
 extern void		ni_stringbuf_trim_empty_lines(ni_stringbuf_t *);
 extern ni_bool_t	ni_stringbuf_empty(const ni_stringbuf_t *);
+extern const char *	ni_stringbuf_join(ni_stringbuf_t *, const ni_string_array_t *, const char *);
 
 extern ni_bool_t	ni_file_exists(const char *);
 extern ni_bool_t	ni_file_executable(const char *);

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -268,6 +268,8 @@ extern ssize_t		ni_parse_hex_data(const char *string, unsigned char *data,
 
 extern unsigned int	ni_parse_bitmap_array(unsigned int *, const ni_intmap_t *, const ni_string_array_t *, ni_string_array_t *);
 extern unsigned int	ni_parse_bitmap_string(unsigned int *, const ni_intmap_t *, const char *, const char *, ni_string_array_t *);
+extern unsigned int	ni_format_bitmap_array(ni_string_array_t *, const ni_intmap_t *, unsigned int, unsigned int *);
+extern const char *	ni_format_bitmap_string(ni_stringbuf_t *, const ni_intmap_t *, unsigned int, unsigned int *, const char *);
 extern const char *	ni_format_bitmap(ni_stringbuf_t *, const ni_intmap_t *, unsigned int, const char *);
 extern ni_bool_t	ni_intmap_file_get_name(const char *, unsigned int *, char **);
 extern ni_bool_t	ni_intmap_file_get_value(const char *, unsigned int *, char **);

--- a/src/util.c
+++ b/src/util.c
@@ -1582,18 +1582,11 @@ ni_string_split(ni_string_array_t *nsa, const char *str, const char *sep,
 const char *
 ni_string_join(char **str, const ni_string_array_t *nsa, const char *sep)
 {
-	ni_stringbuf_t buf;
-	unsigned int i;
+	ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
-	if (nsa == NULL || sep == NULL || str == NULL)
+	if (!sep || !ni_stringbuf_join(&buf, nsa, sep))
 		return NULL;
 
-	ni_stringbuf_init(&buf);
-	for (i=0; i < nsa->count; ++i) {
-		if (i)
-			ni_stringbuf_puts(&buf, sep);
-		ni_stringbuf_puts(&buf, nsa->data[i]);
-	}
 	ni_string_dup(str, buf.string);
 	ni_stringbuf_destroy(&buf);
 
@@ -2253,6 +2246,24 @@ ni_bool_t
 ni_stringbuf_empty(const ni_stringbuf_t *sb)
 {
 	return sb->len == 0; /* bool */
+}
+
+const char *
+ni_stringbuf_join(ni_stringbuf_t *buf, const ni_string_array_t *nsa, const char *sep)
+{
+	unsigned int i;
+	size_t len;
+
+	if (!buf || !nsa)
+		return NULL;
+
+	len = buf->len;
+	for (i = 0; i < nsa->count; ++i) {
+		if (sep && buf->len)
+			ni_stringbuf_puts(buf, sep);
+		ni_stringbuf_puts(buf, nsa->data[i]);
+	}
+	return buf->string ? buf->string + len : NULL;
 }
 
 inline static size_t

--- a/src/util.c
+++ b/src/util.c
@@ -2112,6 +2112,50 @@ ni_parse_hex(const char *string, unsigned char *data, unsigned int datasize)
 	return len;
 }
 
+unsigned int
+ni_parse_bitmap_array(unsigned int *mask, const ni_intmap_t *map, const ni_string_array_t *array,
+			ni_string_array_t *invalid)
+{
+	unsigned int i, flag;
+	const char *name;
+	unsigned int err = 0;
+
+	if (!mask || !map || !array)
+		return -1U;
+
+	for (i = 0; i < array->count; ++i) {
+		name = array->data[i];
+
+		if (!ni_parse_uint_mapped(name, map, &flag) &&
+				flag < 8 * sizeof(*mask)) {
+			*mask |= NI_BIT(flag);
+		} else {
+			if (invalid)
+				ni_string_array_append(invalid, name);
+			err++;
+		}
+	}
+
+	return err;
+}
+
+unsigned int
+ni_parse_bitmap_string(unsigned int *mask, const ni_intmap_t *map, const char *input,
+		const char *sep, ni_string_array_t *invalid)
+{
+	ni_string_array_t array = NI_STRING_ARRAY_INIT;
+	unsigned int err;
+
+	if (!mask || !map || !input)
+		return -1U;
+
+	ni_string_split(&array, input, sep, 0);
+	err = ni_parse_bitmap_array(mask, map, &array, invalid);
+	ni_string_array_destroy(&array);
+
+	return err;
+}
+
 const char *
 ni_format_bitmap(ni_stringbuf_t *buf, const ni_intmap_t *map,
 		unsigned int flags, const char *sep)

--- a/testing/Makefile.am
+++ b/testing/Makefile.am
@@ -11,7 +11,8 @@ noinst_PROGRAMS			= rtnl-test	\
 				  teamd-test	\
 				  xpath-test	\
 				  essid-test	\
-				  cstate-test
+				  cstate-test   \
+				  bitmap-test
 
 AM_CPPFLAGS			= -I$(top_srcdir)/src	\
 				  -I$(top_srcdir)/include
@@ -33,6 +34,7 @@ teamd_test_SOURCES		= teamd-test.c
 xpath_test_SOURCES		= xpath-test.c
 essid_test_SOURCES		= essid-test.c
 cstate_test_SOURCES		= cstate-test.c
+bitmap_test_SOURCES		= bitmap-test.c
 
 EXTRA_DIST			= ibft xpath \
 				  scripts/ifbind.sh

--- a/testing/bitmap-test.c
+++ b/testing/bitmap-test.c
@@ -1,0 +1,233 @@
+/**
+ *	Copyright (C) 2021 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Clemens Famulla-Conrad <cfamullaconrad@suse.com>
+ *
+ *	Description:
+ *		Test for bitmap util functions
+ *		* ni_parse_bitmap_array()
+ *		* ni_parse_bitmap_string()
+ *		* ni_format_bitmap_array()
+ *		* ni_format_bitmap_string()
+ *		* ni_format_bitmap()
+ */
+
+#include <stdarg.h>
+#include <wicked/util.h>
+#include <wicked/logging.h>
+
+
+void string_array_set(ni_string_array_t *arr, ...)
+{
+	va_list ap;
+	const char *s;
+
+	ni_string_array_destroy(arr);
+
+	va_start(ap, arr);
+	while((s = va_arg(ap, const char *))){
+		ni_string_array_append(arr, s);
+	}
+	va_end(ap);
+}
+
+ni_bool_t string_array_eq(ni_string_array_t *arr, ...)
+{
+	va_list ap;
+	const char *s;
+	size_t cnt = 0;
+
+	va_start(ap, arr);
+	while((s = va_arg(ap, const char *))){
+		cnt++;
+		if (ni_string_array_index(arr, s) < 0){
+			va_end(ap);
+			return FALSE;
+		}
+	}
+	va_end(ap);
+	return arr->count == cnt;
+}
+
+int main(int argc, char *argv[])
+{
+	enum {
+		MY_GET = 0,
+		MY_SET
+	};
+
+	ni_intmap_t map[] =  {
+		{ "GET",	MY_GET},
+		{ "SET",	MY_SET},
+		/* aliases */
+		{ "READ",	MY_GET},
+		{ "WRITE",	MY_SET},
+	};
+
+	unsigned int mask_out = 0;
+	unsigned int done_out = 0;
+	unsigned int mask_in = 0;
+	ni_string_array_t array_in = NI_STRING_ARRAY_INIT;
+	ni_string_array_t array_out = NI_STRING_ARRAY_INIT;
+	ni_string_array_t invalid = NI_STRING_ARRAY_INIT;
+	ni_stringbuf_t string_out = NI_STRINGBUF_INIT_DYNAMIC;
+
+#define CLEANUP() \
+	ni_string_array_destroy(&array_in);	\
+	ni_string_array_destroy(&array_out);	\
+	ni_string_array_destroy(&invalid);	\
+	ni_stringbuf_destroy(&string_out);	\
+	mask_out = done_out = mask_in = 0;
+
+	/* ni_parse_bitmap_array() */
+	CLEANUP();
+	mask_out = NI_BIT(MY_SET);
+	ni_string_array_append(&invalid, "invalid");
+	string_array_set(&array_in, "GET", NULL);
+	ni_assert(ni_parse_bitmap_array(&mask_out, map, &array_in, NULL) == 0);
+	ni_assert(string_array_eq(&invalid, "invalid", NULL));
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+
+	CLEANUP();
+	string_array_set(&array_in, "GET", "SET", NULL);
+	ni_assert(ni_parse_bitmap_array(&mask_out, map, &array_in, &invalid) == 0);
+	ni_assert(invalid.count == 0);
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+
+	CLEANUP();
+	string_array_set(&array_in, "GET", "SET", "WRITE", NULL);
+	ni_assert(ni_parse_bitmap_array(&mask_out, map, &array_in, &invalid) == 0);
+	ni_assert(invalid.count == 0);
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+
+	CLEANUP();
+	string_array_set(&array_in, "GET", "SET", "WRITE", "DUMP", NULL);
+	ni_assert(ni_parse_bitmap_array(&mask_out, map, &array_in, &invalid) == 1);
+	ni_assert(string_array_eq(&invalid, "DUMP", NULL));
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+	ni_string_array_destroy(&invalid);
+
+	CLEANUP();
+	string_array_set(&array_in, "GET", "SET", "WRITE", "DUMP", "BLUMP", NULL);
+	ni_assert(ni_parse_bitmap_array(&mask_out, map, &array_in, &invalid) == 2);
+	ni_assert(string_array_eq(&invalid, "DUMP", "BLUMP", NULL));
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+	ni_string_array_destroy(&invalid);
+
+	/* ni_parse_bitmap_string() */
+	CLEANUP();
+	mask_out = NI_BIT(MY_SET);
+	ni_string_array_append(&invalid, "Some garbage!!");
+	ni_assert(ni_parse_bitmap_string(&mask_out, map, "GET", "|", &invalid) == 0);
+	ni_assert(string_array_eq(&invalid, "Some garbage!!", NULL));
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+
+	CLEANUP();
+	ni_assert(ni_parse_bitmap_string(&mask_out, map, "WRITE|GET", "|", &invalid) == 0);
+	ni_assert(invalid.count == 0);
+	ni_assert(mask_out == (NI_BIT(MY_GET) | NI_BIT(MY_SET)));
+
+
+	/* ni_format_bitmap_array() */
+	CLEANUP();
+	mask_in = 0;
+	done_out = 0;
+	ni_string_array_append(&array_out, "Some garbage!!");
+	ni_assert(ni_format_bitmap_array(&array_out, map, mask_in, &done_out) == 0);
+	ni_assert(string_array_eq(&array_out, "Some garbage!!", NULL));
+	ni_assert(done_out == mask_in);
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET);
+	ni_assert(ni_format_bitmap_array(&array_out, map, mask_in, &done_out) == 0);
+	ni_assert(string_array_eq(&array_out, "GET", NULL));
+	ni_assert(done_out == mask_in);
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET);
+	ni_assert(ni_format_bitmap_array(&array_out, map, mask_in, &done_out) == 0);
+	ni_assert(string_array_eq(&array_out, "GET", "SET", NULL));
+	ni_assert(done_out == mask_in);
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET) | NI_BIT(5);
+	ni_assert(ni_format_bitmap_array(&array_out, map, mask_in, &done_out) == NI_BIT(5));
+	ni_assert(string_array_eq(&array_out, "GET", "SET", NULL));
+	ni_assert((done_out ^ mask_in) == NI_BIT(5));
+
+
+	/* ni_format_bitmap_string() */
+	CLEANUP();
+	mask_in = 0;
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, NULL, "|"), NULL));
+
+	CLEANUP();
+	mask_in = 0;
+	done_out = 0xf0;
+	ni_stringbuf_puts(&string_out, "Some garbage!!");
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, NULL, "|"), ""));
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, "|"), ""));
+	ni_assert(done_out == 0xf0);
+	ni_assert(ni_string_eq(string_out.string, "Some garbage!!"));
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET);
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, "|"), "GET"));
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, "#"), "#GET"));
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, NULL), "|GET"));
+	ni_assert(done_out == mask_in);
+	ni_assert(ni_string_eq(string_out.string, "GET#GET|GET"));
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET);
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, "|"), "GET|SET"));
+	ni_assert(done_out == mask_in);
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET) | NI_BIT(5);
+	ni_assert(ni_string_eq(ni_format_bitmap_string(&string_out, map, mask_in, &done_out, "|"), "GET|SET"));
+	ni_assert((done_out ^ mask_in) == NI_BIT(5));
+
+	/* ni_format_bitmap() */
+	CLEANUP();
+	mask_in = 0;
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "|"), NULL));
+
+	CLEANUP();
+	mask_in = 0;
+	ni_stringbuf_puts(&string_out, "Some garbage!!");
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "|"), ""));
+	ni_assert(ni_string_eq(string_out.string, "Some garbage!!"));
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET);
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "|"), "GET"));
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, NULL), "|GET"));
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "#"), "#GET"));
+	ni_assert(ni_string_eq(string_out.string, "GET|GET#GET"));
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET);
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "|"), "GET|SET"));
+
+	CLEANUP();
+	mask_in = NI_BIT(MY_GET) | NI_BIT(MY_SET) | NI_BIT(5);
+	ni_assert(ni_string_eq(ni_format_bitmap(&string_out, map, mask_in, "|"), "GET|SET"));
+
+	printf("ALL TEST SUCCESSFUL!\n");
+	return 0;
+}


### PR DESCRIPTION
Add bitmap utility functions:
 * `ni_parse_bitmap_array()`
 * `ni_parse_bitmap_string()`
 * `ni_format_bitmap_array()`
 * `ni_format_bitmap_string()`