### PR TITLE
ifstatus: Don't show link as "up", if UP and LOWER_UP but not RUNNING

### DIFF
--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1049,7 +1049,6 @@ __ni_netdev_translate_ifflags(unsigned int ifflags, unsigned int prev)
 		retval = NI_IFF_DEVICE_READY | NI_IFF_DEVICE_UP;
 		break;
 
-	case IFF_UP | IFF_LOWER_UP:
 	case IFF_UP | IFF_LOWER_UP | IFF_RUNNING:
 		retval = NI_IFF_DEVICE_READY | NI_IFF_DEVICE_UP |
 			 NI_IFF_LINK_UP | NI_IFF_NETWORK_UP;


### PR DESCRIPTION
With wireless we have the case, that the interface is in operstate equal
to DORMANT. This is used to indicate the EAP authentication and set by
the wpa_supplicant. In such state, we have LOWER_UP and UP, but __not__
RUNNING.