### PR TITLE
buffer: adjust uint length to size_t, guard init

### DIFF
--- a/src/dhcp4/fsm.c
+++ b/src/dhcp4/fsm.c
@@ -91,7 +91,7 @@ ni_dhcp4_fsm_process_dhcp4_packet(ni_dhcp4_device_t *dev, ni_buffer_t *msgbuf, n
 
 	if (!(message = ni_buffer_pull_head(msgbuf, sizeof(*message)))) {
 		sender = ni_capture_from_hwaddr_print(from);
-		ni_debug_dhcp("%s: short dhcp4 packet (%u bytes)%s%s", dev->ifname,
+		ni_debug_dhcp("%s: short dhcp4 packet (%zu bytes)%s%s", dev->ifname,
 				ni_buffer_count(msgbuf),
 				sender ? " sender " : "", sender ? sender : "");
 		return -1;

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -237,7 +237,7 @@ underflow:
 static int
 ni_dhcp4_option_get_opaque(ni_buffer_t *bp, ni_opaque_t *opaque)
 {
-	unsigned int len = ni_buffer_count(bp);
+	size_t len = ni_buffer_count(bp);
 
 	if (!len || len > sizeof(opaque->data))
 		return -1;
@@ -286,9 +286,9 @@ ni_dhcp4_option_get32(ni_buffer_t *bp, uint32_t *var)
 static int
 ni_dhcp4_option_get_string(ni_buffer_t *bp, char **var, unsigned int *lenp)
 {
-	unsigned int len = ni_buffer_count(bp);
+	size_t len = ni_buffer_count(bp);
 
-	if (len == 0)
+	if (len == 0 || len >= UINT_MAX)
 		return -1;
 
 	if (lenp)
@@ -383,7 +383,7 @@ ni_dhcp4_build_msg_put_fqdn_option(const ni_dhcp4_device_t *dev, ni_buffer_t *ms
 	ni_buffer_init(&databuf, optdata, sizeof(optdata));
 	if (ni_buffer_putc(&databuf, flags) < 0 || /* 0000NEOS   flags  */
 	    ni_buffer_putc(&databuf, 0)     < 0 || /* deprecated rdata1 */
-	    ni_buffer_putc(&databuf, 0)      < 0)   /* deprecared rdata2 */
+	    ni_buffer_putc(&databuf, 0)     < 0)   /* deprecared rdata2 */
 		return 1;
 
 	if (!ni_string_empty(hostname) &&
@@ -1903,7 +1903,7 @@ parse_more:
 			ni_debug_dhcp("unable to parse DHCP4 option %s: too short",
 					ni_dhcp4_option_name(option));
 		} else if (ni_buffer_count(&buf)) {
-			ni_debug_dhcp("excess data in DHCP4 option %s - %u bytes left",
+			ni_debug_dhcp("excess data in DHCP4 option %s - %zu bytes left",
 					ni_dhcp4_option_name(option),
 					ni_buffer_count(&buf));
 		}
@@ -2077,7 +2077,7 @@ parse_more:
 			ni_debug_dhcp("unable to parse DHCP4 option %s (%u): too short",
 					ni_dhcp4_option_name(option), option);
 		} else if (ni_buffer_count(&buf)) {
-			ni_debug_dhcp("excess data in DHCP4 option %s (%u): %u data bytes left",
+			ni_debug_dhcp("excess data in DHCP4 option %s (%u): %zu data bytes left",
 					ni_dhcp4_option_name(option), option,
 					ni_buffer_count(&buf));
 		}

--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -381,7 +381,7 @@ ni_dhcp6_process_packet(ni_dhcp6_device_t *dev, ni_buffer_t *msgbuf, const struc
 		case NI_DHCP6_REPLY:
 		case NI_DHCP6_RECONFIGURE:
 			if (ni_dhcp6_parse_client_header(&msg, msgbuf) < 0) {
-				ni_error("%s: short DHCP6 client packet (%u bytes) from %s",
+				ni_error("%s: short DHCP6 client packet (%zu bytes) from %s",
 						dev->ifname, ni_buffer_count(msgbuf),
 						ni_dhcp6_address_print(&msg.sender));
 				return rv;
@@ -2334,14 +2334,14 @@ ni_dhcp6_option_parse_ia_address(ni_buffer_t *bp, ni_dhcp6_ia_t *ia, uint16_t ad
 		}
 
 		if (optbuf.underflow) {
-			ni_debug_dhcp("%s.%s.%s: %u byte of data is too short",
+			ni_debug_dhcp("%s.%s.%s: %zu byte of data is too short",
 				ni_dhcp6_option_name(ia->type),
 				ni_dhcp6_option_name(addr_type),
 				ni_dhcp6_option_name(option),
 				ni_buffer_count(&optbuf));
 			/* goto failure; */
 		} else if (ni_buffer_count(&optbuf)) {
-			ni_debug_dhcp("%s.%s.%s: data is too long - %u bytes left",
+			ni_debug_dhcp("%s.%s.%s: data is too long - %zu bytes left",
 				ni_dhcp6_option_name(ia->type),
 				ni_dhcp6_option_name(addr_type),
 				ni_dhcp6_option_name(option),
@@ -2432,13 +2432,13 @@ __ni_dhcp6_option_parse_ia_options(ni_buffer_t *bp,  ni_dhcp6_ia_t *ia)
 		}
 
 		if (optbuf.underflow) {
-			ni_debug_dhcp("%s.%s: %u byte of data is too short",
+			ni_debug_dhcp("%s.%s: %zu byte of data is too short",
 				ni_dhcp6_option_name(ia->type),
 				ni_dhcp6_option_name(option),
 				ni_buffer_count(&optbuf));
 			/* goto failure; */
 		} else if (ni_buffer_count(&optbuf)) {
-			ni_debug_dhcp("%s.%s: data is too long - %u bytes left",
+			ni_debug_dhcp("%s.%s: data is too long - %zu bytes left",
 				ni_dhcp6_option_name(ia->type),
 				ni_dhcp6_option_name(option),
 				ni_buffer_count(&optbuf));
@@ -3121,10 +3121,10 @@ ni_dhcp6_parse_client_options(ni_dhcp6_device_t *dev, ni_dhcp6_message_t *msg, n
 #endif
 			opt = ni_dhcp_option_new(option, ni_buffer_count(&optbuf), ni_buffer_head(&optbuf));
 			if (ni_dhcp_option_list_append(&lease->dhcp6.options, opt)) {
-				ni_debug_dhcp("unparsed option %s: length %u",
+				ni_debug_dhcp("unparsed option %s: length %zu",
 						ni_dhcp6_option_name(option), ni_buffer_count(&optbuf));
 			} else {
-				ni_debug_dhcp("failed to add unparsed option %s length %u to lease",
+				ni_debug_dhcp("failed to add unparsed option %s length %zu to lease",
 						ni_dhcp6_option_name(option), ni_buffer_count(&optbuf));
 				ni_dhcp_option_free(opt);
 			}
@@ -3133,14 +3133,14 @@ ni_dhcp6_parse_client_options(ni_dhcp6_device_t *dev, ni_dhcp6_message_t *msg, n
 		}
 
 		if (optbuf.underflow) {
-			ni_trace("%s: dhcp6 option %s: %u byte data is too short: %s",
+			ni_trace("%s: dhcp6 option %s: %zu byte data is too short: %s",
 				dev->ifname, ni_dhcp6_option_name(option),
 				ni_buffer_count(&optbuf),
 				__ni_dhcp6_hexdump(&hexbuf, &optbuf));
 			ni_stringbuf_destroy(&hexbuf);
 			/* goto failure; */
 		} else if(ni_buffer_count(&optbuf)) {
-			ni_trace("%s: dhcp6 option %s: data is too long - %u bytes left: %s",
+			ni_trace("%s: dhcp6 option %s: data is too long - %zu bytes left: %s",
 				dev->ifname, ni_dhcp6_option_name(option),
 				ni_buffer_count(&optbuf),
 				__ni_dhcp6_hexdump(&hexbuf, &optbuf));

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -110,7 +110,7 @@ ni_netconfig_firmware_discovery(const char *root, const char *from)
 		return NULL;
 	}
 
-	ni_debug_ifconfig("%s: %s%sbuffer has %u bytes", __func__,
+	ni_debug_ifconfig("%s: %s%sbuffer has %zu bytes", __func__,
 			(from ? from : ""), (from ? " ": ""),
 			ni_buffer_count(buffer));
 	doc = xml_document_from_buffer(buffer, from);

--- a/src/lldp.c
+++ b/src/lldp.c
@@ -536,7 +536,7 @@ ni_lldp_agent_send(ni_lldp_agent_t *agent)
 	if (agent->txCredit > 0) {
 		ni_buffer_t *bp = &agent->sendbuf;
 
-		ni_debug_lldp("%s: sending LLDP packet (PDU len=%u)", agent->dev->name, ni_buffer_count(bp));
+		ni_debug_lldp("%s: sending LLDP packet (PDU len=%zu)", agent->dev->name, ni_buffer_count(bp));
 		/* ni_debug_lldp(PDU=%s", ni_print_hex(ni_buffer_head(bp), ni_buffer_count(bp))); */
 		ni_capture_send(agent->capture, &agent->sendbuf, NULL);
 		agent->txCredit--;
@@ -935,7 +935,7 @@ ni_lldp_tlv_get(ni_buffer_t *bp, ni_buffer_t *vbuf)
 
 	type = head >> 9;
 	len = head & 0x1FF;
-	if (len > ni_buffer_count(bp))
+	if ((size_t)len > ni_buffer_count(bp))
 		return -1;
 
 	data = ni_buffer_pull_head(bp, len);
@@ -986,10 +986,10 @@ ni_lldp_tlv_get_uint32(ni_buffer_t *bp, uint32_t *var)
 static int
 ni_lldp_tlv_get_string(ni_buffer_t *bp, char **var)
 {
-	unsigned int len = ni_buffer_count(bp);
+	size_t len = ni_buffer_count(bp);
 	char *string;
 
-	if (!(string = malloc(len + 1)))
+	if (!len || !(string = malloc(len + 1)))
 		return -1;
 	memcpy(string, ni_buffer_head(bp), len);
 	string[len] = '\0';
@@ -1042,7 +1042,7 @@ ni_lldp_tlv_get_mac(ni_buffer_t *bp, ni_hwaddr_t *mac)
 	void *data;
 
 	if (!(data = ni_buffer_pull_head(bp, ETH_ALEN))) {
-		ni_debug_lldp("%s: bad MAC address length %u", __func__, ni_buffer_count(bp));
+		ni_debug_lldp("%s: bad MAC address length %zu", __func__, ni_buffer_count(bp));
 		return -1;
 	}
 
@@ -1087,7 +1087,7 @@ ni_lldp_tlv_get_netaddr(ni_buffer_t *bp, ni_sockaddr_t *ap)
 		return -1;
 	}
 
-	if (ni_buffer_count(bp) < len) {
+	if (ni_buffer_count(bp) < (size_t)len) {
 		ni_debug_lldp("%s: truncated network address (af %d, len %u)", __func__, af, len);
 		return -1;
 	}


### PR DESCRIPTION
- adjust unsigned int buffer count and tailroom return type to size_t
- add guards and return status in init and ensure_tailroom functions
- adopt the using side to use size_t and zu printf formats