### PR TITLE
dbus: Fix common dbus string_array handling

### DIFF
--- a/src/dbus-object.c
+++ b/src/dbus-object.c
@@ -1356,6 +1356,8 @@ ni_dbus_generic_property_set_string_array(ni_dbus_object_t *obj, const ni_dbus_p
 		return FALSE;
 
 	vptr = __property_data(prop, handle, string_array);
+
+	ni_string_array_destroy(vptr);
 	for (i = 0; i < var->array.len; ++i)
 		ni_string_array_append(vptr, var->string_array_value[i]);
 	return TRUE;


### PR DESCRIPTION
We missed the cleanup of the old value. This lead into
orphan entries in our local datastructure.

It was detected when debugging BSS info on wireless.
If I kept the same SSID/BSSID, but changed pairwise or key management
settings, the old values where still displayed. Because the dbus
object just get updated.