### PR TITLE
compat-suse: Match sysctl.d read order with systemd-sysctl

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -123,8 +123,8 @@ static ni_bool_t		__ni_ipv6_disbled;
 						  NULL }
 #define __NI_SUSE_SYSCTL_SUFFIX			".conf"
 #define __NI_SUSE_SYSCTL_BOOT			"/boot/sysctl.conf-"
-#define __NI_SUSE_SYSCTL_DIRS			{ "/run/sysctl.d",                  \
-						  "/etc/sysctl.d",                  \
+#define __NI_SUSE_SYSCTL_DIRS			{ "/etc/sysctl.d",                  \
+						  "/run/sysctl.d",                  \
 						  "/usr/local/lib/sysctl.d",        \
 						  "/usr/lib/sysctl.d",              \
 						  "/lib/sysctl.d",                  \


### PR DESCRIPTION
Match the read order of sysctl.d directories like systemd-sysctl.
progps-ng does this since 3.3.17 [1].

[1] https://gitlab.com/procps-ng/procps/-/commit/5da3024e4e4231561d922ad356a22c0d5d7bc69f