### PR TITLE
socket.c improvements and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,7 @@ Makefile.in
 /util/mkconst
 /util/schema2html
 /testing/*-test
+testing/*.log
+testing/*.trs
 /html
+test-driver

--- a/src/dbus-connection.c
+++ b/src/dbus-connection.c
@@ -812,6 +812,7 @@ __ni_dbus_watch_close(ni_socket_t *sock)
 			/* Note, we're not explicitly closing the socket.
 			 * We may want to shut down the connection owning
 			 * us, however. */
+			ni_socket_release(wd->socket);
 			wd->socket = NULL;
 #ifdef DEBUG_WATCH_VERBOSE
 			ni_debug_dbus("%s wd %p state changed from %s to %s",__func__,
@@ -881,8 +882,10 @@ __ni_dbus_remove_watch(DBusWatch *watch, void *dummy)
 		if (wd->watch == watch) {
 			__ni_get_dbus_watch_data(wd);
 			*pos = wd->next;
-			if (wd->socket)
+			if (wd->socket) {
 				ni_socket_close(wd->socket);
+				wd->socket = NULL;
+			}
 #ifdef DEBUG_WATCH_VERBOSE
 			ni_debug_dbus("%s wd %p state changed from %s to %s",__func__,
 					wd, __ni_dbus_wd_state_name(wd->state),

--- a/src/socket.c
+++ b/src/socket.c
@@ -271,12 +271,13 @@ ni_socket_wrap(int fd, int sotype)
 static void
 __ni_socket_close(ni_socket_t *sock)
 {
-	if (sock->close) {
-		sock->close(sock);
-	} else if (sock->__fd >= 0) {
-		close(sock->__fd);
+	if (sock->__fd >= 0) {
+		if (sock->close)
+			sock->close(sock);
+		else
+			close(sock->__fd);
+		sock->__fd = -1;
 	}
-	sock->__fd = -1;
 
 	ni_buffer_destroy(&sock->wbuf);
 	ni_buffer_destroy(&sock->rbuf);

--- a/src/socket.c
+++ b/src/socket.c
@@ -79,8 +79,8 @@ ni_socket_release(ni_socket_t *sock)
 
 	sock->refcount--;
 	if (sock->refcount == 0) {
-		__ni_socket_close(sock);
 		ni_assert(!sock->active);
+		__ni_socket_close(sock);
 		if (sock->release_user_data)
 			sock->release_user_data(sock->user_data);
 		free(sock);

--- a/src/socket.c
+++ b/src/socket.c
@@ -35,7 +35,7 @@ static void			__ni_socket_close(ni_socket_t *);
 static void			__ni_default_error_handler(ni_socket_t *);
 static void			__ni_default_hangup_handler(ni_socket_t *);
 
-static ni_socket_array_t	__ni_sockets;
+static ni_socket_array_t	__ni_sockets = NI_SOCKET_ARRAY_INIT;
 
 
 /*
@@ -45,16 +45,6 @@ ni_bool_t
 ni_socket_activate(ni_socket_t *sock)
 {
 	return ni_socket_array_activate(&__ni_sockets, sock);
-}
-
-static inline void
-__ni_socket_deactivate(ni_socket_t **slot)
-{
-	ni_socket_t *sock = *slot;
-
-	*slot = NULL;
-	sock->active = NULL;
-	ni_socket_release(sock);
 }
 
 ni_bool_t
@@ -118,16 +108,14 @@ int
 ni_socket_array_wait(ni_socket_array_t *array, ni_timeout_t timeout)
 {
 	struct pollfd pfd[array->count];
+	ni_socket_t *sock_array[array->count];
 	struct timeval now, expires;
-	unsigned int i, socket_count;
+	unsigned int i, socket_count = 0;
 	int ptimeout = -1;
+	int retval = 0;
 
-	/* First step - cleanup empty socket slots from the array. */
-	ni_socket_array_cleanup(array);
-
-	/* Second step - build pollfd array and get timeouts */
+	/* First step - build pollfd and working socket array and get timeouts */
 	timerclear(&expires);
-	socket_count = 0;
 	for (i = 0; i < array->count; ++i) {
 		ni_socket_t *sock = array->data[i];
 		struct timeval socket_expires;
@@ -135,15 +123,16 @@ ni_socket_array_wait(ni_socket_array_t *array, ni_timeout_t timeout)
 		if (sock->active != array)
 			continue;
 
+		pfd[socket_count].fd = sock->__fd;
+		pfd[socket_count].events = sock->poll_flags;
+		sock_array[socket_count] = ni_socket_hold(sock);
+		socket_count++;
+
 		timerclear(&socket_expires);
 		if (sock->get_timeout && sock->get_timeout(sock, &socket_expires) == 0) {
 			if (!timerisset(&expires) || timercmp(&socket_expires, &expires, <))
 				expires = socket_expires;
 		}
-
-		pfd[socket_count].fd = sock->__fd;
-		pfd[socket_count].events = sock->poll_flags;
-		socket_count++;
 	}
 
 	ni_timer_get_time(&now);
@@ -163,80 +152,78 @@ ni_socket_array_wait(ni_socket_array_t *array, ni_timeout_t timeout)
 
 	if (socket_count == 0 && ptimeout < 0) {
 		ni_debug_socket("no sockets left to watch");
-		return 1;
+		retval = 1;
+		goto out;
 	}
 
 	if (poll(pfd, socket_count, ptimeout) < 0) {
 		if (errno == EINTR)
-			return 0;
+			goto out;
 		ni_error("poll returns error: %m");
-		return -1;
+		retval = -1;
+		goto out;
 	}
 
 	for (i = 0; i < socket_count; ++i) {
-		ni_socket_t *sock = array->data[i];
+		ni_socket_t *sock = sock_array[i];
 
-		if (!sock || sock->active != array)
+		if (sock->active != array)
 			continue;
 
 		if (pfd[i].fd != sock->__fd)
 			continue;
 
-		ni_socket_hold(sock);
-
 		if (pfd[i].revents & POLLERR) {
 			/* Deactivate socket */
-			__ni_socket_deactivate(&array->data[i]);
+			ni_socket_deactivate(sock);
 			sock->handle_error(sock);
-			goto done_with_this_socket;
+			continue;
 		}
 
 		if (pfd[i].revents & POLLIN) {
 			if (sock->receive == NULL) {
 				ni_error("socket %d has no receive callback", sock->__fd);
-				__ni_socket_deactivate(&array->data[i]);
+				ni_socket_deactivate(sock);
 			} else {
 				sock->receive(sock);
 			}
 			if (sock->__fd < 0)
-				goto done_with_this_socket;
+				continue;
 		}
 
 		if (pfd[i].revents & POLLHUP) {
 			if (sock->handle_hangup)
 				sock->handle_hangup(sock);
 			if (sock->__fd < 0)
-				goto done_with_this_socket;
+				continue;
 		} else
 
 		if (pfd[i].revents & POLLOUT) {
 			if (sock->transmit == NULL) {
 				ni_error("socket %d has no transmit callback", sock->__fd);
-				__ni_socket_deactivate(&array->data[i]);
+				ni_socket_deactivate(sock);
 			} else {
 				sock->transmit(sock);
 			}
 		}
-
-done_with_this_socket:
-		ni_socket_release(sock);
 	}
 
 	ni_timer_get_time(&now);
-	for (i = 0; i < array->count && i < socket_count; ++i) {
-		ni_socket_t *sock = array->data[i];
+	for (i = 0; i < socket_count; ++i) {
+		ni_socket_t *sock = sock_array[i];
 
-		if (!sock || sock->active != array)
+		if (sock->active != array)
 			continue;
 
 		if (sock->check_timeout)
 			sock->check_timeout(sock, &now);
 	}
 
-	/* Finally cleanup deactivated/released sockets */
-	ni_socket_array_cleanup(array);
+out:
+	for (i = 0; i < socket_count; ++i)
+		ni_socket_release(sock_array[i]);
 
-	return 0;
+	return retval;
 }
 
 int
@@ -332,18 +319,6 @@ ni_socket_array_destroy(ni_socket_array_t *array)
 		free(array->data);
 		memset(array, 0, sizeof(*array));
 	}
-}
-
-void
-ni_socket_array_cleanup(ni_socket_array_t *array)
-{
-	unsigned int i, j;
-
-	for (i = j = 0; i < array->count; ++i) {
-		if (array->data[i])
-			array->data[j++] = array->data[i];
-	}
-	array->count = j;
 }
 
 static inline void

--- a/testing/Makefile.am
+++ b/testing/Makefile.am
@@ -12,7 +12,10 @@ noinst_PROGRAMS			= rtnl-test	\
 				  xpath-test	\
 				  essid-test	\
 				  cstate-test   \
-				  bitmap-test
+				  bitmap-test	\
+				  socket-mock-test
+
+noinst_HEADERS			= wunit.h
 
 AM_CPPFLAGS			= -I$(top_srcdir)/src	\
 				  -I$(top_srcdir)/include
@@ -35,8 +38,11 @@ xpath_test_SOURCES		= xpath-test.c
 essid_test_SOURCES		= essid-test.c
 cstate_test_SOURCES		= cstate-test.c
 bitmap_test_SOURCES		= bitmap-test.c
+socket_mock_test_SOURCES	= socket-mock-test.c
 
 EXTRA_DIST			= ibft xpath \
 				  scripts/ifbind.sh
+
+TESTS				= socket-mock-test
 
 # vim: ai

--- a/testing/socket-mock-test.c
+++ b/testing/socket-mock-test.c
@@ -1,0 +1,761 @@
+/**
+ *	Copyright (C) 2022 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Clemens Famulla-Conrad <cfamullaconrad@suse.com>
+ *
+ *	Description:
+ *		Unit tests for src/socket.c
+ */
+#include <stdlib.h>
+#include <poll.h>
+#include <errno.h>
+#include <limits.h>
+
+#include <wicked/time.h>
+#include <wicked/logging.h>
+#include <wicked/socket.h>
+#include "socket_priv.h"
+#include "wunit.h"
+
+#define CLEANUP()									\
+	do {										\
+		CHECK2(ni_socket_wait(-1) == 1, "[CLEANUP] Socket array is empty");	\
+		ni_socket_deactivate_all();						\
+	} while (0)
+
+struct s_testdata {
+	unsigned int close_cnt;
+	unsigned int receive_cnt;
+	unsigned int transmit_cnt;
+	unsigned int handle_error_cnt;
+	unsigned int handle_hangup_cnt;
+	unsigned int release_user_data_cnt;
+	unsigned int check_timeout_cnt;
+};
+
+int (*mock_poll)(struct pollfd *, nfds_t, int) = NULL;
+
+int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	if (mock_poll)
+		return mock_poll(fds, nfds, timeout);
+	errno = 666;
+	return -1;
+}
+
+static void cb_receive(ni_socket_t *s)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->receive_cnt++;
+}
+
+static void cb_transmit(ni_socket_t *s)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->transmit_cnt++;
+}
+
+static void cb_handle_error(ni_socket_t *s)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->handle_error_cnt++;
+}
+
+static void cb_close(ni_socket_t *s)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->close_cnt++;
+}
+
+static void cb_handle_hangup(ni_socket_t *s)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->handle_hangup_cnt++;
+}
+
+static void cb_check_timeout(ni_socket_t *s, const struct timeval *now)
+{
+	struct s_testdata *td = (struct s_testdata *) s->user_data;
+
+	ni_assert(td != NULL);
+	td->check_timeout_cnt++;
+}
+
+static void cb_check_timeout_close_socket(ni_socket_t *s, const struct timeval *now)
+{
+	ni_socket_close(s);
+}
+
+static void cb_release_user_data(void *ptr)
+{
+	struct s_testdata *td = ptr;
+
+	ni_assert(td != NULL);
+	td->release_user_data_cnt++;
+}
+
+static void cb_close_socket(ni_socket_t *s)
+{
+	ni_socket_close(s);
+}
+
+static void cb_deactivate_socket(ni_socket_t *s)
+{
+	ni_socket_deactivate(s);
+}
+
+static int cb_get_timeout_expire_in_5(const ni_socket_t *s, struct timeval *ret)
+{
+	ni_timer_get_time(ret);
+	ret->tv_sec += 5;
+	return 0;
+}
+
+static int cb_get_timeout_expire_in_10(const ni_socket_t *s, struct timeval *ret)
+{
+	ni_timer_get_time(ret);
+	ret->tv_sec += 10;
+	return 0;
+}
+
+static int cb_get_timeout_expired(const ni_socket_t *s, struct timeval *ret)
+{
+	ni_timer_get_time(ret);
+	ret->tv_sec -= 5;
+	return 0;
+}
+
+static int mock_poll_set_all_POLLIN(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = POLLIN;
+	return 0;
+}
+
+static int mock_poll_set_all_POLLOUT(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = POLLOUT;
+	return 0;
+}
+
+static int mock_poll_set_all_POLLERR(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = POLLERR;
+	return 0;
+}
+
+static int mock_poll_set_all_POLLHUP(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = POLLHUP;
+	return 0;
+}
+
+static int mock_poll_EINTR(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	errno = EINTR;
+	return -1;
+}
+
+#define POLL_ARGS_FD_SIZE 128
+struct {
+	struct pollfd fds[POLL_ARGS_FD_SIZE];
+	nfds_t nfds;
+	int timeout;
+} poll_args;
+
+static int mock_poll_collect_args(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	ni_assert(nfds <= POLL_ARGS_FD_SIZE);
+	memcpy(poll_args.fds, fds, sizeof(struct pollfd) * nfds);
+	poll_args.timeout = timeout;
+	poll_args.nfds = nfds;
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = 0;
+	return 0;
+}
+
+static int mock_poll_noop(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	nfds_t i;
+
+	for (i = 0; i < nfds; i++)
+		fds[i].revents = 0;
+	return 0;
+}
+
+TESTCASE(poll_errors)
+{
+	/* NULL mock_poll triggers to set errno 666 + return -1 -- logs error */
+	mock_poll = NULL;
+	CHECK2(ni_socket_wait(1) == -1, "Undefined error return -1");
+
+	/* ni_socket_wait does not report interrupted poll errors */
+	mock_poll = mock_poll_EINTR;
+	CHECK2(ni_socket_wait(1) == 0, "EINTR return 0");
+	CLEANUP();
+}
+
+TESTCASE(empty_socket_array)
+{
+	/* ni_socket_wait return 1 on infinite poll without any sockets */
+	mock_poll = mock_poll_noop;
+	ni_socket_deactivate_all();
+	CHECK(ni_socket_wait(-1) == 1);
+	CLEANUP();
+}
+
+TESTCASE(test_call_POLLOUT)
+{
+	ni_socket_t *sock = NULL;
+	struct s_testdata *td;
+
+	ni_socket_deactivate_all();
+
+	/* Check good case to transmit once */
+	sock = ni_socket_wrap(10, 0);
+	sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->transmit = cb_transmit;
+	ni_socket_activate(sock);
+
+	mock_poll = mock_poll_set_all_POLLOUT;
+	CHECK(ni_socket_wait(1) == 0);
+
+	td = (struct s_testdata *) sock->user_data;
+	CHECK2(td->transmit_cnt == 1, "Socket transmit called once.");
+	ni_socket_close(sock);
+	free(td);
+
+	/* Check implicit deactivation with missed transmit callback -- logs error */
+	sock = ni_socket_wrap(10, 0);
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK2(sock->active == NULL, "Socket got deactivated -- no transmit callback");
+	CHECK(sock->refcount == 1);
+	ni_socket_release(sock);
+
+	/*  Check close during transmit callback */
+	sock = ni_socket_wrap(10, 0);
+	sock->transmit = cb_close_socket;
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+
+	CLEANUP();
+}
+
+
+TESTCASE(test_call_POLLIN)
+{
+	ni_socket_t *sock = NULL;
+	struct s_testdata *td;
+
+	ni_socket_deactivate_all();
+
+	/* Check good case to receive once */
+	sock = ni_socket_wrap(10, 0);
+	sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->receive = cb_receive;
+
+	ni_socket_activate(sock);
+
+	mock_poll = mock_poll_set_all_POLLIN;
+	CHECK(ni_socket_wait(1) == 0);
+
+	td = (struct s_testdata *) sock->user_data;
+	CHECK2(td->receive_cnt == 1, "Socket got one receive event.");
+	ni_socket_close(sock);
+	free(td);
+
+	/* Check implicit deactivation of socket without receive callback */
+	sock = ni_socket_wrap(10, 0);
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK2(sock->active == NULL, "Socket got deactivated -- no receive callback");
+	CHECK(sock->refcount == 1);
+	ni_socket_release(sock);
+
+	/*  Check close during receive callback */
+	sock = ni_socket_wrap(10, 0);
+	sock->receive = cb_close_socket;
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+
+	CLEANUP();
+}
+
+TESTCASE(test_call_POLLERR)
+{
+	ni_socket_t *sock = NULL;
+	struct s_testdata *td;
+
+	ni_socket_deactivate_all();
+
+	sock = ni_socket_wrap(10, 0);
+	ni_socket_activate(sock);
+
+	/* check poll signaling an error event - without an error callback:
+	 * logs error to set an error callback and deactivates the socket */
+	mock_poll = mock_poll_set_all_POLLERR;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(sock->error == 1);
+	CHECK(sock->active == NULL);
+	ni_socket_close(sock);
+
+	/* check poll signaling an error event - with callback:
+	 * calls the error callback and deactivates the socket */
+	sock = ni_socket_wrap(10, 0);
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->handle_error = cb_handle_error;
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(sock->error == 0);
+	CHECK(sock->active == NULL);
+	CHECK(td->handle_error_cnt == 1);
+	free(td);
+	ni_socket_release(sock);
+
+	CLEANUP();
+}
+
+TESTCASE(test_call_POLLHUP)
+{
+	ni_socket_t *sock = NULL;
+	struct s_testdata *td;
+
+	ni_socket_deactivate_all();
+
+	sock = ni_socket_wrap(10, 0);
+	ni_socket_activate(sock);
+
+	/* check poll signaling a hangup - without callback */
+	mock_poll = mock_poll_set_all_POLLHUP;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(sock->active != NULL);
+	ni_socket_close(sock);
+
+	/* check poll signaling a hangup - with callback:
+	 * calls the hangup callback */
+	sock = ni_socket_wrap(10, 0);
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->handle_hangup = cb_handle_hangup;
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(sock->active != NULL);
+	CHECK(td->handle_hangup_cnt == 1);
+	free(td);
+	ni_socket_close(sock);
+
+	/* check poll signaling a hangup - with callback closing
+	 * the socket (without to count the call) and a callback
+	 * to release user data and counted call. */
+	sock = ni_socket_wrap(10, 0);
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->handle_hangup = cb_close_socket;
+	sock->release_user_data = cb_release_user_data;
+	ni_socket_activate(sock);
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(td->release_user_data_cnt == 1);
+	free(td);
+
+	CLEANUP();
+}
+
+TESTCASE(close_and_other_get_called)
+{
+	/* test a fixed bug to skip processing (the receive call) of poll
+	 * results on next/2nd socket when the socket before/1st calls close
+	 * and deactivates/removes itself from active poll socket array. */
+
+	ni_socket_t *sock[2];
+	struct s_testdata *td[2];
+	int i;
+
+	for (i = 0; i < 2; i++) {
+		sock[i] = ni_socket_wrap(10+1, 0);
+		sock[i]->release_user_data = cb_release_user_data;
+		td[i] = sock[i]->user_data = xcalloc(1, sizeof(struct s_testdata));
+	}
+	sock[0]->receive = cb_close_socket;
+	sock[1]->receive = cb_receive;
+
+	ni_socket_activate(sock[0]);
+	ni_socket_activate(sock[1]);
+
+	mock_poll = mock_poll_set_all_POLLIN;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(td[0]->release_user_data_cnt == 1);
+	CHECK2(td[1]->receive_cnt == 1, "Second socket get called"); /* failed on former bug */
+
+	ni_socket_close(sock[1]);
+	CHECK2(ni_socket_wait(-1) == 1, "Socket array is empty!");
+	free(td[0]);
+	free(td[1]);
+
+	CLEANUP();
+}
+
+TESTCASE(deactivate_and_other_get_called)
+{
+	/* test a fixed bug to skip processing (the receive call) of poll
+	 * results on next/2nd socket when the socket before/1st deactivates
+	 * (removes) itself from active poll socket array. */
+
+	ni_socket_t *sock[2];
+	struct s_testdata *td[2];
+	int i;
+
+	ni_socket_deactivate_all();
+
+
+	for (i = 0; i < 2; i++) {
+		sock[i] = ni_socket_wrap(10+i, 0);
+		sock[i]->release_user_data = cb_release_user_data;
+		td[i] = sock[i]->user_data = xcalloc(1, sizeof(struct s_testdata));
+	}
+	sock[0]->receive = cb_deactivate_socket;
+	sock[1]->receive = cb_receive;
+
+	ni_socket_activate(sock[0]);
+	ni_socket_activate(sock[1]);
+
+	mock_poll = mock_poll_set_all_POLLIN;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(sock[0]->refcount == 1);
+	CHECK(sock[1]->refcount == 2);
+	CHECK(td[0]->release_user_data_cnt == 0);
+	CHECK2(td[1]->receive_cnt == 1, "Second socket get called"); /* failure on former bug */
+
+	ni_socket_release(sock[0]);
+	ni_socket_close(sock[1]);
+	CHECK2(ni_socket_wait(-1) == 1, "Socket array is empty!");
+	free(td[0]);
+	free(td[1]);
+
+	CLEANUP();
+}
+
+TESTCASE(timeout_and_expire)
+{
+	ni_socket_t *sock = NULL, *sock2 = NULL;
+
+	sock = ni_socket_wrap(10, 0);
+	sock->get_timeout = cb_get_timeout_expire_in_5;
+	ni_socket_activate(sock);
+
+	mock_poll = mock_poll_collect_args;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(poll_args.timeout == 1);
+
+	CHECK(ni_socket_wait(20000) == 0);
+	CHECK(poll_args.timeout <= 5000);
+
+	CHECK(ni_socket_wait(-1) == 0);
+	CHECK(poll_args.timeout <= 50000);
+
+	CHECK(ni_socket_wait(NI_TIMEOUT_INFINITE) == 0);
+	CHECK(poll_args.timeout <= 50000);
+
+	CHECK(ni_socket_wait(0) == 0);
+	CHECK(poll_args.timeout == 0);
+	/* If there are more then one sockets with get_timeout(), take the lower one. */
+	sock2 = ni_socket_wrap(10, 0);
+	sock2->get_timeout = cb_get_timeout_expire_in_10;
+	ni_socket_activate(sock2);
+
+	CHECK(ni_socket_wait(20000) == 0);
+	CHECK(poll_args.timeout <= 5000);
+
+	ni_socket_close(sock);
+	CHECK(ni_socket_wait(20000) == 0);
+	CHECK(poll_args.timeout <= 10000);
+
+	ni_socket_close(sock2);
+
+	/* If there are no sockets, it's like a high resolution sleep() */
+	CHECK(ni_socket_wait(20000) == 0);
+	CHECK(poll_args.timeout == 20000);
+
+	CHECK(ni_socket_wait(INT_MAX + 1L) == 0);
+	CHECK(poll_args.timeout == INT_MAX);
+	/* If no socket has get_timeout(), the given timeout is simply taken */
+	sock = ni_socket_wrap(10, 0);
+	ni_socket_activate(sock);
+
+	CHECK(ni_socket_wait(NI_TIMEOUT_INFINITE) == 0);
+	CHECK(poll_args.timeout == -1);
+
+	CHECK(ni_socket_wait(INT_MAX + 1L) == 0);
+	CHECK(poll_args.timeout == INT_MAX);
+
+	CHECK(ni_socket_wait(1000) == 0);
+	CHECK(poll_args.timeout == 1000);
+	ni_socket_close(sock);
+
+	/* Check if there is an expired socket, poll timeout should be 0 */
+	sock = ni_socket_wrap(10, 0);
+	sock->get_timeout = cb_get_timeout_expired;
+	ni_socket_activate(sock);
+
+	CHECK(ni_socket_wait(NI_TIMEOUT_INFINITE) == 0);
+	CHECK(poll_args.timeout == 0);
+
+	CHECK(ni_socket_wait(1000) == 0);
+	CHECK(poll_args.timeout == 0);
+	ni_socket_close(sock);
+
+	CLEANUP();
+}
+
+TESTCASE(check_timeout)
+{
+	ni_socket_t *sock = NULL, *sock2 = NULL;
+	struct s_testdata *td = NULL, *td2 = NULL;
+
+	mock_poll = mock_poll_noop;
+
+	/* Simple check, if check_timeout() callback was called */
+	sock = ni_socket_wrap(10, 0);
+	sock->check_timeout = cb_check_timeout;
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	ni_socket_activate(sock);
+
+	CHECK(ni_socket_wait(0) == 0);
+	CHECK2(td->check_timeout_cnt == 1, "Simple check, if check_timeout() cb is called");
+	ni_socket_close(sock);
+	free(td);
+
+	/*  Close the socket, while we are in check_timeout() callback */
+	sock = ni_socket_wrap(10, 0);
+	sock->check_timeout = cb_check_timeout;
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	ni_socket_activate(sock);
+
+	sock->check_timeout = cb_check_timeout_close_socket;
+	sock->release_user_data = cb_release_user_data;
+	CHECK(ni_socket_wait(0) == 0);
+	CHECK(td->release_user_data_cnt == 1);
+	free(td);
+
+	/* Check what happen to other sockets, when one socket close it self during
+	 * check_timeout() callback. This test a fixed bug.
+	 */
+	sock = ni_socket_wrap(10, 0);
+	sock->check_timeout = cb_check_timeout_close_socket;
+	sock->release_user_data = cb_release_user_data;
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	ni_socket_activate(sock);
+
+	sock2 = ni_socket_wrap(10, 0);
+	sock2->check_timeout = cb_check_timeout;
+	td2 = sock2->user_data = xcalloc(1, sizeof(struct s_testdata));
+	ni_socket_activate(sock2);
+
+	CHECK(ni_socket_wait(0) == 0);
+	CHECK(td->release_user_data_cnt == 1);
+	CHECK(td2->check_timeout_cnt == 1); /* failed in former bug */
+	CHECK(sock2->refcount == 2);
+	ni_socket_close(sock2);
+	free(td);
+	free(td2);
+
+	CLEANUP();
+}
+
+static int remove_and_add_poll_mock(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+	fds[0].revents = POLLERR;
+	fds[1].revents = POLLIN;
+	return 0;
+}
+
+static void remove_and_add_cb_should_not_be_called(ni_socket_t *s)
+{
+	s->user_data = (void *) 666;
+}
+
+ni_socket_t *remove_and_add_faulty_sock;
+static void remove_and_add_equal_fd_number(ni_socket_t *sock)
+{
+	ni_socket_t *partner_socket = sock->user_data;
+	int fd = partner_socket->__fd;
+
+	ni_socket_close(partner_socket);
+	remove_and_add_faulty_sock = ni_socket_wrap(fd, 0);
+	remove_and_add_faulty_sock->user_data = 0;
+	remove_and_add_faulty_sock->receive = remove_and_add_cb_should_not_be_called;
+	ni_socket_activate(remove_and_add_faulty_sock);
+}
+
+TESTCASE(remove_and_add_in_error_handler)
+{
+	/* If the handle_error() callback removes the erroneous socket, but also
+	 * add a new socket, the new socket should not get called during this
+	 * ni_socket_wait() loop. As the socket was never passed to poll().
+	 * This check a former bug!
+	 */
+
+	ni_socket_t *sock = NULL, *sock2 = NULL;
+
+	sock2 = ni_socket_wrap(11, 0);
+
+	sock = ni_socket_wrap(10, 0);
+	sock->handle_error = remove_and_add_equal_fd_number;
+	sock->user_data = sock2;
+
+	ni_socket_activate(sock);
+	ni_socket_activate(sock2);
+
+	mock_poll = remove_and_add_poll_mock;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(remove_and_add_faulty_sock != NULL);
+	CHECK(remove_and_add_faulty_sock->user_data == 0); /* failed in former bug */
+
+	ni_socket_close(sock);
+	ni_socket_close(remove_and_add_faulty_sock);
+
+	CLEANUP();
+}
+
+static void remove_and_add_different_fd(ni_socket_t *sock)
+{
+	ni_socket_t *partner_socket = sock->user_data;
+	int fd = partner_socket->__fd + 42;
+
+	ni_socket_close(partner_socket);
+	remove_and_add_faulty_sock = ni_socket_wrap(fd, 0);
+	remove_and_add_faulty_sock->user_data = 0;
+	remove_and_add_faulty_sock->receive = remove_and_add_cb_should_not_be_called;
+	ni_socket_activate(remove_and_add_faulty_sock);
+}
+
+TESTCASE(remove_and_add_in_error_handler2)
+{
+	/* Similar to remove_and_add_in_error_handler but the new socket will get
+	 * a different file-descriptor number. */
+
+	ni_socket_t *sock = NULL, *sock2 = NULL;
+
+	sock2 = ni_socket_wrap(11, 0);
+
+	sock = ni_socket_wrap(10, 0);
+	sock->handle_error = remove_and_add_different_fd;
+	sock->user_data = sock2;
+
+	ni_socket_activate(sock);
+	ni_socket_activate(sock2);
+
+	mock_poll = remove_and_add_poll_mock;
+	CHECK(ni_socket_wait(1) == 0);
+	CHECK(remove_and_add_faulty_sock != NULL);
+	CHECK(remove_and_add_faulty_sock->user_data == NULL);
+
+	ni_socket_close(sock);
+	ni_socket_close(remove_and_add_faulty_sock);
+
+	CLEANUP();
+}
+
+TESTCASE(close_callback)
+{
+	struct s_testdata *td;
+	ni_socket_t *sock = NULL;
+
+	sock = ni_socket_wrap(11, 0);
+	td = sock->user_data = xcalloc(1, sizeof(struct s_testdata));
+	sock->close = cb_close;
+
+	ni_socket_close(sock);
+	CHECK(td->close_cnt == 1);
+
+	free(td);
+	CLEANUP();
+}
+
+TESTCASE(activate_socket)
+{
+	/* Check sanity checks of `ni_socket_activte(). E.g. that an already
+	 * activated socket did not get add twice. */
+
+	ni_socket_t *sock = NULL;
+	unsigned int refcnt;
+
+	sock = ni_socket_wrap(11, 0);
+
+	CHECK(ni_socket_activate(NULL) == FALSE);
+	CHECK(ni_socket_array_activate(NULL, sock) == FALSE);
+	CHECK(ni_socket_activate(sock) == TRUE);
+	refcnt = sock->refcount;
+	CHECK(ni_socket_activate(sock) == TRUE);
+	CHECK(sock->refcount == refcnt);
+
+	ni_socket_close(sock);
+
+	CLEANUP();
+}
+
+TESTCASE(socket_arrays_remove)
+{
+	/* Check ni_socket_array function without using global
+	 * __ni_sockets array. */
+
+	ni_socket_t *sock = NULL, *sock2 = NULL;
+	ni_socket_array_t array;
+
+	ni_socket_array_init(&array);
+
+	sock = ni_socket_wrap(10, 0);
+	sock2 = ni_socket_wrap(11, 0);
+
+	CHECK(ni_socket_array_activate(&array, sock) == TRUE);
+	CHECK(ni_socket_array_append(&array, sock2) == TRUE);
+	CHECK(sock2->refcount == 1);
+	CHECK(array.count == 2);
+
+	CHECK(ni_socket_array_remove(&array, sock2) == sock2);
+	CHECK(sock2->refcount == 1);
+	ni_socket_release(sock2);
+
+	CHECK(array.count == 1);
+
+	ni_socket_array_destroy(&array);
+	ni_socket_release(sock);
+}
+
+TESTMAIN();
+

--- a/testing/wunit.h
+++ b/testing/wunit.h
@@ -1,0 +1,143 @@
+/**
+ *	Copyright (C) 2022 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Clemens Famulla-Conrad <cfamullaconrad@suse.com>
+ *
+ *	Description:
+ *		Simple macro collection to write unit tests for wicked.
+ *
+ *	Example:
+ *		cat > testing/my_unit_test.c <<'EOT'
+ *		#include "wunit.h"
+ *
+ *		TESTCASE(foo1) {
+ *			CHECK(1==1);
+ *		}
+ *
+ *		TESTMAIN();
+ *		EOT
+ *
+ *		MFILE=testing/Makefile.am
+ *		echo "TESTS += my_unit_test" >> $MFILE
+ *		echo "my_unit_test_SOURCES = my_unit_test.c" >> $MFILE
+ *		echo "noinst_PROGRAMS += my_unit_test" >> $MFILE
+ *		make check
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <wicked/logging.h>
+
+typedef struct wunit_s wunit_t;
+typedef void (*wunit_test_fn)();
+
+#define MAX_TESTCASES 512
+
+struct wunit_s {
+	unsigned int testcases_idx, fail, ok;
+	struct {
+		wunit_test_fn func;
+		const char *name;
+		unsigned int checks, fail, ok;
+	}
+	testcases[MAX_TESTCASES],
+	*current;
+};
+
+__attribute__((unused)) static wunit_t wunit_ctx = {
+	.testcases_idx = 0,
+	.fail = 0,
+	.ok = 0,
+	.current = NULL
+};
+
+#define MSG(name, ...)							\
+	do {								\
+		int __printed__;					\
+		printf("[%03d/line:%-4d] ",				\
+				wunit_ctx.current->checks, __LINE__);	\
+		__printed__ = printf(name, ##__VA_ARGS__);		\
+		if (__printed__ >= 0 && __printed__ < 50) {		\
+			for (; __printed__ < 50; __printed__++)		\
+				printf(" ");				\
+		}							\
+	} while (0)
+
+#define OK(name, ...)							\
+	do {								\
+		wunit_ctx.current->ok++;				\
+		MSG(name, ##__VA_ARGS__); printf("OK\n");		\
+	} while (0)
+
+#define FAIL(name, ...)							\
+	do {								\
+		wunit_ctx.current->fail++;				\
+		MSG(name, ##__VA_ARGS__); printf("FAILED\n");		\
+	} while (0)
+
+#define CHECK2(stm, name, ...)						\
+	do {								\
+		wunit_ctx.current->checks++;				\
+		if (stm) {						\
+			OK(name, ##__VA_ARGS__);			\
+		} else {						\
+			FAIL(name, ##__VA_ARGS__);			\
+		}							\
+	} while (0)
+
+#define CHECK(stm)		CHECK2(stm, #stm)
+
+#define TESTCASE(ts_name)								\
+	static void ts_name(void);							\
+	static void wunit_register_##ts_name(void)     __attribute__((constructor));	\
+	static void wunit_register_##ts_name(void)					\
+	{										\
+		unsigned int i = wunit_ctx.testcases_idx;				\
+		ni_assert((i + 1) < MAX_TESTCASES);						\
+		memset(&wunit_ctx.testcases[i], 0, sizeof(wunit_ctx.testcases[0]));	\
+		wunit_ctx.testcases[i].func = ts_name;					\
+		wunit_ctx.testcases[i].name = #ts_name;					\
+		wunit_ctx.testcases_idx++;						\
+	}										\
+	static void ts_name(void)
+
+#define TESTMAIN()									\
+	int main(int argc, char *argv[])						\
+	{										\
+		unsigned int i;								\
+		for (i = 0; i < wunit_ctx.testcases_idx; i++) {				\
+			printf("\n#### %s\n", wunit_ctx.testcases[i].name);		\
+			wunit_ctx.current = &wunit_ctx.testcases[i];			\
+			wunit_ctx.testcases[i].func();					\
+			if (wunit_ctx.current->fail > 0)				\
+				wunit_ctx.fail++;					\
+			else								\
+				wunit_ctx.ok++;						\
+		}									\
+		printf("\n\nResults of %d testcases: ", wunit_ctx.testcases_idx);	\
+		printf("(failed: %d) ", wunit_ctx.fail);				\
+		printf("(ok: %d)\n", wunit_ctx.ok);					\
+		printf("==============================================================="\
+				"=========\n");						\
+		for (i = 0; i < wunit_ctx.testcases_idx; i++)				\
+			printf(" %3d: %-59.*s %s\n", i + 1,				\
+				60, wunit_ctx.testcases[i].name,			\
+				wunit_ctx.testcases[i].fail > 0 ? "FAILED" : "OK");	\
+											\
+		return wunit_ctx.fail > 0 ? 1 : 0;					\
+	}


### PR DESCRIPTION
This PR is the second outcome of (bsc#1192508) and the continues work started with 
https://github.com/openSUSE/wicked/pull/912 . 
The `src/socket.c` module had some possible issues in special cases, which solved with
these changes. To avoid regressions, I created a unit test suit for that module, which show the issues in
the old implementation.
Also some code cleanup in dbus was added, where we had wrong refcount handling of `ni_socket_t` objects.