### PR TITLE
 ifstatus: Fix warning of unexpected interface flag combination (bsc#1192164)

### DIFF
--- a/src/ifevent.c
+++ b/src/ifevent.c
@@ -394,7 +394,7 @@ __ni_rtevent_dellink(ni_netconfig_t *nc, const struct sockaddr_nl *nladdr, struc
 	} else {
 		unsigned int old_flags = dev->link.ifflags;
 
-		dev->link.ifflags = __ni_netdev_translate_ifflags(ifi->ifi_flags, old_flags);
+		dev->link.ifflags = __ni_netdev_translate_ifflags(dev->name, ifi->ifi_flags, old_flags);
 		dev->deleted = 1;
 		__ni_netdev_process_events(nc, dev, old_flags);
 		ni_client_state_drop(dev->link.ifindex);

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1941,7 +1941,7 @@ __ni_netdev_process_newlink(ni_netdev_t *dev, struct nlmsghdr *h,
 		if (rv == -NI_ERROR_RADIO_DISABLED) {
 			ni_debug_ifconfig("%s: radio disabled, not refreshing wireless info", dev->name);
 			ni_netdev_set_wireless(dev, NULL);
-		} else 
+		} else
 		if (rv < 0)
 			ni_error("%s: failed to refresh wireless info", dev->name);
 		break;

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1046,6 +1046,7 @@ __ni_netdev_translate_ifflags(unsigned int ifflags, unsigned int prev)
 	switch (ifflags & (IFF_RUNNING | IFF_LOWER_UP | IFF_UP)) {
 	case IFF_UP:
 	case IFF_UP | IFF_RUNNING:
+	case IFF_UP | IFF_LOWER_UP:
 		retval = NI_IFF_DEVICE_READY | NI_IFF_DEVICE_UP;
 		break;
 
@@ -1058,7 +1059,8 @@ __ni_netdev_translate_ifflags(unsigned int ifflags, unsigned int prev)
 		break;
 
 	default:
-		ni_warn("unexpected combination of interface flags 0x%x", ifflags);
+		ni_warn("unexpected combination of interface flags 0x%x",
+			ifflags & (IFF_RUNNING | IFF_LOWER_UP | IFF_UP));
 	}
 
 #ifdef IFF_DORMANT

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1039,7 +1039,7 @@ done:
  * Translate interface flags
  */
 unsigned int
-__ni_netdev_translate_ifflags(unsigned int ifflags, unsigned int prev)
+__ni_netdev_translate_ifflags(const char * ifname, unsigned int ifflags, unsigned int prev)
 {
 	unsigned int retval = (prev & NI_IFF_DEVICE_READY);
 
@@ -1059,8 +1059,8 @@ __ni_netdev_translate_ifflags(unsigned int ifflags, unsigned int prev)
 		break;
 
 	default:
-		ni_warn("unexpected combination of interface flags 0x%x",
-			ifflags & (IFF_RUNNING | IFF_LOWER_UP | IFF_UP));
+		ni_warn("%s: unexpected combination of interface flags 0x%x",
+			ifname, ifflags & (IFF_RUNNING | IFF_LOWER_UP | IFF_UP));
 	}
 
 #ifdef IFF_DORMANT
@@ -1454,7 +1454,7 @@ __ni_process_ifinfomsg_linkinfo(ni_linkinfo_t *link, const char *ifname,
 	ni_netdev_t *master;
 
 	link->hwaddr.type = link->hwpeer.type = ifi->ifi_type;
-	link->ifflags = __ni_netdev_translate_ifflags(ifi->ifi_flags, link->ifflags);
+	link->ifflags = __ni_netdev_translate_ifflags(ifname, ifi->ifi_flags, link->ifflags);
 
 	if (ni_netdev_link_always_ready(link))
 		link->ifflags |= NI_IFF_DEVICE_READY;

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -68,7 +68,7 @@ extern ni_addrconf_lease_t *__ni_netdev_find_lease(ni_netdev_t *, unsigned int, 
 extern ni_addrconf_lease_t *__ni_netdev_address_to_lease(ni_netdev_t *, const ni_address_t *, unsigned int);
 extern ni_addrconf_lease_t *__ni_netdev_route_to_lease(ni_netdev_t *, const ni_route_t *, unsigned int);
 extern void		__ni_netdev_track_ipv6_autoconf(ni_netdev_t *, int);
-extern unsigned int	__ni_netdev_translate_ifflags(unsigned int, unsigned int);
+extern unsigned int	__ni_netdev_translate_ifflags(const char *, unsigned int, unsigned int);
 extern void		__ni_netdev_process_events(ni_netconfig_t *, ni_netdev_t *, unsigned int);
 extern void		__ni_netdev_event(ni_netconfig_t *, ni_netdev_t *, ni_event_t);
 


### PR DESCRIPTION
Do not log warnings for a valid flag combination on interface state
changes, regression of 9970c28 .