### PR TITLE
dracut: fix and improve option handling the cmdline parser (boo#1182227)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -2934,16 +2934,20 @@ ni_compat_generate_interface(xml_document_t *doc, const ni_compat_netdev_t *comp
 		return NULL;
 
 	if((namenode = xml_node_new("name", ifnode))) {
+		if (!ni_string_empty(compat->dev->name)) {
+			/* we identify it by persistent/perdictable ifname */
+			xml_node_set_cdata(namenode, compat->dev->name);
+		} else
 		if (compat->identify.hwaddr.len &&
 		    compat->identify.hwaddr.type == ARPHRD_ETHER) {
-			/* whatever the name currently is, just use the name of
+			/* Note: compatibility to the obsolete use-nanny=false
+			 *       fsm namespace/identify (never used in ifcfg).
+			 *
+			 * whatever the name currently is, just use the name of
 			 * the ethernet device with given permanent-address */
 			xml_node_add_attr(namenode, "namespace", "ethernet");
 			xml_node_new_element("permanent-address", namenode,
 				ni_link_address_print(&compat->identify.hwaddr));
-		} else {
-			/* we identify it by persistent/perdictable ifname */
-			xml_node_set_cdata(namenode, compat->dev->name);
 		}
 
 		if (ni_compat_generate_ifnode_content(ifnode, compat)) {

--- a/client/compat.c
+++ b/client/compat.c
@@ -532,7 +532,7 @@ __ni_compat_generate_bonding(xml_node_t *ifnode, const ni_compat_netdev_t *compa
 			ni_bonding_mii_carrier_detect_name(bond->miimon.carrier_detect));
 	}
 
-	snodes = xml_node_create(child, "slaves");
+	snodes = bond->slaves.count ? xml_node_create(child, "slaves") : NULL;
 	for (i = 0; i < bond->slaves.count; ++i) {
 		ni_bonding_slave_t *slave = bond->slaves.data[i];
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -3145,7 +3145,7 @@ try_vlan(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 			/* name<TAG> */
 			len = strlen(dev->name);
 			vlantag = &dev->name[len];
-			while(len > 0 && isdigit((unsigned char)vlantag[-1]))
+			while(len-- && isdigit((unsigned char)vlantag[-1]))
 				vlantag--;
 		}
 		if (ni_parse_uint(vlantag, &tag, 10) < 0) {


### PR DESCRIPTION
- fix to avoid adding interface configs twice
- fix vlan id parsing from vlan interface name in dracut and also in ifcfg
- fix swapped devices, missed lowerdev config relation and improve vlan= (error) option handling
- improve bridge=, bond=, team= option (error) handling, use master relation instead port list (deprecated)
- do not generate config from `ifname=`, but expose the match as pre-parsed parser backend meta option
- refactor to parse parameters in order (e.g. bonding= before ip=)