### PR TITLE
wireless: remove libiw dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,7 +10,6 @@ These devel packages should be installed to compile wicked from source:
   autoconf
   libtool
   libnl-devel
-  libiw-devel
   dbus-1-devel
   pkg-config
   libgcrypt-devel

--- a/README
+++ b/README
@@ -96,12 +96,12 @@ These factory interfaces are attached to the
 Frequently Asked Questions
 ==========================
 
-We have a FAQ section hosted in our GitHub's wiki, be sure to check that 
+We have a FAQ section hosted in our GitHub's wiki, be sure to check that
 out for common questions about usage or Wicked in general:
 
         https://github.com/openSUSE/wicked/wiki/FAQ
 
-For any questions not answered on the FAQ, please read our section 
+For any questions not answered on the FAQ, please read our section
 below: "Where to discuss or report bugs"
 
 What's currently supported
@@ -150,8 +150,7 @@ To build wicked from sources, try following commands:
 
 	zypper in git-core rpm-build gcc make pkg-config \
 		autoconf automake libtool systemd-devel \
-		libnl3-devel libiw-devel dbus-1-devel \
-		libgcrypt-devel
+		libnl3-devel dbus-1-devel libgcrypt-devel
 	git clone https://github.com/openSUSE/wicked.git
 	cd wicked
 	./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,6 @@ if test "X$enable_systemd" = Xyes; then
 fi
 
 # Checks for header files.
-AC_CHECK_HEADER([iwlib.h],[],[AC_MSG_ERROR([Please install libiw-devel to get wireless.h])])
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h])
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/ioctl.h sys/param.h])
 AC_CHECK_HEADERS([sys/socket.h sys/time.h syslog.h unistd.h])

--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1138,12 +1138,9 @@ __ni_process_ifinfomsg_linktype(ni_linkinfo_t *link, const char *ifname, ni_netc
 			/* We're at the very least an ethernet. */
 			tmp_link_type = NI_IFTYPE_ETHERNET;
 
-			/*
-			 * Try to detect if this is a  WLAN device.
-			 * The official way of doing this is to check whether
-			 * ioctl(SIOCGIWNAME) succeeds.
-			 */
-			if (__ni_wireless_get_name(ifname, NULL, 0) == 0)
+			/* rtnetlink does not tell us if the device has a
+			 * wireless extensions or not, but sysfs does. */
+			if ( ni_sysfs_netif_exists(ifname, "wireless"))
 				tmp_link_type = NI_IFTYPE_WIRELESS;
 
 			memset(&drv_info, 0, sizeof(drv_info));

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -109,27 +109,6 @@ __ni_ethtool(const char *ifname, int cmd, void *data)
 }
 
 /*
- * Call a wireless extension
- */
-int
-__ni_wireless_ext(const ni_netdev_t *dev, int cmd,
-			void *data, size_t data_len, unsigned int flags)
-{
-	struct iwreq iwr;
-
-	memset(&iwr, 0, sizeof(iwr));
-	strncpy(iwr.ifr_name, dev->name, IFNAMSIZ);
-	iwr.u.data.pointer = data;
-	iwr.u.data.length = data_len;
-	iwr.u.data.flags = flags;
-
-	if (__ni_ioctl(cmd, &iwr) < 0)
-		return -1;
-	/* Not optimal yet */
-	return iwr.u.data.length;
-}
-
-/*
  * Bridge helper functions
  */
 int
@@ -162,46 +141,6 @@ __ni_brioctl_del_port(const char *ifname, unsigned int port_index)
 	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 	ifr.ifr_ifindex = port_index;
 	return __ni_ioctl(SIOCBRDELIF, &ifr);
-}
-
-/*
- * Wireless extension ioctls
- */
-int
-__ni_wireless_get_name(const char *name, char *result, size_t size)
-{
-	struct iwreq iwreq;
-
-	memset(&iwreq, 0, sizeof(iwreq));
-	strncpy(iwreq.ifr_name, name, IFNAMSIZ);
-	if (__ni_ioctl(SIOCGIWNAME, &iwreq) < 0)
-		return -1;
-
-	if (size) {
-		strncpy(result, iwreq.ifr_name, size-1);
-		result[size-1] = '\0';
-	}
-	return 0;
-}
-
-int
-__ni_wireless_get_essid(const char *name, char *result, size_t size)
-{
-	char buffer[IW_ESSID_MAX_SIZE];
-	struct iwreq iwreq;
-
-	memset(&iwreq, 0, sizeof(iwreq));
-	strncpy(iwreq.ifr_name, name, IFNAMSIZ);
-	iwreq.u.essid.pointer = buffer;
-	iwreq.u.essid.length = sizeof(buffer);
-	if (__ni_ioctl(SIOCGIWESSID, &iwreq) < 0)
-		return -1;
-
-	if (size) {
-		strncpy(result, buffer, size-1);
-		result[size-1] = '\0';
-	}
-	return 0;
 }
 
 /*

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -14,7 +14,6 @@
 #include <linux/fib_rules.h>
 
 #define __user /* unclean header file */
-#include <wireless.h>
 
 #include <wicked/types.h>
 
@@ -40,15 +39,10 @@ __ni_rta_get_uint16(uint16_t *val, struct rtattr *rta)
 }
 
 extern int		__ni_ethtool(const char *, int, void *);
-extern int		__ni_wireless_ext(const ni_netdev_t *dev, int cmd,
-				void *data, size_t data_len, unsigned int flags);
 extern int		__ni_brioctl_add_bridge(const char *);
 extern int		__ni_brioctl_del_bridge(const char *);
 extern int		__ni_brioctl_add_port(const char *, unsigned int);
 extern int		__ni_brioctl_del_port(const char *, unsigned int);
-
-extern int		__ni_wireless_get_name(const char *, char *, size_t);
-extern int		__ni_wireless_get_essid(const char *, char *, size_t);
 
 extern int		__ni_tuntap_create(const ni_netdev_t *);
 

--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -77,11 +77,6 @@ Obsoletes:      libwicked-0-6 < %{version}
 %endif
 
 BuildRequires:  libnl3-devel
-%if 0%{?suse_version} > 1110
-BuildRequires:  libiw-devel
-%else
-BuildRequires:  wireless-tools
-%endif
 BuildRequires:  dbus-1-devel
 BuildRequires:  libgcrypt-devel
 BuildRequires:  pkg-config


### PR DESCRIPTION
Remove libiw dependency (since https://github.com/openSUSE/wicked/pull/872)
used to detect wireless interfaces only.
Unfortunately `rtnetlink(7)` does not provide this info in the `NEWLINK`
message, so we're using sysfs telling us if an interface has a wireless
extension, once the `/sys/class/net/$name/wireless` directory exists
(issue: https://github.com/openSUSE/wicked/issues/910).