### PR TITLE
gitlab-ci: Use CI_PROJECT_NAMESPACE for wicked-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,3 @@
 include:
-  - project: 'wicked-maintainers/wicked-ci'
+  - project: '$CI_PROJECT_NAMESPACE/wicked-ci'
     file: '/wicked-ci.yml'


### PR DESCRIPTION
Use the wicked-ci.yml from the same `PROJECT_NAMESPACE` as the wicked
repo belongs to. E.g. if the CI is running on the project `cfconrad/wicked`
it will also use the `wicked-ci.yml` from `cfconrad/wicked-ci`.