### PR TITLE
dhcp4: add option to set route pref-src to dhcp IP (bsc#1192353)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -2269,6 +2269,9 @@ __ni_compat_generate_dhcp4_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 		xml_node_dict_set(dhcp, "route-priority",
 				ni_sprint_uint(compat->dhcp4.route_priority));
 
+	if (compat->dhcp4.route_set_src)
+		xml_node_dict_set(dhcp, "route-set-src",
+				ni_format_boolean(compat->dhcp4.route_set_src));
 
 	if (compat->dhcp4.start_delay)
 		xml_node_dict_set(dhcp, "start-delay",

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5422,6 +5422,8 @@ __ni_suse_addrconf_dhcp4_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 	}
 	if (ni_sysconfig_get_integer(sc, "DHCLIENT_ROUTE_PRIORITY", &uint))
 		compat->dhcp4.route_priority = uint;
+	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_ROUTE_SET_SRC")))
+		ni_parse_boolean(string, &compat->dhcp4.route_set_src);
 
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_MODIFY_SMB_CONF"))) {
 		if (ni_string_eq(string, "yes")) {

--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -76,6 +76,14 @@ DHCLIENT_BROADCAST=""
 #
 DHCLIENT_CREATE_CID=""
 
+## Type:        list(,yes,no)
+## Default:     ""
+#
+# When set to yes, the DHCPv4 IP address is set as the preferred source
+# in DHCPv4 provided routes.
+#
+DHCLIENT_ROUTE_SET_SRC=""
+
 ## Type:        list(enabled,disabled,default,)
 ## Default:     ""
 #

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -82,6 +82,7 @@ typedef struct ni_compat_netdev {
 		ni_tristate_t	broadcast;
 
 		unsigned int	route_priority;
+		ni_bool_t	route_set_src;
 		unsigned int	update;
 
 		ni_string_array_t request_options;

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -480,6 +480,7 @@ static ni_dbus_property_t	dhcp4_request_properties[] = {
 	DHCP4REQ_STRING_PROPERTY(hostname, hostname, RO),
 	DHCP4REQ_DICT_PROPERTY(fqdn, fqdn, RO),
 	DHCP4REQ_UINT_PROPERTY(route-priority, route_priority, RO),
+	DHCP4REQ_BOOL_PROPERTY(route-set-src, route_set_src, RO),
 
 	DHCP4REQ_STRING_ARRAY_PROPERTY(request-options, request_options, RO),
 

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -71,6 +71,10 @@ one of them does it.
 .BR DHCLIENT_ROUTE_PRIORITY
 This option allows to set a metric/priority for DHCPv4 routes. Default is 0.
 .TP
+.BR DHCLIENT_ROUTE_SET_SRC\ { \fIno\fR* | yes }
+When set to yes, the DHCPv4 IP address is set as the preferred source
+in DHCPv4 provided routes.
+.TP
 .BR DHCLIENT_CLIENT_ID
 Specifies a client identifier string. By default an id derived from the
 hardware address of the network interface is sent as client identifier.

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -222,6 +222,7 @@
       <qualify type="boolean"/>
     </fqdn>
     <route-priority type="uint32" />
+    <route-set-src type="boolean" />
 
     <request-options class="array" element-type="string" element-name="option" />
   </define>

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -292,6 +292,7 @@ ni_dhcp4_acquire(ni_dhcp4_device_t *dev, const ni_dhcp4_request_t *info)
 	config->doflags = ni_dhcp4_do_bits(ni_config_dhcp4_find_device(dev->ifname), config->update);
 
 	config->route_priority = info->route_priority;
+	config->route_set_src = info->route_set_src;
 	config->recover_lease = info->recover_lease;
 	config->release_lease = info->release_lease;
 	config->broadcast = info->broadcast;

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -155,6 +155,7 @@ struct ni_dhcp4_request {
 	ni_dhcp_fqdn_t		fqdn;
 	char *			hostname;
 	unsigned int		route_priority;
+	ni_bool_t		route_set_src;
 
 	ni_string_array_t	request_options;
 
@@ -198,6 +199,7 @@ struct ni_dhcp4_config {
 	ni_tristate_t		broadcast;
 
 	unsigned int		route_priority;
+	ni_bool_t		route_set_src;
 
 	unsigned int		max_lease_time;
 	ni_bool_t		recover_lease;

--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -897,6 +897,10 @@ ni_dhcp4_fsm_commit_lease(ni_dhcp4_device_t *dev, ni_addrconf_lease_t *lease)
 						continue;
 					rp->protocol = RTPROT_DHCP;
 					rp->priority = dev->config->route_priority;
+					if (dev->config->route_set_src) {
+						ni_sockaddr_set_ipv4(&rp->pref_src,
+							lease->dhcp4.address, 0);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When enabled in SUSE ifcfg config files with DHCLIENT_ROUTE_SET_SRC=yes
or via `<ipv4:dhcp><route-set-src>true</route-set-src></ipv4:dhcp>` in xml
config, the DHCPv4 IP address is set as the preferred source in DHCPv4 provided
routes.