### PR TITLE
Fix sysctl values for loopback device (bsc#1181163, bsc#1178357)

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -6112,7 +6112,9 @@ ni_suse_ifcfg_get_firewall(const ni_sysconfig_t *sc, ni_compat_netdev_t *compat)
 static const ni_var_t *
 __ifsysctl_get_var(ni_var_array_t *vars, const char *path, const char *ifname, const char *attr)
 {
-	const char *names[] = { "all", "default", ifname, NULL };
+	const char *def_names[] = { "all", "default", ifname, NULL };
+	const char *lo_names[] = { ifname, NULL };
+	const char **names = ni_string_eq(ifname, "lo") ? lo_names : def_names;
 	const char **name;
 	const ni_var_t *ret = NULL;
 	const ni_var_t *var;

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -352,7 +352,7 @@ __change_int(const char *ifname, const char *attr, int value)
 static ni_bool_t
 __tristate_changed(ni_tristate_t cfg, ni_tristate_t sys)
 {
-	return ni_tristate_is_set(cfg) && cfg != sys;
+	return ni_tristate_is_set(sys) && ni_tristate_is_set(cfg) && cfg != sys;
 }
 
 int
@@ -831,7 +831,7 @@ __ni_ipv6_devconf_process_flag(ni_netdev_t *dev, unsigned int flag, int value)
 		ipv6->conf.accept_ra = value < 0 ? 0 : value > 2 ? 2 : value;
 		break;
 	case NI_IPV6_DEVCONF_ACCEPT_DAD:
-		ipv6->conf.accept_dad = value < 0 ? 0 : value > 2 ? 2 : value;
+		ipv6->conf.accept_dad = value < -1 ? -1 : value > 2 ? 2 : value;
 		break;
 	case NI_IPV6_DEVCONF_AUTOCONF:
 		ipv6->conf.autoconf = !!value;


### PR DESCRIPTION
- Discard config requests on sysctl variables which have the value "-1" (bsc#1181163, bsc#1178357)
- Do not inherit "default" and "all" settings for loopback device (bsc#1181163)