### PR TITLE
xml-schema: Fix refcount handling for ni_xs_type_t

### DIFF
--- a/src/xml-schema.c
+++ b/src/xml-schema.c
@@ -1171,6 +1171,7 @@ ni_xs_build_complex_type(xml_node_t *node, const char *className, ni_xs_scope_t 
 				ni_error("%s: array definition references unknown element type <%s>", __func__, typeAttr);
 				return NULL;
 			}
+			ni_xs_type_hold(elementType);
 		} else {
 			elementType = ni_xs_build_one_type(node, scope);
 			if (elementType == NULL)


### PR DESCRIPTION
If the loaded xml-schema is errournous (e.g. a typo or missing include),
the cleanup can hit a ni_assert(), because of missing refcount increment
of the "array-element" type referenced in "array" type.