### PR TITLE
wireless: reconnect on unexpected wpa_supplicant restart (bsc#1183495)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1546,37 +1546,40 @@ static ni_bool_t
 __ni_compat_generate_wireless(xml_node_t *ifnode, const ni_compat_netdev_t *compat)
 {
 	ni_wireless_t *wlan;
+	ni_wireless_config_t *conf;
 	ni_wireless_network_t *net;
 	xml_node_t *wireless, *networks;
 	char *tmp = NULL;
 	unsigned int i;
 
 	wlan = ni_netdev_get_wireless(compat->dev);
+	if (!wlan || !(conf = wlan->conf))
+		return FALSE;
 
 	if (!(wireless = xml_node_create(ifnode, "wireless"))) {
 		return FALSE;
 	}
 
-	if (ni_string_len(wlan->conf.country) == 2) {
-		xml_node_new_element("country", wireless, wlan->conf.country);
+	if (ni_string_len(conf->country) == 2) {
+		xml_node_new_element("country", wireless, conf->country);
 	}
 
-	if (wlan->conf.ap_scan <= NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH &&
-		ni_string_printf(&tmp, "%u", wlan->conf.ap_scan)) {
+	if (conf->ap_scan <= NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH &&
+		ni_string_printf(&tmp, "%u", conf->ap_scan)) {
 		xml_node_new_element("ap-scan", wireless, tmp);
 		ni_string_free(&tmp);
 	}
 
-	if (!ni_string_empty(wlan->conf.driver))
-		xml_node_new_element("wpa-driver", wireless, wlan->conf.driver);
+	if (!ni_string_empty(conf->driver))
+		xml_node_new_element("wpa-driver", wireless, conf->driver);
 
-	if (wlan->conf.networks.count) {
+	if (conf->networks.count) {
 		if (!(networks = xml_node_create(NULL, "networks"))) {
 			return FALSE;
 		}
 
-		for (i = 0; i < wlan->conf.networks.count; i++) {
-			if (!(net = wlan->conf.networks.data[i])) {
+		for (i = 0; i < conf->networks.count; i++) {
+			if (!(net = conf->networks.data[i])) {
 				continue;
 			}
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -3660,7 +3660,7 @@ try_add_wireless_net(const ni_sysconfig_t *sc, ni_netdev_t *dev, const char *suf
 		goto failure;
 	}
 
-	if (ni_wireless_essid_already_exists(wlan, &essid)) {
+	if (ni_wireless_config_has_essid(wlan->conf, &essid)) {
 		ni_error("ifcfg-%s: double configuration of the same ESSID=%s",
 			dev->name, var->value);
 		goto failure;

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -3765,13 +3765,13 @@ try_add_wireless_net(const ni_sysconfig_t *sc, ni_netdev_t *dev, const char *suf
 		}
 	}
 
-	if (ni_wireless_parse_auth_mode(sc, net, suffix, dev->name, wlan->conf.ap_scan) < 0)
+	if (ni_wireless_parse_auth_mode(sc, net, suffix, dev->name, wlan->conf->ap_scan) < 0)
 		goto failure;
 
-	if (!__ni_wireless_parse_psk_auth(sc, net, suffix, dev->name, wlan->conf.ap_scan))
+	if (!__ni_wireless_parse_psk_auth(sc, net, suffix, dev->name, wlan->conf->ap_scan))
 		goto failure;
 
-	if (!__ni_wireless_parse_eap_auth(sc, net, suffix, dev->name, wlan->conf.ap_scan))
+	if (!__ni_wireless_parse_eap_auth(sc, net, suffix, dev->name, wlan->conf->ap_scan))
 		goto failure;
 
 	if (net->keymgmt_proto & NI_BIT(NI_WIRELESS_KEY_MGMT_NONE)) {
@@ -3781,7 +3781,7 @@ try_add_wireless_net(const ni_sysconfig_t *sc, ni_netdev_t *dev, const char *suf
 			net->auth_algo = NI_BIT(NI_WIRELESS_AUTH_OPEN);
 	}
 
-	ni_wireless_network_array_append(&wlan->conf.networks, net);
+	ni_wireless_network_array_append(&wlan->conf->networks, net);
 
 	return TRUE;
 
@@ -3817,11 +3817,13 @@ try_add_wireless(const ni_sysconfig_t *sc, ni_netdev_t *dev)
 		return FALSE;
 	}
 
+	if (!wlan->conf && !(wlan->conf = ni_wireless_config_new()))
+		return FALSE;
 
 	/* Default is ap_scan = 1 */
 	if ((tmp = ni_sysconfig_get_value(sc, "WIRELESS_AP_SCANMODE"))) {
-		if ((ni_parse_uint(tmp, &wlan->conf.ap_scan, 10) < 0) ||
-			(wlan->conf.ap_scan > NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH)) {
+		if ((ni_parse_uint(tmp, &wlan->conf->ap_scan, 10) < 0) ||
+			(wlan->conf->ap_scan > NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH)) {
 			ni_error("ifcfg-%s: wrong WIRELESS_AP_SCANMODE value",
 				dev->name);
 			goto failure;
@@ -3839,7 +3841,7 @@ try_add_wireless(const ni_sysconfig_t *sc, ni_netdev_t *dev)
 			check_country = TRUE;
 		}
 
-		ni_string_dup(&wlan->conf.driver, tmp);
+		ni_string_dup(&wlan->conf->driver, tmp);
 	}
 	else {
 		check_country = TRUE;
@@ -3851,7 +3853,7 @@ try_add_wireless(const ni_sysconfig_t *sc, ni_netdev_t *dev)
 			if ((2 == ni_string_len(tmp)) &&
 				(isalpha((unsigned char) tmp[0])) &&
 				(isalpha((unsigned char) tmp[1]))) {
-					ni_string_dup(&wlan->conf.country, tmp);
+					ni_string_dup(&wlan->conf->country, tmp);
 			}
 			else {
 				ni_error("ifcfg-%s: wrong WIRELESS_REGULATORY_DOMAIN value",

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -354,6 +354,7 @@ extern void				ni_wireless_config_free(ni_wireless_config_t **);
 extern ni_bool_t			ni_wireless_config_init(ni_wireless_config_t *);
 extern void				ni_wireless_config_destroy(ni_wireless_config_t *);
 extern void				ni_wireless_config_copy(ni_wireless_config_t *, ni_wireless_config_t *);
+extern ni_bool_t			ni_wireless_config_has_essid(ni_wireless_config_t *, ni_wireless_ssid_t *);
 
 extern ni_wireless_scan_t *		ni_wireless_scan_new(ni_netdev_t *, unsigned int);
 extern void				ni_wireless_scan_free(ni_wireless_scan_t *);
@@ -394,7 +395,6 @@ extern const char *			ni_wireless_ssid_print_data(const unsigned char *data, siz
 extern const char *			ni_wireless_ssid_print(const ni_wireless_ssid_t *, ni_stringbuf_t *out);
 extern ni_bool_t			ni_wireless_ssid_parse(ni_wireless_ssid_t *, const char *);
 extern ni_bool_t			ni_wireless_ssid_eq(ni_wireless_ssid_t *, ni_wireless_ssid_t *);
-extern ni_bool_t			ni_wireless_essid_already_exists(ni_wireless_t *, ni_wireless_ssid_t *);
 
 extern const char *			ni_wireless_mode_to_name(ni_wireless_mode_t);
 extern ni_bool_t			ni_wireless_name_to_mode(const char *, unsigned int *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -350,6 +350,7 @@ extern int				ni_wireless_disconnect(ni_netdev_t *);
 
 extern ni_bool_t			ni_wireless_config_init(ni_wireless_config_t *);
 extern void				ni_wireless_config_destroy(ni_wireless_config_t *);
+extern void				ni_wireless_config_copy(ni_wireless_config_t *, ni_wireless_config_t *);
 
 extern ni_wireless_scan_t *		ni_wireless_scan_new(ni_netdev_t *, unsigned int);
 extern void				ni_wireless_scan_free(ni_wireless_scan_t *);
@@ -363,6 +364,7 @@ extern void				ni_wireless_network_free(ni_wireless_network_t *);
 extern void				ni_wireless_network_array_init(ni_wireless_network_array_t *);
 extern void				ni_wireless_network_array_append(ni_wireless_network_array_t *, ni_wireless_network_t *);
 extern void				ni_wireless_network_array_destroy(ni_wireless_network_array_t *);
+extern void				ni_wireless_network_array_copy(ni_wireless_network_array_t *, ni_wireless_network_array_t *);
 
 extern ni_wireless_bss_t *		ni_wireless_bss_new();
 extern void				ni_wireless_bss_init(ni_wireless_bss_t *bss);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -315,7 +315,7 @@ typedef struct ni_wireless_scan {
 struct ni_wireless {
 	ni_wireless_interface_capabilities_t	capabilities;
 
-	ni_wireless_config_t			conf;
+	ni_wireless_config_t *			conf;
 	ni_wireless_scan_t			scan;
 
 	/* Association information */
@@ -348,6 +348,8 @@ extern int				ni_wireless_set_network(ni_netdev_t *, ni_wireless_network_t *);
 extern int				ni_wireless_connect(ni_netdev_t *);
 extern int				ni_wireless_disconnect(ni_netdev_t *);
 
+extern ni_wireless_config_t *		ni_wireless_config_new();
+extern void				ni_wireless_config_free(ni_wireless_config_t **);
 extern ni_bool_t			ni_wireless_config_init(ni_wireless_config_t *);
 extern void				ni_wireless_config_destroy(ni_wireless_config_t *);
 extern void				ni_wireless_config_copy(ni_wireless_config_t *, ni_wireless_config_t *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -313,6 +313,7 @@ typedef struct ni_wireless_scan {
 } ni_wireless_scan_t;
 
 struct ni_wireless {
+	ni_bool_t				reconnect;
 	ni_wireless_interface_capabilities_t	capabilities;
 
 	ni_wireless_config_t *			conf;

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1014,6 +1014,9 @@ ni_wireless_setup(ni_netdev_t *dev, ni_wireless_config_t *conf)
 		return ret;
 	}
 
+	/* setup successfull, store configuration for expected wpa_supplicant restarts */
+	ni_wireless_config_copy(&wlan->conf, conf);
+
 	if (wlan->scan.interval > 0)
 		__ni_wireless_scan_timer_arm(&wlan->scan, dev, 1);
 	return ret;
@@ -1518,6 +1521,20 @@ ni_wireless_config_destroy(ni_wireless_config_t *conf)
 	}
 }
 
+void
+ni_wireless_config_copy(ni_wireless_config_t *dst, ni_wireless_config_t *src)
+{
+	if (!src || !dst || dst == src)
+		return;
+
+	ni_string_dup(&dst->country, src->country);
+	dst->ap_scan = src->ap_scan;
+	ni_string_dup(&dst->driver, src->driver);
+
+	ni_wireless_network_array_destroy(&dst->networks);
+	ni_wireless_network_array_copy(&dst->networks, &src->networks);
+}
+
 ni_wireless_t *
 ni_wireless_new(ni_netdev_t *dev)
 {
@@ -1770,6 +1787,15 @@ ni_wireless_network_array_destroy(ni_wireless_network_array_t *array)
 		ni_wireless_network_put(array->data[i]);
 	free(array->data);
 	memset(array, 0, sizeof(*array));
+}
+
+void
+ni_wireless_network_array_copy(ni_wireless_network_array_t *dst, ni_wireless_network_array_t *src)
+{
+	unsigned int i;
+
+	for (i = 0; i < src->count; ++i)
+		ni_wireless_network_array_append(dst, src->data[i]);
 }
 
 /*

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1040,6 +1040,12 @@ int
 ni_wireless_connect(ni_netdev_t *dev)
 {
 	ni_wpa_nif_t *wif;
+	ni_wireless_t *wlan;
+	int ret;
+
+	ni_debug_wireless("%s(%s)", __func__, dev->name);
+	if (!(wlan = dev->wireless))
+		return -NI_ERROR_INVALID_ARGS;
 
 	if (!(wif = ni_wireless_get_wpa_interface(dev))) {
 		ni_warn("Wireless connect failed - unknown interface %s(%d)",
@@ -1050,7 +1056,9 @@ ni_wireless_connect(ni_netdev_t *dev)
 	if (ni_rfkill_disabled(NI_RFKILL_TYPE_WIRELESS))
 		return -NI_ERROR_RADIO_DISABLED;
 
-	return ni_wpa_nif_set_all_networks_property_enabled(wif, TRUE);
+	if (!(ret = ni_wpa_nif_set_all_networks_property_enabled(wif, TRUE)))
+		wlan->reconnect = TRUE;
+	return ret;
 }
 
 /*
@@ -1060,6 +1068,12 @@ int
 ni_wireless_disconnect(ni_netdev_t *dev)
 {
 	ni_wpa_nif_t *wif;
+	ni_wireless_t *wlan;
+
+	ni_debug_wireless("%s(%s)", __func__, dev->name);
+	if (!(wlan = dev->wireless))
+		return -NI_ERROR_INVALID_ARGS;
+	wlan->reconnect = FALSE;
 
 	if (!(wif = ni_wireless_get_wpa_interface(dev))) {
 		ni_warn("Wireless disconnect failed - unknown interface %s(%d)",

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1626,6 +1626,23 @@ ni_wireless_config_copy(ni_wireless_config_t *dst, ni_wireless_config_t *src)
 	ni_wireless_network_array_copy(&dst->networks, &src->networks);
 }
 
+ni_bool_t
+ni_wireless_config_has_essid(ni_wireless_config_t *conf, ni_wireless_ssid_t *essid)
+{
+	unsigned int i, count;
+	ni_wireless_network_t *net;
+
+	ni_assert(conf != NULL && essid != NULL);
+
+	for (i = 0, count = conf->networks.count; i < count; i++) {
+		net = conf->networks.data[i];
+		if (ni_wireless_ssid_eq(&net->essid, essid))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 ni_wireless_t *
 ni_wireless_new(ni_netdev_t *dev)
 {
@@ -2107,24 +2124,6 @@ ni_wireless_ssid_eq(ni_wireless_ssid_t *a, ni_wireless_ssid_t *b)
 
 	return FALSE;
 }
-
-ni_bool_t
-ni_wireless_essid_already_exists(ni_wireless_t *wlan, ni_wireless_ssid_t *essid)
-{
-	unsigned int i, count;
-	ni_wireless_network_t *net;
-
-	ni_assert(wlan != NULL && essid != NULL && wlan->conf != NULL);
-
-	for (i = 0, count = wlan->conf->networks.count; i < count; i++) {
-		net = wlan->conf->networks.data[i];
-		if (ni_wireless_ssid_eq(&net->essid, essid))
-			return TRUE;
-	}
-
-	return FALSE;
-}
-
 
 static ni_bool_t
 ni_wireless_wep_key_validate_string(const char *key)

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1721,6 +1721,7 @@ void
 ni_wireless_bss_free(ni_wireless_bss_t **bss)
 {
 	ni_wireless_bss_destroy(*bss);
+	free(*bss);
 	*bss = NULL;
 }
 

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1123,6 +1123,10 @@ ni_wpa_nif_add_network(ni_wpa_nif_t *wif, const ni_wpa_net_properties_t *conf, n
 
 	ni_debug_wpa("Call to %s.%s(%s) returned object-path: %s",
 			interface, method, wif->device.name, object_path);
+
+	if (ni_string_array_index(&wif->properties.network_paths, object_path) < 0)
+		ni_string_array_append(&wif->properties.network_paths, object_path);
+
 	if (path)
 		ni_stringbuf_puts(path, object_path);
 

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -30,11 +30,19 @@
 #define SIGNAL_ERR(path, member, msg, ...) \
 	ni_error("%s: %s signal processing error: " msg, path, member, ##__VA_ARGS__);
 
+typedef struct ni_wpa_ops_handler		ni_wpa_ops_handler_t;
+struct ni_wpa_ops_handler {
+	ni_wpa_ops_handler_t			*next;
+	ni_wpa_client_ops_t			ops;
+	unsigned int				ifindex;
+};
+
 struct ni_wpa_client {
 	ni_dbus_client_t *			dbus;
 	ni_dbus_object_t *			object;
 
 	ni_wpa_nif_t *				nifs;
+	ni_wpa_ops_handler_t			*ops_handler_list;
 };
 static ni_wpa_client_t *			wpa_client; /* singelton */
 
@@ -63,6 +71,7 @@ static ni_dbus_object_t *			ni_objectmodel_wpa_nif_object_new(ni_wpa_client_t *,
 
 static ni_wpa_nif_t *				ni_objectmodel_wpa_nif_unwrap(const ni_dbus_object_t *, DBusError *);
 
+static void					ni_wpa_dbus_signal(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
 static void					ni_wpa_nif_signal(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
 static void					ni_wpa_signal(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
 
@@ -363,7 +372,101 @@ ni_wpa_client_open()
 				ni_wpa_nif_signal,
 				wpa);
 
+	ni_dbus_client_add_signal_handler(dbc,
+				NI_DBUS_BUS_NAME,	/* sender */
+				NULL,			/* object path */
+				NI_DBUS_INTERFACE,	/* object interface */
+				ni_wpa_dbus_signal,
+				wpa);
+
 	return wpa;
+}
+
+ni_wpa_ops_handler_t*
+ni_wpa_ops_handler_new(unsigned int ifindex)
+{
+	ni_wpa_ops_handler_t *handler;
+
+	handler = calloc(1, sizeof(*handler));
+	if (!handler) {
+		ni_error("Unable to alloc wpa client ops_handler -- out of memory");
+		return NULL;
+	}
+	handler->ifindex = ifindex;
+	return handler;
+}
+
+void
+ni_wpa_ops_handler_free(ni_wpa_ops_handler_t *handler)
+{
+	if (handler)
+		free(handler);
+}
+
+void
+ni_wpa_ops_handler_list_append(ni_wpa_ops_handler_t **list, ni_wpa_ops_handler_t *handler)
+{
+	while (*list)
+		list = &(*list)->next;
+	*list = handler;
+}
+
+ni_wpa_ops_handler_t *
+ni_wpa_ops_handler_find(ni_wpa_ops_handler_t **list, unsigned int ifindex)
+{
+	ni_wpa_ops_handler_t *handler;
+
+	for (handler = *list; handler; handler = handler->next) {
+		if (handler->ifindex == ifindex)
+			return handler;
+	}
+	return NULL;
+}
+
+ni_bool_t
+ni_wpa_ops_handler_list_delete(ni_wpa_ops_handler_t **list, ni_wpa_ops_handler_t *handler)
+{
+	ni_wpa_ops_handler_t **pos, *cur;
+
+	for (pos = list; (cur = *pos); pos = &cur->next) {
+		if (cur == handler) {
+			*pos = cur->next;
+			cur->next = NULL;
+			ni_wpa_ops_handler_free(cur);
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+ni_bool_t
+ni_wpa_client_set_ops(unsigned int ifindex, ni_wpa_client_ops_t* ops)
+{
+	ni_wpa_client_t *wpa = ni_wpa_client();
+	ni_wpa_ops_handler_t *new;
+
+	if (ni_wpa_ops_handler_find(&wpa->ops_handler_list, ifindex))
+		return TRUE;
+
+	new = ni_wpa_ops_handler_new(ifindex);
+	if (!new)
+		return FALSE;
+	new->ops = *ops;
+
+	ni_wpa_ops_handler_list_append(&wpa->ops_handler_list, new);
+	return TRUE;
+}
+
+ni_bool_t
+ni_wpa_client_del_ops(unsigned int ifindex)
+{
+	ni_wpa_client_t *wpa = ni_wpa_client();
+	ni_wpa_ops_handler_t *handler;
+
+	if ((handler = ni_wpa_ops_handler_find(&wpa->ops_handler_list, ifindex)))
+		return ni_wpa_ops_handler_list_delete(&wpa->ops_handler_list, handler);
+
+	return FALSE;
 }
 
 #if 0
@@ -371,6 +474,7 @@ static void
 ni_wpa_client_free(ni_wpa_client_t *wpa)
 {
 	ni_wpa_nif_t *wif;
+	ni_wpa_ops_handler_t *handler;
 
 	if (wpa->dbus) {
 		ni_dbus_client_free(wpa->dbus);
@@ -383,6 +487,9 @@ ni_wpa_client_free(ni_wpa_client_t *wpa)
 		wif->client = NULL;
 		ni_wpa_nif_free(wif);
 	}
+
+	while ((handler = wpa->ops_handler_list) != NULL)
+		ni_wpa_ops_handler_list_delete(&wpa->ops_handler_list, handler);
 
 	if (wpa->object) {
 		ni_dbus_object_free(wpa->object);
@@ -2490,6 +2597,89 @@ ni_wpa_nif_signal_eap(ni_wpa_nif_t *wif, const char *member, ni_dbus_message_t *
 cleanup:
 	ni_dbus_variant_destroy(&args[0]);
 	ni_dbus_variant_destroy(&args[1]);
+}
+
+static void
+ni_wpa_handle_wpa_supplicant_start(ni_wpa_client_t *wpa)
+{
+	ni_wpa_ops_handler_t *handler;
+	ni_netconfig_t *nc;
+	ni_netdev_t *dev;
+
+	if (!(nc = ni_global_state_handle(0))) {
+		ni_error("%s: Failed to get global net state", __func__);
+		return;
+	}
+
+	for (handler = wpa->ops_handler_list; handler; handler = handler->next) {
+		if ((dev = ni_netdev_by_index(nc, handler->ifindex)) &&
+		    handler->ops.on_wpa_supplicant_start)
+			handler->ops.on_wpa_supplicant_start(dev);
+	}
+}
+
+static void
+ni_wpa_handle_wpa_supplicant_stop(ni_wpa_client_t *wpa)
+{
+	ni_wpa_ops_handler_t *handler;
+	ni_netdev_t *dev;
+	ni_wpa_nif_t *wif;
+	ni_netconfig_t *nc;
+
+	while ((wif = wpa->nifs) != NULL)
+		ni_wpa_nif_free(wif);
+
+	if (!(nc = ni_global_state_handle(0))) {
+		ni_error("%s: Failed to get global net state", __func__);
+		return;
+	}
+
+	for (handler = wpa->ops_handler_list; handler; handler = handler->next) {
+		if ((dev = ni_netdev_by_index(nc, handler->ifindex)) &&
+		    handler->ops.on_wpa_supplicant_stop)
+			handler->ops.on_wpa_supplicant_stop(dev);
+	}
+}
+
+static void
+ni_wpa_dbus_signal(ni_dbus_connection_t *connection, ni_dbus_message_t *msg, void *user_data)
+{
+	ni_wpa_client_t *wpa = (ni_wpa_client_t*) user_data;
+	ni_dbus_variant_t args[3] = { NI_DBUS_VARIANT_INIT, NI_DBUS_VARIANT_INIT, NI_DBUS_VARIANT_INIT};
+	const char *member = dbus_message_get_member(msg);
+	const char *path = dbus_message_get_path(msg);
+	const char *name = NULL;
+	const char *old_owner = NULL;
+	const char *new_owner = NULL;
+
+	if (!ni_string_eq(member, "NameOwnerChanged"))
+		return;
+
+	if (ni_dbus_message_get_args_variants(msg, args, 3) != 3
+		|| !ni_dbus_variant_get_string(&args[0], &name)
+		|| !ni_dbus_variant_get_string(&args[1], &old_owner)
+		|| !ni_dbus_variant_get_string(&args[2], &new_owner)
+		){
+		SIGNAL_ERR(path, member, "unable to extract property-dict");
+		goto cleanup;
+	}
+
+	if (ni_string_eq(name, NI_WPA_INTERFACE)) {
+		if (ni_string_empty(old_owner) && !ni_string_empty(new_owner)) {
+			ni_debug_wpa("Start of wpa_supplicant (new owner '%s')", new_owner);
+			ni_wpa_handle_wpa_supplicant_start(wpa);
+		}
+		else if (!ni_string_empty(old_owner) && ni_string_empty(new_owner)) {
+			ni_debug_wpa("Stop of wpa_supplicant (old owner '%s')", old_owner);
+			ni_wpa_handle_wpa_supplicant_stop(wpa);
+		}
+	}
+
+
+cleanup:
+	ni_dbus_variant_destroy(&args[0]);
+	ni_dbus_variant_destroy(&args[1]);
+	ni_dbus_variant_destroy(&args[2]);
 }
 
 static void

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -12,6 +12,7 @@
 
 
 typedef struct ni_wpa_client			ni_wpa_client_t;
+typedef struct ni_wpa_client_ops		ni_wpa_client_ops_t;
 typedef struct ni_wpa_nif			ni_wpa_nif_t;
 typedef struct ni_wpa_nif_ops			ni_wpa_nif_ops_t;
 typedef struct ni_wpa_nif_properties		ni_wpa_nif_properties_t;
@@ -263,6 +264,11 @@ typedef enum {
 
 } ni_wpa_net_property_type_t;
 
+struct ni_wpa_client_ops {
+	void (*on_wpa_supplicant_start)(ni_netdev_t*);
+	void (*on_wpa_supplicant_stop)(ni_netdev_t*);
+};
+
 struct ni_wpa_nif_ops {
 	void (*on_network_added)(ni_wpa_nif_t*, const char*, const ni_wpa_net_properties_t*);
 	void (*on_network_selected)(ni_wpa_nif_t*, const char*);
@@ -369,6 +375,8 @@ struct ni_wpa_bss {
 };
 
 extern ni_wpa_client_t *			ni_wpa_client();
+extern ni_bool_t				ni_wpa_client_set_ops(unsigned int, ni_wpa_client_ops_t*);
+extern ni_bool_t				ni_wpa_client_del_ops(unsigned int);
 
 extern int					ni_wpa_get_interface(ni_wpa_client_t *, const char *, unsigned int,
 								ni_wpa_nif_t **);


### PR DESCRIPTION
When wpa_supplicant get restarted (e.g. in case of an update) the previous configuration is lost.
As we configure wpa_supplicant via DBus, there is no persistent state by default, thus we need to send the 
configuration again, once wpa_supplicant is back on the DBus.

Bug: https://bugzilla.suse.com/show_bug.cgi?id=1183495