### PR TITLE
nanny: Fix ni_nanny_identify_node_owner() exit condition

### DIFF
--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -529,6 +529,9 @@ ni_nanny_identify_node_owner(ni_nanny_t *mgr, xml_node_t *node, ni_stringbuf_t *
 	ni_managed_device_t *mdev;
 	ni_ifworker_t *w = NULL;
 
+	if (!node)
+		return NULL;
+
 	for (mdev = mgr->device_list; mdev; mdev = mdev->next) {
 		if (mdev->selected_config == node) {
 			w = ni_managed_device_get_worker(mdev);
@@ -536,8 +539,7 @@ ni_nanny_identify_node_owner(ni_nanny_t *mgr, xml_node_t *node, ni_stringbuf_t *
 		}
 	}
 
-	if (node != NULL)
-		w = ni_nanny_identify_node_owner(mgr, node->parent, path);
+	w = ni_nanny_identify_node_owner(mgr, node->parent, path);
 
 found:
 	if (w == NULL)


### PR DESCRIPTION
The function is calling it self recursively with `node->parent`, but
didn't checked if node is already a root one.

This just fix the `Segmentation fault` which was discovered, if we reach
a configuration constraint like:

```xml
<password type="string" constraint="required">
  <meta:user-input type="password" prompt="please enter WPA EAP password"/>
</password>
```
and the password wasn't set in the current configuration.

But it doesn't fix the prompt for password!