### PR TITLE
Fix sysctl file read precedence

### DIFF
--- a/client/suse/ifsysctl.c
+++ b/client/suse/ifsysctl.c
@@ -148,9 +148,10 @@ __ni_sysctl_file_load(ni_var_array_t *vars, const char *filename,
 
 	fp = fopen(filename, "re");
 	if(fp == NULL) {
-		if (errno != ENOENT) {
+		if (errno != ENOENT)
 			ni_error("Unable to open %s: %m", filename);
-		}
+		else
+			ni_debug_readwrite("Cannot open '%s': %m", filename);
 		return FALSE;
 	}
 

--- a/client/suse/ifsysctl.c
+++ b/client/suse/ifsysctl.c
@@ -261,6 +261,7 @@ __ni_ifsysctl_vars_map(ni_var_array_t *vars, const char *key, const char *val)
 	/*
 	 * And finally add it to the array
 	 */
+	ni_debug_readwrite("Add sysctl variable '%s=%s'", key, val);
 	ni_var_array_set(vars, key, val);
 	ni_stringbuf_destroy(&buf);
 }

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -44,6 +44,7 @@ struct ni_variable {
 	char *		name;
 	char *		value;
 };
+typedef int (*ni_var_compare_fn_t)(const ni_var_t*, const ni_var_t*);
 
 #define NI_VAR_INIT		{ .name = NULL, .value = NULL }
 
@@ -192,6 +193,9 @@ extern ni_bool_t	ni_var_array_set_long(ni_var_array_t *, const char *, long);
 extern ni_bool_t	ni_var_array_set_ulong(ni_var_array_t *, const char *, unsigned long);
 extern ni_bool_t	ni_var_array_set_double(ni_var_array_t *, const char *, double);
 extern ni_bool_t	ni_var_array_set_boolean(ni_var_array_t *, const char *, int);
+
+extern void		ni_var_array_sort(ni_var_array_t *, ni_var_compare_fn_t);
+extern void		ni_var_array_sort_by_name(ni_var_array_t *);
 
 extern void		ni_var_array_list_append(ni_var_array_t **, ni_var_array_t *);
 extern void		ni_var_array_list_destroy(ni_var_array_t **);

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,7 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
@@ -1033,6 +1034,19 @@ ni_bool_t
 ni_var_array_set_boolean(ni_var_array_t *nva, const char *name, int value)
 {
 	return ni_var_array_set(nva, name, value? "yes" : "no");
+}
+
+void
+ni_var_array_sort(ni_var_array_t *nva, ni_var_compare_fn_t fn)
+{
+	qsort(nva->data, nva->count, sizeof(ni_var_t),
+			(int (*)(const void *, const void *)) fn);
+}
+
+void
+ni_var_array_sort_by_name(ni_var_array_t *nva)
+{
+	ni_var_array_sort(nva, ni_var_name_cmp);
 }
 
 void


### PR DESCRIPTION
 * Respect sort order of filenames from sysctl.d directories (complete commit 140a945645a1292d4bb5efd240f02f386ae70ae6).
 * Display sysctl key value pairs in debug
 * Add `ni_var_array_sort()` function.