### PR TITLE
cleanup: warnings, time calculations and dhcp fixes (bsc#1188019)

### DIFF
--- a/autoip4/main.c
+++ b/autoip4/main.c
@@ -439,7 +439,7 @@ autoip4_supplicant(void)
 #endif
 
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		do {
 			timeout = ni_timer_next_timeout();

--- a/client/arputil.c
+++ b/client/arputil.c
@@ -181,7 +181,7 @@ do_arp_run(struct arp_handle *handle)
 
 	ret = NI_WICKED_RC_ERROR;
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		ret = NI_WICKED_RC_SUCCESS;
 		timeout = ni_timer_next_timeout();

--- a/client/compat.c
+++ b/client/compat.c
@@ -2450,7 +2450,7 @@ __ni_compat_generate_auto6_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 
 	aconf = __ni_compat_generate_dynamic_addrconf(ifnode, "ipv6:auto", 0, compat->auto6.update);
 
-	if (aconf && compat->auto6.defer_timeout != -1U) {
+	if (aconf && compat->auto6.defer_timeout) {
 		xml_node_dict_set(aconf, "defer-timeout",
 				ni_sprint_timeout(compat->auto6.defer_timeout));
 	}

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -120,7 +120,7 @@ ni_do_ifdown(int argc, char **argv)
 	ni_ifworker_array_t ifmarked;
 	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
 	unsigned int nmarked, max_state = NI_FSM_STATE_DEVICE_DOWN;
-	unsigned int timeout = NI_IFWORKER_DEFAULT_TIMEOUT;
+	unsigned int seconds = NI_IFWORKER_DEFAULT_TIMEOUT;
 	ni_stringbuf_t sb = NI_STRINGBUF_INIT_DYNAMIC;
 	ni_fsm_t *fsm;
 	int c, status = NI_WICKED_RC_USAGE;
@@ -173,11 +173,7 @@ ni_do_ifdown(int argc, char **argv)
 			break;
 
 		case OPT_TIMEOUT:
-			if (!strcmp(optarg, "infinite")) {
-				timeout = NI_IFWORKER_INFINITE_TIMEOUT;
-			} else if (ni_parse_uint(optarg, &timeout, 10) >= 0) {
-				timeout *= 1000; /* sec -> msec */
-			} else {
+			if (ni_parse_seconds_timeout(optarg, &seconds)) {
 				ni_error("ifdown: cannot parse timeout option \"%s\"", optarg);
 				goto usage;
 			}
@@ -199,8 +195,8 @@ usage:
 				"      Delete device. Despite of persistent mode being set\n"
 				"  --no-delete\n"
 				"      Do not attempt to delete a device, neither physical nor virtual\n"
-				"  --timeout <nsec>\n"
-				"      Timeout after <nsec> seconds\n",
+				"  --timeout <sec>\n"
+				"      Timeout after <sec> seconds\n",
 				sb.string
 				);
 			ni_stringbuf_destroy(&sb);
@@ -216,13 +212,14 @@ usage:
 	ifmarker.target_range.min = NI_FSM_STATE_NONE;
 	ifmarker.target_range.max = max_state;
 
-	fsm->worker_timeout = ni_fsm_find_max_timeout(fsm, timeout);
+	fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
+					NI_TIMEOUT_FROM_SEC(seconds));
 
 	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
 		ni_debug_application("wait for interfaces infinitely");
 	else
 		ni_debug_application("wait %u seconds for interfaces",
-					fsm->worker_timeout/1000);
+					NI_TIMEOUT_SEC(fsm->worker_timeout));
 
 	if (!ni_fsm_create_client(fsm)) {
 		/* Severe error we always explicitly return */

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -356,7 +356,7 @@ ni_do_ifreload(const char *caller, int argc, char **argv)
 	ni_nanny_fsm_monitor_t *monitor = NULL;
 	ni_bool_t opt_persistent = FALSE;
 	ni_bool_t opt_transient = FALSE;
-	unsigned int opt_timeout = 0;
+	unsigned int seconds = 0;
 	int c, status = NI_WICKED_RC_USAGE;
 	char *saved_argv0, *program = NULL;
 	unsigned int i;
@@ -386,11 +386,7 @@ ni_do_ifreload(const char *caller, int argc, char **argv)
 			break;
 
 		case OPT_TIMEOUT:
-			if (!strcmp(optarg, "infinite")) {
-				opt_timeout = NI_IFWORKER_INFINITE_TIMEOUT;
-			} else if (ni_parse_uint(optarg, &opt_timeout, 10) >= 0) {
-				opt_timeout *= 1000; /* sec -> msec */
-			} else {
+			if (ni_parse_seconds_timeout(optarg, &seconds)) {
 				ni_error("%s: cannot parse timeout option \"%s\"",
 						program, optarg);
 				goto usage;
@@ -459,12 +455,12 @@ usage:
 	}
 
 	/* Set timeout how long the action is allowed to wait */
-	if (opt_timeout) {
-		fsm->worker_timeout = opt_timeout; /* One set by user */
+	if (seconds) {
+		fsm->worker_timeout = NI_TIMEOUT_FROM_SEC(seconds);
 	} else
 	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-					ni_wait_for_interfaces*1000);
+					NI_TIMEOUT_FROM_SEC(ni_wait_for_interfaces));
 	} else {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
 					NI_IFWORKER_DEFAULT_TIMEOUT);
@@ -474,7 +470,7 @@ usage:
 		ni_debug_application("wait for interfaces infinitely");
 	else
 		ni_debug_application("wait %u seconds for interfaces",
-					fsm->worker_timeout/1000);
+					NI_TIMEOUT_SEC(fsm->worker_timeout));
 
 	/* Build the up a config relations/hierarchy tree */
 	if (ni_fsm_build_hierarchy(fsm, FALSE) < 0) {

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -409,14 +409,14 @@ ni_nanny_fsm_monitor_run(ni_nanny_fsm_monitor_t *monitor, ni_ifworker_array_t *m
 
 	monitor->marked = ni_ifworker_array_clone(marked);
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		if (!monitor->marked || !monitor->marked->count)
 			break;
 
 		timeout = ni_timer_next_timeout();
 		if (monitor->timeout == 0 ||
-		    (monitor->timeout > 0 && timeout < 0))
+		    (monitor->timeout > 0 && timeout == NI_TIMEOUT_INFINITE))
 			break;
 
 		if (ni_socket_wait(timeout) != 0)

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -37,6 +37,7 @@
 
 #include <wicked/netinfo.h>
 #include <wicked/logging.h>
+#include <wicked/socket.h>
 #include <wicked/fsm.h>
 
 #include "client/ifconfig.h"

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -49,7 +49,7 @@
 
 struct ni_nanny_fsm_monitor {
 	const ni_timer_t *      timer;
-	unsigned long		timeout;
+	ni_timeout_t		timeout;
 	ni_ifworker_array_t *	marked;
 };
 
@@ -387,7 +387,7 @@ ni_nanny_fsm_monitor_new(ni_fsm_t *fsm)
 }
 
 ni_bool_t
-ni_nanny_fsm_monitor_arm(ni_nanny_fsm_monitor_t *monitor, unsigned long timeout)
+ni_nanny_fsm_monitor_arm(ni_nanny_fsm_monitor_t *monitor, ni_timeout_t timeout)
 {
 	if (monitor) {
 		monitor->timeout = timeout;
@@ -485,7 +485,7 @@ ni_do_ifup(int argc, char **argv)
 	ni_bool_t check_prio = TRUE, set_persistent = FALSE;
 	ni_bool_t opt_transient = FALSE;
 	int c, status = NI_WICKED_RC_USAGE;
-	unsigned int timeout = 0;
+	unsigned int seconds = 0;
 	ni_fsm_t *fsm;
 
 	fsm = ni_fsm_new();
@@ -516,16 +516,9 @@ ni_do_ifup(int argc, char **argv)
 			break;
 
 		case OPT_TIMEOUT:
-			if (!strcmp(optarg, "infinite")) {
-				timeout = NI_IFWORKER_INFINITE_TIMEOUT;
-			} else {
-				unsigned int sec;
-
-				if (ni_parse_uint(optarg, &sec, 10) < 0) {
-					ni_error("ifup: cannot parse timeout option \"%s\"", optarg);
-					goto usage;
-				}
-				timeout = sec * 1000; /* sec -> msec */
+			if (ni_parse_seconds_timeout(optarg, &seconds)) {
+				ni_error("ifup: cannot parse timeout option \"%s\"", optarg);
+				goto usage;
 			}
 			break;
 
@@ -622,12 +615,12 @@ usage:
 	}
 
 	/* Set timeout how long the action is allowed to wait */
-	if (timeout) {
-		fsm->worker_timeout = timeout; /* One set by user */
+	if (seconds) {
+		fsm->worker_timeout = NI_TIMEOUT_FROM_SEC(seconds);
 	} else
 	if (ni_wait_for_interfaces) {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-				ni_wait_for_interfaces*1000);
+				NI_TIMEOUT_FROM_SEC(ni_wait_for_interfaces));
 	} else {
 		fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
 				NI_IFWORKER_DEFAULT_TIMEOUT);
@@ -637,7 +630,7 @@ usage:
 		ni_debug_application("wait for interfaces infinitely");
 	else
 		ni_debug_application("wait %u seconds for interfaces",
-					fsm->worker_timeout/1000);
+					NI_TIMEOUT_SEC(fsm->worker_timeout));
 
 	ni_nanny_fsm_monitor_arm(monitor, fsm->worker_timeout);
 

--- a/client/main.c
+++ b/client/main.c
@@ -94,7 +94,7 @@ int			opt_global_dryrun;
 char *			opt_global_rootdir;
 ni_bool_t		opt_systemd;
 
-unsigned int ni_wait_for_interfaces;
+unsigned int 		ni_wait_for_interfaces;
 
 static int		do_show_xml(int, char **);
 extern int		do_nanny(int, char **);

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -376,9 +376,11 @@ __ni_suse_read_global_ifsysctl(const char *root, const char *path)
 					__ni_suse_string_compare);
 
 			for (i = 0; i < names.count; ++i) {
-				snprintf(pathbuf, sizeof(pathbuf), "%s/%s",
-						dirname, names.data[i]);
-				name = ni_realpath(pathbuf, &real);
+				char *path = NULL;
+				if (!ni_string_printf(&path, "%s/%s", dirname, names.data[i]))
+					continue;
+				name = ni_realpath(path, &real);
+				ni_string_free(&path);
 				if (name && ni_isreg(name))
 					ni_string_array_append(&files, name);
 				ni_string_free(&real);

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5394,7 +5394,7 @@ __ni_suse_addrconf_dhcp4_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 		compat->dhcp4.acquire_timeout = uint;
 
 	if (ni_sysconfig_get_integer(sc, "DHCLIENT_LEASE_TIME", &uint))
-		compat->dhcp4.lease_time = ((int) uint >= 0) ? uint : 0;
+		compat->dhcp4.lease_time = uint;
 
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT_USE_LAST_LEASE")))
 		compat->dhcp4.recover_lease = !ni_string_eq(string, "no");
@@ -5578,7 +5578,7 @@ __ni_suse_addrconf_dhcp6_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 		compat->dhcp6.acquire_timeout = uint;
 
 	if (ni_sysconfig_get_integer(sc, "DHCLIENT6_LEASE_TIME", &uint))
-		compat->dhcp6.lease_time = ((int) uint >= 0) ? uint : 0;
+		compat->dhcp6.lease_time = uint;
 
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_USE_LAST_LEASE")))
 		compat->dhcp6.recover_lease = !ni_string_eq(string, "no");

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -1684,10 +1684,9 @@ __ni_suse_startmode(const ni_sysconfig_t *sc)
 		}
 
 		if ((value = ni_sysconfig_get_value(sc, "LINK_READY_WAIT"))) {
-			if (ni_string_eq(value, "infinite"))
-				control->link_timeout = NI_IFWORKER_INFINITE_TIMEOUT;
-			else
-				ni_parse_uint(value, &control->link_timeout, 10);
+			if (ni_parse_seconds_timeout(value, &control->link_timeout)
+			||  control->link_timeout == NI_IFWORKER_INFINITE_SECONDS)
+				control->link_timeout = 0; /* ifcfg(5): default is 0 */
 		}
 	}
 	return control;
@@ -5724,7 +5723,7 @@ __ni_suse_addrconf_auto6(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 	}
 
 	compat->auto6.enabled = TRUE;
-	compat->auto6.defer_timeout = -1U; /* use a built-in timeout by default */
+	compat->auto6.defer_timeout = 0; /* use a built-in timeout by default */
 	if ((merged = ni_sysconfig_merge_defaults(sc, __ni_suse_config_defaults))) {
 		const char *value;
 

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -165,7 +165,7 @@ typedef struct ni_nanny_fsm_monitor	ni_nanny_fsm_monitor_t;
 
 extern ni_nanny_fsm_monitor_t *	ni_nanny_fsm_monitor_new(ni_fsm_t *);
 extern ni_bool_t		ni_nanny_fsm_monitor_arm(ni_nanny_fsm_monitor_t *,
-							unsigned long);
+							ni_timeout_t);
 extern void			ni_nanny_fsm_monitor_run(ni_nanny_fsm_monitor_t *,
 							ni_ifworker_array_t *, int);
 extern void			ni_nanny_fsm_monitor_reset(ni_nanny_fsm_monitor_t *);

--- a/dhcp4/main.c
+++ b/dhcp4/main.c
@@ -492,7 +492,7 @@ dhcp4_supplicant(void)
 #endif
 
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		do {
 			timeout = ni_timer_next_timeout();

--- a/dhcp6/main.c
+++ b/dhcp6/main.c
@@ -468,7 +468,7 @@ dhcp6_supplicant(void)
 #endif
 
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		do {
 			timeout = ni_timer_next_timeout();

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -39,6 +39,7 @@ wicked_include_HEADERS		= \
 	wicked/sysconfig.h	\
 	wicked/system.h		\
 	wicked/team.h		\
+	wicked/time.h		\
 	wicked/tunneling.h	\
 	wicked/tuntap.h		\
 	wicked/types.h		\

--- a/include/wicked/address.h
+++ b/include/wicked/address.h
@@ -14,9 +14,6 @@
 #include <wicked/types.h>
 #include <wicked/util.h>
 
-#define NI_LIFETIME_EXPIRED	0
-#define NI_LIFETIME_INFINITE	0xffffffffU
-
 union ni_sockaddr {
 	sa_family_t		ss_family;
 	struct sockaddr_storage	ss;

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -44,8 +44,9 @@ typedef enum ni_config_origin_prio {
 	NI_CONFIG_ORIGIN_PRIO_UNKNOWN = 100,
 } ni_config_origin_prio_t;
 
-#define NI_IFWORKER_DEFAULT_TIMEOUT	30000
-#define NI_IFWORKER_INFINITE_TIMEOUT	((unsigned int) -1)
+#define NI_IFWORKER_DEFAULT_TIMEOUT	NI_TIMEOUT_FROM_SEC(30)
+#define NI_IFWORKER_INFINITE_TIMEOUT	NI_TIMEOUT_INFINITE
+#define NI_IFWORKER_INFINITE_SECONDS	NI_SECONDS_INFINITE
 
 typedef struct ni_fsm			ni_fsm_t;
 typedef struct ni_ifworker		ni_ifworker_t;
@@ -252,7 +253,7 @@ struct ni_fsm_event {
 struct ni_fsm {
 	ni_ifworker_array_t	pending;
 	ni_ifworker_array_t	workers;
-	unsigned int		worker_timeout;
+	ni_timeout_t		worker_timeout;
 	ni_bool_t		readonly;
 
 	unsigned int		timeout_count;
@@ -399,7 +400,7 @@ extern void			ni_ifworker_array_remove_with_children(ni_ifworker_array_t *, ni_i
 extern int			ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
 extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);
 
-extern unsigned int		ni_fsm_find_max_timeout(ni_fsm_t *, unsigned int);
+extern ni_timeout_t		ni_fsm_find_max_timeout(ni_fsm_t *, ni_timeout_t);
 extern void			ni_fsm_require_register_type(const char *, ni_fsm_require_ctor_t *);
 extern ni_fsm_require_t *	ni_fsm_require_new(ni_fsm_require_fn_t *, ni_fsm_require_dtor_t *);
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -330,7 +330,7 @@ extern unsigned int		ni_fsm_policy_array_index(const ni_fsm_policy_array_t *, co
 extern ni_dbus_client_t *	ni_fsm_create_client(ni_fsm_t *);
 extern ni_bool_t		ni_fsm_refresh_state(ni_fsm_t *);
 extern unsigned int		ni_fsm_schedule(ni_fsm_t *);
-extern ni_bool_t		ni_fsm_do(ni_fsm_t *fsm, long *timeout_p);
+extern ni_bool_t		ni_fsm_do(ni_fsm_t *, ni_timeout_t *);
 extern void			ni_fsm_mainloop(ni_fsm_t *);
 extern void			ni_fsm_set_process_event_callback(ni_fsm_t *, void (*)(ni_fsm_t *, ni_ifworker_t *, ni_fsm_event_t *), void *);
 extern unsigned int		ni_fsm_get_matching_workers(ni_fsm_t *, ni_ifmatcher_t *, ni_ifworker_array_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -8,7 +8,7 @@
 #ifndef __CLIENT_FSM_H__
 #define __CLIENT_FSM_H__
 
-#include <wicked/socket.h>	/* needed for ni_timer_t */
+#include <wicked/time.h>
 #include <wicked/secret.h>
 #include <wicked/objectmodel.h>
 #include <wicked/dbus.h>

--- a/include/wicked/socket.h
+++ b/include/wicked/socket.h
@@ -1,46 +1,31 @@
 /*
- * Network socket related functionality for wicked.
- * No user serviceable parts inside.
+ *	Network socket related functionality for wicked.
  *
- * Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2012-2021 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
  */
 
-#ifndef __WICKED_SOCKET_H__
-#define __WICKED_SOCKET_H__
-
-#include <stdio.h>
+#ifndef WICKED_SOCKET_H
+#define WICKED_SOCKET_H
 
 #include <wicked/types.h>
-#include <sys/types.h>
-
-typedef struct ni_timeout_param {
-	int			nretries;	/* limit the number of retries; < 0 means unlimited */
-
-	unsigned int		timeout;	/* current timeout value, without jitter */
-	int			increment;	/* how to change the timeout every time ni_timeout_increase()
-						 * is called.
-						 * If == 0, timeout stays constant.
-						 * If > 0, timeout is incremented by this value every time (linear backoff).
-						 * If < 0, timeout is doubled every time (exponential backoff)
-						 */
-	ni_int_range_t		jitter;		/* randomize timeout in [jitter.min, jitter.max] interval */
-	unsigned int		max_timeout;	/* timeout is capped by max_timeout */
-
-	ni_bool_t		(*backoff_callback)(struct ni_timeout_param *);
-	int			(*timeout_callback)(void *);
-	void			*timeout_data;
-} ni_timeout_param_t;
-
-typedef struct ni_timer	ni_timer_t;
-typedef void		ni_timeout_callback_t(void *, const ni_timer_t *);
-
-extern const ni_timer_t *ni_timer_register(unsigned long, ni_timeout_callback_t *, void *);
-extern void *		ni_timer_cancel(const ni_timer_t *);
-extern const ni_timer_t *ni_timer_rearm(const ni_timer_t *, unsigned long);
-extern long		ni_timer_next_timeout(void);
-extern int		ni_timer_get_time(struct timeval *tv);
-extern int		ni_time_timer_to_real(const struct timeval *, struct timeval *);
-extern int		ni_time_real_to_timer(const struct timeval *, struct timeval *);
 
 extern ni_socket_t *	ni_socket_hold(ni_socket_t *);
 extern void		ni_socket_release(ni_socket_t *);
@@ -52,10 +37,4 @@ extern int		ni_socket_wait(long timeout);
 
 extern void		ni_socket_close(ni_socket_t *);
 
-extern unsigned long	ni_timeout_arm(struct timeval *, const ni_timeout_param_t *);
-extern unsigned long	ni_timeout_arm_msec(struct timeval *, const ni_timeout_param_t *);
-extern unsigned long	ni_timeout_randomize(unsigned long timeout, const ni_int_range_t *jitter);
-extern ni_bool_t	ni_timeout_recompute(ni_timeout_param_t *);
-
-#endif /* __WICKED_SOCKET_H__ */
-
+#endif /* WICKED_SOCKET_H */

--- a/include/wicked/socket.h
+++ b/include/wicked/socket.h
@@ -33,7 +33,7 @@ extern ni_socket_t *	ni_socket_wrap(int fd, int sotype);
 extern ni_bool_t	ni_socket_activate(ni_socket_t *);
 extern ni_bool_t	ni_socket_deactivate(ni_socket_t *);
 extern void		ni_socket_deactivate_all(void);
-extern int		ni_socket_wait(long timeout);
+extern int		ni_socket_wait(ni_timeout_t timeout);
 
 extern void		ni_socket_close(ni_socket_t *);
 

--- a/include/wicked/time.h
+++ b/include/wicked/time.h
@@ -1,0 +1,67 @@
+/*
+ *	Time related functionality for wicked.
+ *
+ *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2012-2021 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
+ */
+
+#ifndef WICKED_TIME_H
+#define WICKED_TIME_H
+
+#include <wicked/types.h>
+
+typedef	struct ni_timeout_param	ni_timeout_param_t;
+
+struct ni_timeout_param {
+	int			nretries;	/* limit the number of retries; < 0 means unlimited */
+
+	unsigned int		timeout;	/* current timeout value, without jitter */
+	int			increment;	/* how to change the timeout every time ni_timeout_increase()
+						 * is called.
+						 * If == 0, timeout stays constant.
+						 * If > 0, timeout is incremented by this value every time (linear backoff).
+						 * If < 0, timeout is doubled every time (exponential backoff)
+						 */
+	ni_int_range_t		jitter;		/* randomize timeout in [jitter.min, jitter.max] interval */
+	unsigned int		max_timeout;	/* timeout is capped by max_timeout */
+
+	ni_bool_t		(*backoff_callback)(struct ni_timeout_param *);
+	int			(*timeout_callback)(void *);
+	void			*timeout_data;
+};
+
+typedef struct ni_timer		ni_timer_t;
+typedef void			ni_timeout_callback_t(void *, const ni_timer_t *);
+
+extern const ni_timer_t *	ni_timer_register(unsigned long, ni_timeout_callback_t *, void *);
+extern void *			ni_timer_cancel(const ni_timer_t *);
+extern const ni_timer_t *	ni_timer_rearm(const ni_timer_t *, unsigned long);
+extern long			ni_timer_next_timeout(void);
+extern int			ni_timer_get_time(struct timeval *tv);
+
+extern int			ni_time_timer_to_real(const struct timeval *, struct timeval *);
+extern int			ni_time_real_to_timer(const struct timeval *, struct timeval *);
+
+extern unsigned long		ni_timeout_arm(struct timeval *, const ni_timeout_param_t *);
+extern unsigned long		ni_timeout_arm_msec(struct timeval *, const ni_timeout_param_t *);
+extern unsigned long		ni_timeout_randomize(unsigned long timeout, const ni_int_range_t *jitter);
+extern ni_bool_t		ni_timeout_recompute(ni_timeout_param_t *);
+
+#endif /* WICKED_TIME_H */

--- a/include/wicked/time.h
+++ b/include/wicked/time.h
@@ -27,12 +27,37 @@
 
 #include <wicked/types.h>
 
-typedef	struct ni_timeout_param	ni_timeout_param_t;
+/*
+ * Lifetime is an uint32 in seconds as in dhcp, ipv6 RFCs, ...
+ *
+ * Timeout is a sufficient type to store lifetimes and timeouts
+ * from config files/user options in miliseconds.
+ *
+ * Jitter is an int range (in miliseconds limitted to +/-24days)
+ * to randomize a timeout (usually +/-0.1sec or 1-10sec ranges).
+ *
+ * We're using timeval for the actual time in microseconds, what
+ * allows to use the timeradd, ... <sys/time.h> macros/functions.
+ */
+#define NI_SECONDS_INFINITE	0xffffffffU
+
+#define NI_LIFETIME_EXPIRED	0U
+#define NI_LIFETIME_INFINITE	NI_SECONDS_INFINITE
+
+#define NI_TIMEOUT_UNIT		((ni_timeout_t)1000)
+#define NI_TIMEOUT_FROM_SEC(s)	((ni_timeout_t)s * NI_TIMEOUT_UNIT)
+#define NI_TIMEOUT_SEC(t)	((unsigned int)(t / NI_TIMEOUT_UNIT))
+#define NI_TIMEOUT_MSEC(t)	((unsigned int)(t % NI_TIMEOUT_UNIT))
+#define NI_TIMEOUT_USEC(t)	((suseconds_t)(t % NI_TIMEOUT_UNIT) * 1000)
+
+#define NI_TIMEOUT_INFINITE	NI_TIMEOUT_FROM_SEC(NI_SECONDS_INFINITE)
+
+typedef struct ni_timeout_param	ni_timeout_param_t;
 
 struct ni_timeout_param {
 	int			nretries;	/* limit the number of retries; < 0 means unlimited */
 
-	unsigned int		timeout;	/* current timeout value, without jitter */
+	ni_timeout_t		timeout;	/* current timeout value, without jitter */
 	int			increment;	/* how to change the timeout every time ni_timeout_increase()
 						 * is called.
 						 * If == 0, timeout stays constant.
@@ -40,7 +65,7 @@ struct ni_timeout_param {
 						 * If < 0, timeout is doubled every time (exponential backoff)
 						 */
 	ni_int_range_t		jitter;		/* randomize timeout in [jitter.min, jitter.max] interval */
-	unsigned int		max_timeout;	/* timeout is capped by max_timeout */
+	ni_timeout_t		max_timeout;	/* timeout is capped by max_timeout */
 
 	ni_bool_t		(*backoff_callback)(struct ni_timeout_param *);
 	int			(*timeout_callback)(void *);
@@ -50,18 +75,23 @@ struct ni_timeout_param {
 typedef struct ni_timer		ni_timer_t;
 typedef void			ni_timeout_callback_t(void *, const ni_timer_t *);
 
-extern const ni_timer_t *	ni_timer_register(unsigned long, ni_timeout_callback_t *, void *);
+extern const ni_timer_t *	ni_timer_register(ni_timeout_t, ni_timeout_callback_t *, void *);
 extern void *			ni_timer_cancel(const ni_timer_t *);
-extern const ni_timer_t *	ni_timer_rearm(const ni_timer_t *, unsigned long);
-extern long			ni_timer_next_timeout(void);
-extern int			ni_timer_get_time(struct timeval *tv);
+extern const ni_timer_t *	ni_timer_rearm(const ni_timer_t *, ni_timeout_t);
+extern ni_timeout_t		ni_timer_next_timeout(void);
+extern int			ni_timer_get_time(struct timeval *);
 
 extern int			ni_time_timer_to_real(const struct timeval *, struct timeval *);
 extern int			ni_time_real_to_timer(const struct timeval *, struct timeval *);
 
-extern unsigned long		ni_timeout_arm(struct timeval *, const ni_timeout_param_t *);
-extern unsigned long		ni_timeout_arm_msec(struct timeval *, const ni_timeout_param_t *);
-extern unsigned long		ni_timeout_randomize(unsigned long timeout, const ni_int_range_t *jitter);
+extern ni_timeout_t		ni_timeout_arm_sec(struct timeval *, const ni_timeout_param_t *);
+extern ni_timeout_t		ni_timeout_arm_msec(struct timeval *, const ni_timeout_param_t *);
+extern ni_timeout_t		ni_timeout_randomize(ni_timeout_t, const ni_int_range_t *);
 extern ni_bool_t		ni_timeout_recompute(ni_timeout_param_t *);
+
+extern ni_timeout_t		ni_timeout_since(const struct timeval *, const struct timeval *, struct timeval *);
+extern ni_timeout_t		ni_timeout_left(const struct timeval *, const struct timeval *, struct timeval *);
+
+extern ni_bool_t		ni_timeval_add_timeout(struct timeval *, ni_timeout_t);
 
 #endif /* WICKED_TIME_H */

--- a/include/wicked/types.h
+++ b/include/wicked/types.h
@@ -24,7 +24,9 @@ typedef enum {
 	NI_TRISTATE_ENABLE	= 1
 } ni_tristate_t;
 
-typedef union ni_sockaddr	ni_sockaddr_t;
+typedef unsigned long long	ni_timeout_t;
+
+typedef union  ni_sockaddr	ni_sockaddr_t;
 typedef struct ni_netconfig	ni_netconfig_t;
 typedef struct ni_netdev	ni_netdev_t;
 typedef struct ni_route		ni_route_t;

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -444,6 +444,8 @@ extern void		ni_string_toupper(char *);
 extern char *		ni_sprint_hex(const unsigned char *, size_t);
 extern const char *	ni_sprint_uint(unsigned int);
 extern const char *	ni_sprint_timeout(unsigned int);
+extern const char *	ni_format_seconds_timeout(char **, unsigned int);
+extern int		ni_parse_seconds_timeout(const char *, unsigned int *);
 
 /*
  * When we allocate temporary resources (such as tempfiles)

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -10,9 +10,9 @@
 #include <sys/mman.h>
 
 #include <wicked/types.h>
+#include <wicked/time.h>
 #include <wicked/util.h>
 #include <wicked/logging.h>
-#include <wicked/socket.h>	/* for the timer stuff */
 
 typedef enum ni_wireless_mode {
 	NI_WIRELESS_MODE_UNKNOWN,

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -224,19 +224,23 @@ ni_nanny_policy_load(ni_nanny_t *mgr)
 		unsigned int i;
 
 		for (i = 0; i < files.count; ++i) {
-			char path[PATH_MAX];
+			char *path = NULL;
 			xml_document_t *doc;
 
-			snprintf(path, sizeof(path), "%s/%s", nanny_dir, files.data[i]);
-			doc = xml_document_read(path);
-			if (doc == NULL) {
+			if (!ni_string_printf(&path, "%s/%s", nanny_dir, files.data[i]))
+				continue;
+
+			if (!(doc = xml_document_read(path))) {
 				ni_error("Unable to read policy file %s: %m", path);
+				ni_string_free(&path);
 				continue;
 			}
 
 			if (!ni_nanny_create_policy(NULL, mgr, doc, NULL, TRUE)) {
 				ni_error("Unable to create policy from file '%s'", path);
 			}
+
+			ni_string_free(&path);
 			xml_document_free(doc);
 		}
 	}

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -289,7 +289,7 @@ babysit(void)
 #endif
 
 	while (!ni_caught_terminal_signal()) {
-		long timeout = NI_IFWORKER_INFINITE_TIMEOUT;
+		ni_timeout_t timeout = NI_TIMEOUT_INFINITE;
 
 		do {
 			ni_fsm_do(mgr->fsm, &timeout);

--- a/nanny/policy.c
+++ b/nanny/policy.c
@@ -47,7 +47,7 @@ ni_managed_policy_filename(const char *name, char *path, size_t size)
 static ni_bool_t
 ni_managed_policy_save_node(const xml_node_t *pnode)
 {
-	char path[PATH_MAX] = {'\0'};
+	char path[PATH_MAX - sizeof(".XXXXXX")] = {'\0'};
 	char temp[PATH_MAX] = {'\0'};
 	const char *pname;
 	FILE *fp;

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -200,11 +200,11 @@
       <identifier type="string"/>
     </user-class>
 
-    <start-delay type="uint32" />
-    <defer-timeout type="uint32" />
-    <acquire-timeout type="uint32" />
+    <start-delay type="seconds-type" />
+    <defer-timeout type="seconds-type" />
+    <acquire-timeout type="seconds-type" />
 
-    <lease-time type="uint32" />
+    <lease-time type="seconds-type" />
     <recover-lease type="boolean" />
     <release-lease type="boolean" />
     <broadcast type="tristate" />
@@ -261,11 +261,11 @@
     <client-id type="string" />
     <!-- vendor-class type="string" / -->
 
-    <start-delay type="uint32" />
-    <defer-timeout type="uint32" />
-    <acquire-timeout type="uint32" />
+    <start-delay type="seconds-type" />
+    <defer-timeout type="seconds-type" />
+    <acquire-timeout type="seconds-type" />
 
-    <lease-time type="uint32" />
+    <lease-time type="seconds-type" />
     <recover-lease type="boolean" />
     <release-lease type="boolean" />
 
@@ -342,7 +342,7 @@
 <service name="ipv6:auto" interface="org.opensuse.Network.Addrconf.ipv6.auto" object-class="netif">
   <define name="request" class="dict">
     <enabled type="boolean"/>
-    <defer-timeout type="uint32" />
+    <defer-timeout type="seconds-type" />
     <update type="builtin-addrconf-update-mask" />
   </define>
   <define name="properties" type="interface:addrconf-lease"/>

--- a/schema/interface.xml
+++ b/schema/interface.xml
@@ -17,8 +17,8 @@
    <label type="string"/>
 
    <cache-info class="dict">
-     <valid-lifetime type="uint32" />
-     <preferred-lifetime type="uint32" />
+     <valid-lifetime type="valid-lifetime-type" />
+     <preferred-lifetime type="pref-lifetime-type" />
    </cache-info>
 
    <!-- This is the addrconf method that owns this address -->

--- a/schema/types.xml
+++ b/schema/types.xml
@@ -85,4 +85,15 @@
   <false value="0"/>
   <true value="1"/>
 </define>
+<define name="valid-lifetime-type" type="uint32" constraint="enum">
+  <infinite   value="4294967295"/>
+  <expired    value="0"/>
+</define>
+<define name="pref-lifetime-type" type="uint32" constraint="enum">
+  <infinite   value="4294967295"/>
+  <deprecated value="0"/>
+</define>
+<define name="seconds-type" type="uint32" constraint="enum">
+  <infinite   value="4294967295"/>
+</define>
 

--- a/server/main.c
+++ b/server/main.c
@@ -289,7 +289,7 @@ run_interface_server(void)
 #endif
 
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		do {
 			timeout = ni_timer_next_timeout();

--- a/src/address.c
+++ b/src/address.c
@@ -1684,7 +1684,7 @@ ni_lifetime_left(unsigned int lifetime, const struct timeval *acquired, const st
 
 	if (timercmp(current, acquired, >)) {
 		timersub(current, acquired, &dif);
-		if (lifetime >= dif.tv_sec) {
+		if ((unsigned long)lifetime >= (unsigned long)dif.tv_sec) {
 			lifetime -= dif.tv_sec;
 			return lifetime;
 		}

--- a/src/address.c
+++ b/src/address.c
@@ -24,7 +24,7 @@
 
 #include <wicked/logging.h>
 #include <wicked/netinfo.h>
-#include <wicked/socket.h>
+#include <wicked/time.h>
 #include <wicked/route.h>
 #include "util_priv.h"
 

--- a/src/async-resolver.c
+++ b/src/async-resolver.c
@@ -10,7 +10,7 @@
 #include <wicked/address.h>
 #include <wicked/resolver.h>
 #include <wicked/logging.h>
-#include <wicked/socket.h>
+#include <wicked/time.h>
 #include <stdlib.h>
 
 #include <sys/types.h>

--- a/src/capture.c
+++ b/src/capture.c
@@ -327,7 +327,7 @@ ni_capture_inspect_udp_header(void *data, size_t bytes, size_t *payload_len,
 void
 ni_capture_arm_retransmit(ni_capture_t *capture)
 {
-	ni_timeout_arm(&capture->retrans.deadline, &capture->retrans.timeout);
+	ni_timeout_arm_sec(&capture->retrans.deadline, &capture->retrans.timeout);
 }
 
 void

--- a/src/client/client_state.c
+++ b/src/client/client_state.c
@@ -19,7 +19,6 @@
 #include <wicked/fsm.h>
 #include <wicked/xml.h>
 #include <wicked/util.h>
-#include <wicked/socket.h>	/* for ni_timer_get_time()  */
 #include <wicked/netinfo.h>	/* for ni_config_statedir() */
 #include <wicked/logging.h>
 

--- a/src/client/client_state.c
+++ b/src/client/client_state.c
@@ -430,7 +430,7 @@ ni_client_state_scripts_copy(ni_client_state_scripts_t *dst,
 ni_bool_t
 ni_client_state_save(const ni_client_state_t *client_state, unsigned int ifindex)
 {
-	char path[PATH_MAX] = {'\0'};
+	char path[PATH_MAX - sizeof(".XXXXXX")] = {'\0'};
 	char temp[PATH_MAX] = {'\0'};
 	xml_node_t *node;
 	FILE *fp = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -541,7 +541,7 @@ ni_config_parse_addrconf_dhcp4_nodes(ni_config_dhcp4_t *dhcp4, xml_node_t *node)
 			ni_string_dup(&dhcp4->vendor_class, child->cdata);
 		else
 		if (!strcmp(child->name, "lease-time") && child->cdata)
-			dhcp4->lease_time = strtoul(child->cdata, NULL, 0);
+			ni_parse_uint(child->cdata, &dhcp4->lease_time, 0);
 		else
 		if (!strcmp(child->name, "ignore-server")) {
 			if ((attrval = xml_node_get_attr(child, "ip")) != NULL)
@@ -1080,10 +1080,10 @@ ni_config_parse_addrconf_dhcp6_nodes(ni_config_dhcp6_t *dhcp6, xml_node_t *node)
 			}
 		} else
 		if (!strcmp(child->name, "lease-time") && child->cdata) {
-			dhcp6->lease_time = strtoul(child->cdata, NULL, 0);
+			ni_parse_uint(child->cdata, &dhcp6->lease_time, 0);
 		} else
 		if (!strcmp(child->name, "release-retransmits") && child->cdata) {
-			dhcp6->release_nretries = strtoul(child->cdata, NULL, 0);
+			ni_parse_uint(child->cdata, &dhcp6->release_nretries, 0);
 		} else
 		if (!strcmp(child->name, "info-refresh-time")) {
 			const char *attrval;

--- a/src/config.c
+++ b/src/config.c
@@ -1038,11 +1038,9 @@ ni_config_parse_addrconf_dhcp6_nodes(ni_config_dhcp6_t *dhcp6, xml_node_t *node)
 		} else
 		if (!strcmp(child->name, "vendor-class") &&
 		    (attrval = xml_node_get_attr(child, "enterprise-number")) != NULL) {
-			char *      err;
-			long        num;
-			
-			num = strtol(attrval, &err, 0);
-			if (*err != '\0' || num < 0 || num >= 0xffffffff) {
+			unsigned int num;
+
+			if (ni_parse_uint(attrval, &num, 0)) {
 				ni_error("config: unable to parse <vendor-class enterprise-number=\"%s\">",
 						attrval);
 				return FALSE;
@@ -1062,11 +1060,9 @@ ni_config_parse_addrconf_dhcp6_nodes(ni_config_dhcp6_t *dhcp6, xml_node_t *node)
 		} else
 		if (!strcmp(child->name, "vendor-opts") &&
 		    (attrval = xml_node_get_attr(child, "enterprise-number")) != NULL) {
-			char *      err;
-			long        num;
-			
-			num = strtol(attrval, &err, 0);
-			if (*err != '\0' || num < 0 || num >= 0xffffffff) {
+			unsigned int num;
+
+			if (ni_parse_uint(attrval, &num, 0)) {
 				ni_error("config: unable to parse <vendor-class enterprise-number=\"%s\">",
 						attrval);
 				return FALSE;

--- a/src/dbus-objects/misc.c
+++ b/src/dbus-objects/misc.c
@@ -2102,6 +2102,7 @@ ni_objectmodel_set_addrconf_dhcp6_ia_dict(ni_dhcp6_ia_t *ia, const ni_dbus_varia
 {
 	const ni_dbus_variant_t *array;
 	const char *type = NULL;
+	int64_t i64;
 
 	if (!ia || !dict || !ni_dbus_variant_is_dict(dict))
 		return FALSE;
@@ -2122,8 +2123,12 @@ ni_objectmodel_set_addrconf_dhcp6_ia_dict(ni_dhcp6_ia_t *ia, const ni_dbus_varia
 
 	if (!ni_dbus_dict_get_uint32(dict, "iaid", &ia->iaid))
 		return FALSE;
-	if (!ni_dbus_dict_get_int64(dict, "acquired", &ia->acquired.tv_sec))
+	if (ni_dbus_dict_get_int64(dict, "acquired", &i64)) {
+		ia->acquired.tv_sec = i64;
+		ia->acquired.tv_usec = 0;
+	} else {
 		return FALSE;
+	}
 
 	switch (ia->type) {
 	case NI_DHCP6_OPTION_IA_PD:

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -323,7 +323,7 @@ ni_dhcp4_acquire(ni_dhcp4_device_t *dev, const ni_dhcp4_request_t *info)
 	if (config->fqdn.enabled == NI_TRISTATE_DEFAULT)
 		ni_tristate_set(&config->fqdn.enabled, FALSE);
 	if (config->fqdn.enabled == NI_TRISTATE_ENABLE && ni_string_empty(config->hostname))
-		config->fqdn.update = NI_DHCP4_FQDN_UPDATE_NONE;
+		config->fqdn.update = NI_DHCP_FQDN_UPDATE_NONE;
 
 	if (!ni_dhcp4_parse_client_id(&config->client_id, dev->system.hwaddr.type, info->clientid))
 		ni_dhcp4_set_config_client_id(&config->client_id, dev, info->create_cid);

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -343,9 +343,9 @@ ni_dhcp4_acquire(ni_dhcp4_device_t *dev, const ni_dhcp4_request_t *info)
 
 	if (ni_log_facility(NI_TRACE_DHCP)) {
 		ni_trace("Received request:");
-		ni_trace("  acquire-timeout %u", config->acquire_timeout);
-		ni_trace("  max lease-time  %u", config->max_lease_time);
-		ni_trace("  start-delay     %u", config->start_delay);
+		ni_trace("  acquire-timeout %s", ni_sprint_timeout(config->acquire_timeout));
+		ni_trace("  max lease-time  %s", ni_sprint_timeout(config->max_lease_time));
+		ni_trace("  start-delay     %s", ni_sprint_timeout(config->start_delay));
 		ni_trace("  hostname        %s", config->hostname[0]? config->hostname : "<none>");
 		if (config->fqdn.enabled == NI_TRISTATE_ENABLE) {
 			ni_trace("  fqdn            update %s, encode %s, qualify %s",

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -191,7 +191,11 @@ ni_dhcp4_device_uptime(const ni_dhcp4_device_t *dev, unsigned int clamp)
 		timersub(&now, &dev->start_time, &uptime);
 	else
 		timerclear(&uptime);
-	return (uptime.tv_sec < clamp) ? uptime.tv_sec : clamp;
+
+	if ((unsigned long)uptime.tv_sec < (unsigned long)clamp)
+		return (unsigned int)uptime.tv_sec;
+	else
+		return clamp;
 }
 
 void

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -278,7 +278,7 @@ extern int		ni_dhcp4_config_ignore_server(const char *);
 extern int		ni_dhcp4_config_have_server_preference(void);
 extern int		ni_dhcp4_config_server_preference_ipaddr(struct in_addr);
 extern int		ni_dhcp4_config_server_preference_hwaddr(const ni_hwaddr_t *);
-extern unsigned int	ni_dhcp4_config_max_lease_time(void);
+extern unsigned int	ni_dhcp4_config_max_lease_time(const char *);
 extern void		ni_dhcp4_config_free(ni_dhcp4_config_t *);
 
 extern ni_dhcp4_request_t *ni_dhcp4_request_new(void);

--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -500,7 +500,7 @@ ni_dhcp4_fsm_rebind(ni_dhcp4_device_t *dev, ni_bool_t oneshot)
 
 		dev->config->capture_timeout = dev->config->capture_max_timeout;
 		timersub(&expire_time, &now, &deadline);
-		if (deadline.tv_sec < dev->config->capture_timeout)
+		if ((unsigned long)deadline.tv_sec < (unsigned long)dev->config->capture_timeout)
 			dev->config->capture_timeout = deadline.tv_sec;
 
 		ni_dhcp4_fsm_set_timeout(dev, dev->config->capture_timeout);

--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -63,7 +63,7 @@ void
 ni_dhcp4_fsm_init_device(ni_dhcp4_device_t *dev)
 {
 	if (dev->config->defer_timeout) {
-		unsigned long msec = dev->config->defer_timeout * 1000;
+		ni_timeout_t msec = NI_TIMEOUT_FROM_SEC(dev->config->defer_timeout);
 		if (dev->defer.timer)
 			ni_timer_rearm(dev->defer.timer, msec);
 		else
@@ -354,9 +354,10 @@ ni_dhcp4_fsm_restart(ni_dhcp4_device_t *dev)
 }
 
 static void
-ni_dhcp4_fsm_set_timeout_msec(ni_dhcp4_device_t *dev, unsigned int msec)
+ni_dhcp4_fsm_set_timeout_msec(ni_dhcp4_device_t *dev, ni_timeout_t msec)
 {
-	ni_debug_dhcp("%s: setting fsm timeout to %u msec", dev->ifname, msec);
+	ni_debug_dhcp("%s: setting fsm timeout to %u.%03u sec", dev->ifname,
+			NI_TIMEOUT_SEC(msec), NI_TIMEOUT_MSEC(msec));
 	if (dev->fsm.timer)
 		ni_timer_rearm(dev->fsm.timer, msec);
 	else
@@ -364,9 +365,9 @@ ni_dhcp4_fsm_set_timeout_msec(ni_dhcp4_device_t *dev, unsigned int msec)
 }
 
 static void
-ni_dhcp4_fsm_set_timeout(ni_dhcp4_device_t *dev, unsigned int seconds)
+ni_dhcp4_fsm_set_timeout_sec(ni_dhcp4_device_t *dev, unsigned int seconds)
 {
-	ni_dhcp4_fsm_set_timeout_msec(dev, 1000 * seconds);
+	ni_dhcp4_fsm_set_timeout_msec(dev, NI_TIMEOUT_FROM_SEC(seconds));
 }
 
 unsigned int
@@ -417,7 +418,7 @@ __ni_dhcp4_fsm_discover(ni_dhcp4_device_t *dev, int scan_offers)
 	if (dev->config->acquire_timeout && dev->config->acquire_timeout - dev->config->elapsed_timeout < dev->config->capture_max_timeout)
 		dev->config->capture_timeout = dev->config->acquire_timeout - dev->config->elapsed_timeout;
 
-	ni_dhcp4_fsm_set_timeout(dev, dev->config->capture_timeout);
+	ni_dhcp4_fsm_set_timeout_sec(dev, dev->config->capture_timeout);
 	ni_dhcp4_device_send_message(dev, DHCP4_DISCOVER, lease);
 
 	ni_dhcp4_device_drop_best_offer(dev);
@@ -446,7 +447,7 @@ ni_dhcp4_fsm_request(ni_dhcp4_device_t *dev, const ni_addrconf_lease_t *lease)
 	if (dev->config->acquire_timeout && dev->config->acquire_timeout - dev->config->elapsed_timeout < dev->config->capture_max_timeout)
 		dev->config->capture_timeout = dev->config->acquire_timeout - dev->config->elapsed_timeout;
 
-	ni_dhcp4_fsm_set_timeout(dev, dev->config->capture_timeout);
+	ni_dhcp4_fsm_set_timeout_sec(dev, dev->config->capture_timeout);
 	ni_dhcp4_device_send_message(dev, DHCP4_REQUEST, lease);
 }
 
@@ -467,7 +468,7 @@ ni_dhcp4_fsm_renewal(ni_dhcp4_device_t *dev, ni_bool_t oneshot)
 		if (timercmp(&expire_time, &now, >) && timercmp(&deadline, &expire_time, >))
 			deadline = expire_time;
 
-		ni_dhcp4_fsm_set_timeout(dev, deadline.tv_sec - now.tv_sec);
+		ni_dhcp4_fsm_set_timeout_sec(dev, deadline.tv_sec - now.tv_sec);
 		ni_dhcp4_device_send_message_unicast(dev, DHCP4_REQUEST, dev->lease);
 		if (!oneshot)
 			retry = TRUE;
@@ -503,7 +504,7 @@ ni_dhcp4_fsm_rebind(ni_dhcp4_device_t *dev, ni_bool_t oneshot)
 		if ((unsigned long)deadline.tv_sec < (unsigned long)dev->config->capture_timeout)
 			dev->config->capture_timeout = deadline.tv_sec;
 
-		ni_dhcp4_fsm_set_timeout(dev, dev->config->capture_timeout);
+		ni_dhcp4_fsm_set_timeout_sec(dev, dev->config->capture_timeout);
 		ni_dhcp4_device_send_message(dev, DHCP4_REQUEST, dev->lease);
 		if (!oneshot)
 			retry = TRUE;
@@ -548,7 +549,7 @@ ni_dhcp4_fsm_reboot(ni_dhcp4_device_t *dev)
 	dev->lease->fqdn.qualify = dev->config->fqdn.qualify;
 	ni_string_free(&dev->lease->hostname);
 
-	ni_dhcp4_fsm_set_timeout(dev, dev->config->capture_timeout);
+	ni_dhcp4_fsm_set_timeout_sec(dev, dev->config->capture_timeout);
 	ni_dhcp4_device_send_message(dev, DHCP4_REQUEST, dev->lease);
 }
 
@@ -568,7 +569,7 @@ ni_dhcp4_fsm_decline(ni_dhcp4_device_t *dev)
 
 	/* RFC 2131 mandates we should wait for 10 seconds before
 	 * retrying discovery. */
-	ni_dhcp4_fsm_set_timeout(dev, 10);
+	ni_dhcp4_fsm_set_timeout_sec(dev, 10);
 }
 
 void
@@ -689,13 +690,13 @@ ni_dhcp4_fsm_timeout(ni_dhcp4_device_t *dev)
 			return;
 		ni_error("%s: unable to rebind lease", dev->ifname);
 		ni_dhcp4_fsm_restart(dev);
-		ni_dhcp4_fsm_set_timeout(dev, ni_dhcp4_fsm_start_delay(conf->start_delay));
+		ni_dhcp4_fsm_set_timeout_sec(dev, ni_dhcp4_fsm_start_delay(conf->start_delay));
 		break;
 
 	case NI_DHCP4_STATE_REBOOT:
 		ni_error("%s: unable to confirm lease", dev->ifname);
 		ni_dhcp4_fsm_restart(dev);
-		ni_dhcp4_fsm_set_timeout(dev, ni_dhcp4_fsm_start_delay(conf->start_delay));
+		ni_dhcp4_fsm_set_timeout_sec(dev, ni_dhcp4_fsm_start_delay(conf->start_delay));
 		break;
 	case __NI_DHCP4_STATE_MAX:
 		break;
@@ -832,10 +833,10 @@ ni_dhcp4_process_ack(ni_dhcp4_device_t *dev, ni_addrconf_lease_t *lease)
 
 	if (lease->dhcp4.rebind_time >= lease->dhcp4.lease_time) {
 		ni_debug_dhcp("%s: dhcp4.rebind_time greater than dhcp4.lease_time, using default", dev->ifname);
-		lease->dhcp4.rebind_time = lease->dhcp4.lease_time * 7 / 8;
+		lease->dhcp4.rebind_time = (unsigned long long)lease->dhcp4.lease_time * 7 / 8;
 	} else if (lease->dhcp4.rebind_time == 0) {
 		ni_debug_dhcp("%s: no dhcp4.rebind_time supplied, using default", dev->ifname);
-		lease->dhcp4.rebind_time = lease->dhcp4.lease_time * 7 / 8;
+		lease->dhcp4.rebind_time = (unsigned long long)lease->dhcp4.lease_time * 7 / 8;
 	}
 
 	if (lease->dhcp4.renewal_time >= lease->dhcp4.rebind_time) {
@@ -848,7 +849,7 @@ ni_dhcp4_process_ack(ni_dhcp4_device_t *dev, ni_addrconf_lease_t *lease)
 
 	if (lease->dhcp4.renewal_time > dev->config->max_lease_time) {
 		ni_debug_dhcp("clamping lease time to %u sec", dev->config->max_lease_time);
-		lease->dhcp4.renewal_time = dev->config->max_lease_time;
+		lease->dhcp4.renewal_time = dev->config->max_lease_time / 2;
 	}
 
 	/* set lease to validate and commit or decline */
@@ -882,7 +883,7 @@ ni_dhcp4_fsm_commit_lease(ni_dhcp4_device_t *dev, ni_addrconf_lease_t *lease)
 		if (dev->config->dry_run == NI_DHCP4_RUN_NORMAL) {
 			ni_debug_dhcp("%s: schedule renewal of lease in %u seconds",
 					dev->ifname, lease->dhcp4.renewal_time);
-			ni_dhcp4_fsm_set_timeout(dev, lease->dhcp4.renewal_time);
+			ni_dhcp4_fsm_set_timeout_sec(dev, lease->dhcp4.renewal_time);
 		}
 
 		/* If the user requested a specific route metric, apply it now */
@@ -1197,7 +1198,7 @@ ni_dhcp4_process_nak(ni_dhcp4_device_t *dev)
 
 	/* If we constantly get NAKs then we should slowly back off */
 	ni_debug_dhcp("Received NAK, backing off for %u seconds", dev->dhcp4.nak_backoff);
-	ni_dhcp4_fsm_set_timeout(dev, dev->dhcp4.nak_backoff);
+	ni_dhcp4_fsm_set_timeout_sec(dev, dev->dhcp4.nak_backoff);
 
 	dev->dhcp4.nak_backoff *= 2;
 	if (dev->dhcp4.nak_backoff > NAK_BACKOFF_MAX)

--- a/src/dhcp4/tester.c
+++ b/src/dhcp4/tester.c
@@ -359,7 +359,7 @@ ni_dhcp4_tester_run(ni_dhcp4_tester_t *opts)
 
 	dhcp4_tester_status = NI_WICKED_RC_IN_PROGRESS;
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		timeout = ni_timer_next_timeout();
 

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -340,7 +340,7 @@ ni_dhcp6_device_uptime(const ni_dhcp6_device_t *dev, unsigned int clamp)
 {
 	struct timeval now;
 	struct timeval delta;
-	long           uptime = 0;
+	unsigned long uptime = 0;
 
 	ni_timer_get_time(&now);
 	if (timerisset(&dev->retrans.start) && timercmp(&now, &dev->retrans.start, >)) {

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -25,7 +25,7 @@
 
 #include <wicked/netinfo.h>	/* FIXME: required by addrconf.h ... */
 #include <wicked/addrconf.h>
-#include <wicked/socket.h>
+#include <wicked/time.h>
 #include "dhcp6/options.h"
 #include "dhcp6/request.h"
 #include "buffer.h"

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -201,9 +201,9 @@ struct ni_dhcp6_device {
 	struct {
 	    struct timeval	start;		/* when we've sent first msg        */
 	    unsigned int	count;		/* transfer count                   */
-	    unsigned int	delay;		/* initial delay                    */
+	    ni_timeout_t	delay;		/* initial delay in msec            */
 	    unsigned int	jitter;		/* jitter base for 1000 msec        */
-	    unsigned int	duration;	/* max duration in msec             */
+	    ni_timeout_t	duration;	/* max duration in msec             */
 	    struct timeval	deadline;	/* next delay/timeout deadline      */
 	    ni_timeout_param_t	params;		/* timeout parameters               */
 	} retrans;

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -2140,6 +2140,7 @@ ni_dhcp6_fsm_decline(ni_dhcp6_device_t *dev)
 
 
 	if (dev->retrans.count == 0) {
+		ni_dhcp6_fsm_timer_cancel(dev);
 
 		if (!ni_dhcp6_fsm_decline_info(dev, dev->lease->dhcp6.ia_list,
 				"Initiating DHCPv6 lease addresses decline",
@@ -2345,6 +2346,7 @@ ni_dhcp6_fsm_bound_info(ni_dhcp6_device_t *dev)
 	unsigned int refresh;
 	struct timeval now;
 
+	ni_dhcp6_fsm_timer_cancel(dev);
 	dev->fsm.state = NI_DHCP6_STATE_BOUND;
 
 	refresh = ni_dhcp6_config_info_refresh_time(dev->ifname, &range);
@@ -2386,6 +2388,7 @@ ni_dhcp6_fsm_bound(ni_dhcp6_device_t *dev)
 	if (dev->config->mode & NI_BIT(NI_DHCP6_MODE_INFO))
 		return ni_dhcp6_fsm_bound_info(dev);
 
+	ni_dhcp6_fsm_timer_cancel(dev);
 	timeout = ni_dhcp6_fsm_get_renewal_timeout(dev);
 	if (timeout > 0) {
 		dev->fsm.state = NI_DHCP6_STATE_BOUND;

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -1675,8 +1675,15 @@ ni_dhcp6_remaining_time(struct timeval *start, unsigned int timeout)
 	struct timeval dif;
 
 	ni_timer_get_time(&now);
-	timersub(&now, start, &dif);
-	return timeout > dif.tv_sec ? timeout - dif.tv_sec : 0;
+	if (timercmp(&now, start, >))
+		timersub(&now, start, &dif);
+	else
+		timerclear(&dif);
+
+	if ((unsigned long)timeout > (unsigned long)dif.tv_sec)
+		return (unsigned int)(timeout - dif.tv_sec);
+	else
+		return 0;
 }
 
 ni_bool_t
@@ -2446,7 +2453,7 @@ __ni_dhcp6_fsm_mark_ia_by_time(ni_dhcp6_device_t *dev,  unsigned int (*get_ia_ti
 			struct timeval dif;
 
 			timersub(&now, &ia->acquired, &dif);
-			if (dif.tv_sec + 1 >= rt) {
+			if ((unsigned long)dif.tv_sec + 1 >= (unsigned long)rt) {
 				ia->flags |= flag;
 				++ count;
 			}
@@ -2511,7 +2518,7 @@ __ni_dhcp6_fsm_get_timeout(ni_dhcp6_device_t *dev, unsigned int (*get_ia_time)(n
 			struct timeval dif;
 
 			timersub(&now, &ia->acquired, &dif);
-			if (lt > dif.tv_sec)
+			if ((unsigned long)lt > (unsigned long)dif.tv_sec)
 				lt -= dif.tv_sec;
 		}
 	}
@@ -2566,7 +2573,7 @@ ni_dhcp6_fsm_get_expire_timeout(ni_dhcp6_device_t *dev)
 			struct timeval dif;
 
 			timersub(&now, &ia->acquired, &dif);
-			if (lt > dif.tv_sec)
+			if ((unsigned long)lt > (unsigned long)dif.tv_sec)
 				lt -= dif.tv_sec;
 		}
 	}

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -42,7 +42,6 @@ static void			ni_dhcp6_fsm_timeout(ni_dhcp6_device_t *);
 static void			ni_dhcp6_fsm_fail_timeout(ni_dhcp6_device_t *);
 static void             	__ni_dhcp6_fsm_timeout(void *, const ni_timer_t *);
 static void			ni_dhcp6_fsm_timer_cancel(ni_dhcp6_device_t *);
-static unsigned int		ni_dhcp6_remaining_time(struct timeval *, unsigned int);
 
 static int			ni_dhcp6_fsm_solicit      (ni_dhcp6_device_t *);
 static int			__ni_dhcp6_fsm_release    (ni_dhcp6_device_t *, unsigned int);
@@ -429,10 +428,11 @@ ni_dhcp6_fsm_retransmit_end(ni_dhcp6_device_t *dev)
 }
 
 void
-ni_dhcp6_fsm_set_timeout_msec(ni_dhcp6_device_t *dev, unsigned long msec)
+ni_dhcp6_fsm_set_timeout_msec(ni_dhcp6_device_t *dev, ni_timeout_t msec)
 {
 	if (msec != 0) {
-		ni_debug_dhcp("%s: setting fsm timeout to %lu msec", dev->ifname, msec);
+		ni_debug_dhcp("%s: setting fsm timeout to %u.%03u sec", dev->ifname,
+				NI_TIMEOUT_SEC(msec), NI_TIMEOUT_MSEC(msec));
 		if (dev->fsm.timer) {
 			ni_timer_rearm(dev->fsm.timer, msec);
 		} else {
@@ -442,6 +442,12 @@ ni_dhcp6_fsm_set_timeout_msec(ni_dhcp6_device_t *dev, unsigned long msec)
 		ni_timer_cancel(dev->fsm.timer);
 		dev->fsm.timer = NULL;
 	}
+}
+
+void
+ni_dhcp6_fsm_set_timeout_sec(ni_dhcp6_device_t *dev, unsigned int seconds)
+{
+	ni_dhcp6_fsm_set_timeout_msec(dev, NI_TIMEOUT_FROM_SEC(seconds));
 }
 
 static void
@@ -473,20 +479,20 @@ __show_remaining_timeouts(ni_dhcp6_device_t *dev, const char *info)
 {
 	if (dev->config->defer_timeout) {
 		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
-			"%s: %s in state %s, remaining defer   timeout: %u of %u",
+			"%s: %s in state %s, remaining defer   timeout: %u of %u sec",
 				dev->ifname, info,
 				ni_dhcp6_fsm_state_name(dev->fsm.state),
-				ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->defer_timeout),
+				ni_lifetime_left(dev->config->defer_timeout,
+						&dev->start_time, NULL),
 				dev->config->defer_timeout);
 	}
 	if (dev->config->acquire_timeout) {
 		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_DHCP,
-			"%s: %s in state %s, remaining acquire timeout: %u of %u",
+			"%s: %s in state %s, remaining acquire timeout: %u of %u sec",
 				dev->ifname, info,
 				ni_dhcp6_fsm_state_name(dev->fsm.state),
-				ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->acquire_timeout),
+				ni_lifetime_left(dev->config->acquire_timeout,
+						&dev->start_time, NULL),
 				dev->config->acquire_timeout);
 	}
 }
@@ -561,11 +567,10 @@ ni_dhcp6_fsm_timeout(ni_dhcp6_device_t *dev)
 			unsigned int deadline;
 
 			/* Do we still need this safeguard? */
-			deadline = ni_dhcp6_remaining_time(&dev->start_time,
-						dev->config->defer_timeout);
+			deadline = ni_lifetime_left(dev->config->defer_timeout,
+					&dev->start_time, NULL);
 			if (deadline) {
-				deadline *= 1000;
-				ni_dhcp6_fsm_set_timeout_msec(dev, deadline);
+				ni_dhcp6_fsm_set_timeout_sec(dev, deadline);
 				dev->fsm.fail_on_timeout = 0;
 				return;
 			}
@@ -575,11 +580,10 @@ ni_dhcp6_fsm_timeout(ni_dhcp6_device_t *dev)
 		if (dev->config->acquire_timeout) {
 			unsigned int deadline;
 
-			deadline = ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->acquire_timeout);
+			deadline = ni_lifetime_left(dev->config->acquire_timeout,
+					&dev->start_time, NULL);
 			if (deadline) {
-				deadline *= 1000;
-				ni_dhcp6_fsm_set_timeout_msec(dev, deadline);
+				ni_dhcp6_fsm_set_timeout_sec(dev, deadline);
 				dev->fsm.fail_on_timeout = 1;
 				return;
 			}
@@ -603,10 +607,9 @@ ni_dhcp6_fsm_timeout(ni_dhcp6_device_t *dev)
 		if (dev->config->acquire_timeout) {
 			unsigned int deadline;
 
-			deadline = ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->acquire_timeout);
+			deadline = ni_lifetime_left(dev->config->acquire_timeout,
+					&dev->start_time, NULL);
 			if (deadline) {
-				deadline *= 1000;
 				ni_dhcp6_fsm_set_timeout_msec(dev, deadline);
 				dev->fsm.fail_on_timeout = 1;
 				return;
@@ -1668,24 +1671,6 @@ ni_dhcp6_fsm_process_client_message(ni_dhcp6_device_t *dev, ni_dhcp6_message_t *
 	return rv;
 }
 
-static unsigned int
-ni_dhcp6_remaining_time(struct timeval *start, unsigned int timeout)
-{
-	struct timeval now;
-	struct timeval dif;
-
-	ni_timer_get_time(&now);
-	if (timercmp(&now, start, >))
-		timersub(&now, start, &dif);
-	else
-		timerclear(&dif);
-
-	if ((unsigned long)timeout > (unsigned long)dif.tv_sec)
-		return (unsigned int)(timeout - dif.tv_sec);
-	else
-		return 0;
-}
-
 ni_bool_t
 ni_dhcp6_config_update_ia_list(ni_dhcp6_device_t *dev)
 {
@@ -1787,21 +1772,21 @@ ni_dhcp6_fsm_solicit(ni_dhcp6_device_t *dev)
 			goto cleanup;
 
 		if (dev->config->start_delay) {
-			dev->retrans.delay = dev->config->start_delay * 1000;
+			dev->retrans.delay = NI_TIMEOUT_FROM_SEC(dev->config->start_delay);
 		}
 
 		if (dev->config->defer_timeout) {
-			deadline = ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->defer_timeout);
+			deadline = ni_lifetime_left(dev->config->defer_timeout,
+					&dev->start_time, NULL);
 			dev->fsm.fail_on_timeout = 0;
 		}
 		if (!deadline && dev->config->acquire_timeout) {
-			deadline = ni_dhcp6_remaining_time(&dev->start_time,
-					dev->config->acquire_timeout);
+			deadline = ni_lifetime_left(dev->config->acquire_timeout,
+					&dev->start_time, NULL);
 			dev->fsm.fail_on_timeout = 1;
 		}
 		if (deadline) {
-			dev->retrans.duration = deadline * 1000;
+			dev->retrans.duration = NI_TIMEOUT_FROM_SEC(deadline);
 		}
 
 		dev->fsm.state = NI_DHCP6_STATE_SELECTING;
@@ -1829,7 +1814,7 @@ ni_dhcp6_fsm_solicit(ni_dhcp6_device_t *dev)
 		lease->fqdn.qualify = dev->config->fqdn.qualify;
 
 		if (dev->config->max_rt && dev->config->max_rt != -1U)
-			dev->retrans.params.max_timeout = dev->config->max_rt;
+			dev->retrans.params.max_timeout = NI_TIMEOUT_FROM_SEC(dev->config->max_rt);
 
 		if (ni_dhcp6_build_message(dev, NI_DHCP6_SOLICIT, &dev->message, lease) != 0)
 			goto cleanup;
@@ -1899,7 +1884,7 @@ ni_dhcp6_fsm_request_info(ni_dhcp6_device_t *dev)
 				dev->ifname);
 
 		if (dev->config->max_rt && dev->config->max_rt != -1U)
-			dev->retrans.params.max_timeout = dev->config->max_rt;
+			dev->retrans.params.max_timeout = NI_TIMEOUT_FROM_SEC(dev->config->max_rt);
 
 		if (ni_dhcp6_build_message(dev, NI_DHCP6_INFO_REQUEST, &dev->message, NULL) != 0)
 			return -1;
@@ -1945,8 +1930,8 @@ ni_dhcp6_fsm_confirm_prefix(ni_dhcp6_device_t *dev, const ni_addrconf_lease_t *l
 
 		/* reselect new when last prefix expires earlier */
 		if (deadline != NI_LIFETIME_EXPIRED &&
-		    (deadline * 1000) < dev->retrans.duration)
-			dev->retrans.duration = deadline * 1000;
+		    deadline < NI_TIMEOUT_SEC(dev->retrans.duration))
+			dev->retrans.duration = NI_TIMEOUT_FROM_SEC(deadline);
 
 		dev->fsm.state = NI_DHCP6_STATE_REBINDING;
 		rv = ni_dhcp6_device_transmit_init(dev);
@@ -2009,8 +1994,7 @@ ni_dhcp6_fsm_confirm_lease(ni_dhcp6_device_t *dev, const ni_addrconf_lease_t *le
 static int
 ni_dhcp6_fsm_renew(ni_dhcp6_device_t *dev)
 {
-	unsigned int deadline;
-	struct timeval duration;
+	unsigned int duration;
 	int rv = -1;
 
 	if (!dev->lease)
@@ -2025,18 +2009,15 @@ ni_dhcp6_fsm_renew(ni_dhcp6_device_t *dev)
 			return 1;
 		}
 
-		deadline = ni_dhcp6_fsm_get_rebind_timeout(dev);
-		ni_timer_get_time(&duration);
-		duration.tv_sec += deadline;
-
-		ni_info("%s: Initiating renewal of DHCPv6 lease, duration %s",
-				dev->ifname, ni_dhcp6_print_timeval(&duration));
+		duration = ni_dhcp6_fsm_get_rebind_timeout(dev);
+		ni_info("%s: Initiating renewal of DHCPv6 lease, duration %usec",
+				dev->ifname, duration);
 
 		dev->dhcp6.xid = 0;
 		if (ni_dhcp6_init_message(dev, NI_DHCP6_RENEW, dev->lease) != 0)
 			return -1;
 
-		dev->retrans.duration = deadline * 1000;
+		dev->retrans.duration = NI_TIMEOUT_FROM_SEC(duration);
 		dev->fsm.state = NI_DHCP6_STATE_RENEWING;
 
 		rv = ni_dhcp6_device_transmit_init(dev);
@@ -2057,8 +2038,7 @@ ni_dhcp6_fsm_renew(ni_dhcp6_device_t *dev)
 static int
 ni_dhcp6_fsm_rebind(ni_dhcp6_device_t *dev)
 {
-	unsigned int deadline;
-	struct timeval duration;
+	unsigned int duration;
 	int rv = -1;
 
 	if (!dev->lease)
@@ -2080,19 +2060,17 @@ ni_dhcp6_fsm_rebind(ni_dhcp6_device_t *dev)
 			return 1;
 		}
 
-		deadline = ni_dhcp6_fsm_get_expire_timeout(dev);
-		ni_timer_get_time(&duration);
-		duration.tv_sec += deadline;
+		duration = ni_dhcp6_fsm_get_expire_timeout(dev);
 
-		ni_info("%s: Initiating rebind of DHCPv6 lease, duration %s",
-			dev->ifname, ni_dhcp6_print_timeval(&duration));
+		ni_info("%s: Initiating rebind of DHCPv6 lease, duration %usec",
+			dev->ifname, duration);
 
 		dev->dhcp6.xid = 0;
 		if (ni_dhcp6_init_message(dev, NI_DHCP6_REBIND, dev->lease) != 0)
 			return -1;
 
 		dev->fsm.state = NI_DHCP6_STATE_REBINDING;
-		dev->retrans.duration = deadline * 1000;
+		dev->retrans.duration = NI_TIMEOUT_FROM_SEC(duration);
 		rv = ni_dhcp6_device_transmit_init(dev);
 	} else {
 		/* Pickup more IA's that reached rebind time
@@ -2391,7 +2369,7 @@ ni_dhcp6_fsm_bound_info(ni_dhcp6_device_t *dev)
 		return ni_dhcp6_fsm_request_info(dev);
 
 	default:
-		ni_dhcp6_fsm_set_timeout_msec(dev, (unsigned long)refresh * 1000);
+		ni_dhcp6_fsm_set_timeout_sec(dev, refresh);
 		break;
 	}
 	return 0;
@@ -2401,7 +2379,6 @@ static int
 ni_dhcp6_fsm_bound(ni_dhcp6_device_t *dev)
 {
 	unsigned int timeout;
-	struct timeval start;
 
 	if (!dev->lease)
 		return -1;
@@ -2419,14 +2396,11 @@ ni_dhcp6_fsm_bound(ni_dhcp6_device_t *dev)
 					dev->ifname,
 					ni_dhcp6_fsm_state_name(dev->fsm.state));
 		} else {
-			ni_timer_get_time(&start);
-			start.tv_sec += timeout;
-
-			ni_debug_dhcp("%s: Reached %s state, scheduled RENEW to start in %s",
+			ni_debug_dhcp("%s: Reached %s state, scheduled RENEW to start in %usec",
 					dev->ifname, ni_dhcp6_fsm_state_name(dev->fsm.state),
-					ni_dhcp6_print_timeval(&start));
+					timeout);
 
-			ni_dhcp6_fsm_set_timeout_msec(dev, timeout * 1000);
+			ni_dhcp6_fsm_set_timeout_sec(dev, timeout);
 		}
 		return 0;
 	}

--- a/src/dhcp6/fsm.h
+++ b/src/dhcp6/fsm.h
@@ -51,8 +51,9 @@ const char *			ni_dhcp6_fsm_state_name(int state);
 extern int			ni_dhcp6_fsm_process_client_message(ni_dhcp6_device_t *,
 							ni_dhcp6_message_t *, ni_buffer_t *);
 
-extern void			ni_dhcp6_fsm_set_timeout_msec(ni_dhcp6_device_t *, unsigned long);
-
+extern void			ni_dhcp6_fsm_set_timeout_msec(ni_dhcp6_device_t *, ni_timeout_t);
+extern void			ni_dhcp6_fsm_set_timeout_sec(ni_dhcp6_device_t *, unsigned int);
+ 
 extern int			ni_dhcp6_fsm_start(ni_dhcp6_device_t *dev);
 extern void			ni_dhcp6_fsm_reset(ni_dhcp6_device_t *dev);
 extern int			ni_dhcp6_fsm_release(ni_dhcp6_device_t *dev);

--- a/src/dhcp6/lease.c
+++ b/src/dhcp6/lease.c
@@ -31,7 +31,7 @@
 
 #include <wicked/netinfo.h>
 #include <wicked/addrconf.h>
-#include <wicked/socket.h>	/* ni_time functions */
+#include <wicked/time.h>
 #include <wicked/xml.h>
 
 #include "duid.h"

--- a/src/dhcp6/options.c
+++ b/src/dhcp6/options.c
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <wicked/time.h>
 #include <wicked/util.h>
 #include "dhcp6/options.h"
 #include "util_priv.h"

--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -2106,6 +2106,7 @@ ni_dhcp6_ia_get_rebind_time(ni_dhcp6_ia_t *ia)
 ni_bool_t
 ni_dhcp6_ia_is_active(ni_dhcp6_ia_t *ia, struct timeval *now)
 {
+	struct timeval delta;
 	unsigned int lft;
 
 	if (!now || !ia || !timerisset(&ia->acquired))
@@ -2115,7 +2116,11 @@ ni_dhcp6_ia_is_active(ni_dhcp6_ia_t *ia, struct timeval *now)
 	if (lft == NI_DHCP6_INFINITE_LIFETIME)
 		return TRUE;
 
-	return ia->acquired.tv_sec + lft > now->tv_sec + 1;
+	if (!timercmp(now, &ia->acquired, >))
+		return FALSE;
+
+	timersub(now, &ia->acquired, &delta);
+	return ((unsigned long)lft > (unsigned long)delta.tv_sec + 1);
 }
 
 unsigned int

--- a/src/dhcp6/protocol.h
+++ b/src/dhcp6/protocol.h
@@ -150,7 +150,7 @@ enum NI_DHCP6_MSG_TYPE {
  * https://tools.ietf.org/html/rfc4242#section-3.1
  */
 #define NI_DHCP6_IRT_DEFAULT	  86400	/* default refresh time in sec  */
-#define NI_DHCP6_IRT_MINIMUM	    600 /* minimum refresh time         */
+#define NI_DHCP6_IRT_MINIMUM	    600 /* minimum refresh time in sec  */
 
 /*
  * Timeout and backoff handling initializers
@@ -280,8 +280,6 @@ extern unsigned int	ni_dhcp6_ia_get_renewal_time(ni_dhcp6_ia_t *);
 extern ni_bool_t	ni_dhcp6_ia_is_active(ni_dhcp6_ia_t *, struct timeval *);
 extern unsigned int	ni_dhcp6_ia_list_count_active(ni_dhcp6_ia_t *, struct timeval *now);
 extern unsigned int	ni_dhcp6_ia_copy_to_lease_addrs(const ni_dhcp6_device_t *, ni_addrconf_lease_t *);
-
-extern const char *	ni_dhcp6_print_timeval(const struct timeval *);
 
 extern const char *	ni_dhcp6_address_print(const struct in6_addr *);
 

--- a/src/dhcp6/tester.c
+++ b/src/dhcp6/tester.c
@@ -396,7 +396,7 @@ ni_dhcp6_tester_run(ni_dhcp6_tester_t *opts)
 
 	dhcp6_tester_status = NI_WICKED_RC_IN_PROGRESS;
 	while (!ni_caught_terminal_signal()) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		timeout = ni_timer_next_timeout();
 		if (dev->config && (dev->config->mode & NI_BIT(NI_DHCP6_MODE_AUTO))) {

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -5830,7 +5830,7 @@ ni_fsm_create_client(ni_fsm_t *fsm)
 }
 
 ni_bool_t
-ni_fsm_do(ni_fsm_t *fsm, long *timeout_p)
+ni_fsm_do(ni_fsm_t *fsm, ni_timeout_t *timeout)
 {
 	ni_bool_t pending_workers;
 
@@ -5847,7 +5847,7 @@ ni_fsm_do(ni_fsm_t *fsm, long *timeout_p)
 		pending_workers = !!ni_fsm_schedule(fsm);
 
 		fsm->timeout_count = 0;
-		*timeout_p = ni_timer_next_timeout();
+		*timeout = ni_timer_next_timeout();
 		ni_dbus_objects_garbage_collect();
 	} while (fsm->timeout_count);
 
@@ -5857,7 +5857,7 @@ ni_fsm_do(ni_fsm_t *fsm, long *timeout_p)
 void
 ni_fsm_mainloop(ni_fsm_t *fsm)
 {
-	long timeout;
+	ni_timeout_t timeout;
 
 	while (!ni_caught_terminal_signal()) {
 		if (!ni_fsm_do(fsm, &timeout))

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -11,7 +11,7 @@
 
 #include <wicked/netinfo.h>
 #include <wicked/logging.h>
-#include <wicked/socket.h>
+#include <wicked/time.h>
 #include <wicked/ipv6.h>
 #include <errno.h>
 

--- a/src/leaseinfo.c
+++ b/src/leaseinfo.c
@@ -44,7 +44,7 @@
 #include <wicked/netinfo.h>
 #include <wicked/nis.h>
 #include <wicked/route.h>
-#include <wicked/socket.h>	/* ni_time functions */
+#include <wicked/time.h>
 
 #include "appconfig.h"
 #include "util_priv.h"

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -11,6 +11,8 @@
 #include <stdio.h>
 
 #include <wicked/types.h>
+#include <wicked/time.h>
+#include <wicked/socket.h>
 #include <wicked/netinfo.h>
 #include <wicked/addrconf.h>
 #include <wicked/logging.h>
@@ -128,8 +130,6 @@ static inline ni_bool_t	__ni_addrconf_should_update(unsigned int mask, unsigned 
 /*
  * Packet capture and raw sockets
  */
-#include <wicked/socket.h>
-
 typedef struct ni_capture_devinfo {
 	char *			ifname;
 	unsigned int		ifindex;

--- a/src/process.c
+++ b/src/process.c
@@ -17,6 +17,7 @@
 
 #include <wicked/logging.h>
 #include <wicked/socket.h>
+#include <wicked/time.h>
 #include "socket_priv.h"
 #include "process.h"
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -9,7 +9,9 @@
 
 #include <time.h>
 #include <sys/time.h>
-#include <wicked/socket.h>
+
+#include <wicked/time.h>
+
 #include "netinfo_priv.h"
 #include "util_priv.h"
 

--- a/src/util.c
+++ b/src/util.c
@@ -1689,11 +1689,40 @@ ni_sprint_uint(unsigned int value)
 const char *
 ni_sprint_timeout(unsigned int timeout)
 {
-	if (timeout == NI_IFWORKER_INFINITE_TIMEOUT)
+	if (timeout == NI_SECONDS_INFINITE)
 		return "infinite";
 	return ni_sprint_uint(timeout);
 }
 
+const char *
+ni_format_seconds_timeout(char **str, unsigned int timeout)
+{
+	if (!str) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (timeout == NI_SECONDS_INFINITE)
+		return ni_string_printf(str, "infinite");
+	else
+		return ni_string_printf(str, "%u", timeout);
+}
+
+int
+ni_parse_seconds_timeout(const char *str, unsigned int *timeout)
+{
+	if (!timeout) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (ni_string_eq(str, "infinite")) {
+		*timeout = NI_SECONDS_INFINITE;
+		return 0;
+	} else {
+		return ni_parse_uint(str, timeout, 10);
+	}
+}
 
 int
 ni_parse_long(const char *input, long *result, int base)

--- a/src/util.c
+++ b/src/util.c
@@ -1445,8 +1445,8 @@ ni_bool_t
 ni_file_exists_fmt(const char *fmt, ...)
 {
 	char *path = NULL;
-	ni_bool_t ret;
 	va_list ap;
+	int ret;
 
 	if (!fmt)
 		return FALSE;
@@ -1454,7 +1454,7 @@ ni_file_exists_fmt(const char *fmt, ...)
 	va_start(ap, fmt);
 	ret = vasprintf(&path, fmt, ap) > 0;
 	va_end(ap);
-	if (!ret)
+	if (ret < 0 || !path)
 		return FALSE;
 
 	ret = ni_file_exists(path);

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -515,7 +515,7 @@ ni_wireless_wpa_net_format_wep(ni_wpa_net_properties_t *properties, const ni_wir
 					return FALSE;
 			break;
 		default:
-			ni_warn("Unknown WEP key format len=%lu", len);
+			ni_warn("Unknown WEP key format len=%zu", len);
 		}
 	}
 	return TRUE;

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1138,12 +1138,12 @@ ni_wpa_nif_add_blob(ni_wpa_nif_t *wif, const char *name, unsigned const char *da
 	ni_dbus_variant_set_byte_array(&args[1], data, len);
 
 	interface = ni_dbus_object_get_default_interface(wif->object);
-	ni_debug_wpa("%s: Calling %s.%s(%s, len=%lu)", wif->device.name, interface, method, name, len);
+	ni_debug_wpa("%s: Calling %s.%s(%s, len=%zu)", wif->device.name, interface, method, name, len);
 
 	err = -NI_ERROR_DBUS_CALL_FAILED;
 	if (!ni_dbus_object_call_variant(wif->object, interface, method,
 					2, args, 0, NULL, &error)) {
-		ni_error("%s: dbus call %s.%s(%s, len=%lu) failed (%s: %s)", wif->device.name,
+		ni_error("%s: dbus call %s.%s(%s, len=%zu) failed (%s: %s)", wif->device.name,
 				ni_dbus_object_get_path(wif->object), method, name, len,
 				error.name, error.message);
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -1052,7 +1052,7 @@ __xpath_enode_predicate_evaluate(const xpath_enode_t *enode, xpath_result_t *lef
 			case XPATH_INTEGER:
 				/* Predicate indices are 1 based */
 				index = rn->value.integer;
-				if (0 < index && index - 1 < left->count)
+				if (0 < index && (unsigned long)index - 1 < (unsigned long)left->count)
 					xpath_result_append_element(result,
 							left->node[index-1].value.node);
 				break;

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -258,12 +258,12 @@ handle_name_or_axis:
 					goto failed;
 				}
 
-				ident = NULL;
 				if (colons[2] != '\0') {
 					/* This one has form "axis::Name" */
 					ident = colons + 2;
 				} else if (*pos == '*') {
 					/* This one has form "axis::*" */
+					ident = NULL;
 					++pos;
 				} else {
 					ni_error("operator %s:: must be followed by Name or *", ident);

--- a/testing/rtnl-test.c
+++ b/testing/rtnl-test.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 	ni_server_enable_interface_nduseropt_events(rtnl_test_interface_ndopt_event);
 
 	while (!term_sig) {
-		long timeout;
+		ni_timeout_t timeout;
 
 		if (hup_sig) {
 			hup_sig = 0;


### PR DESCRIPTION
- Cleanup timer/timeout and lifetime types and calculations with very high or
  infinite lease time, which caused high cpu on RaspberryPi 2 (bsc#1188019)
- dhcp6: fix incorrect retransmission time randomization (re-)calculations
  USGv6: DHCPv6_7_1_05c, DHCPv6_7_1_05c, DHCPv6_7_1_05c
- fix warnings from more recent compilers