### PR TITLE
client: add --[no-]release option to ifdown/ifreload (jsc#SLE-10249)

### DIFF
--- a/client/ifup.c
+++ b/client/ifup.c
@@ -478,7 +478,7 @@ ni_do_ifup(int argc, char **argv)
 	};
 
 	ni_ifmatcher_t ifmatch;
-	ni_ifworker_array_t ifmarked;
+	ni_ifworker_array_t ifmarked = NI_IFWORKER_ARRAY_INIT;
 	ni_nanny_fsm_monitor_t *monitor = NULL;
 	ni_string_array_t opt_ifconfig = NI_STRING_ARRAY_INIT;
 	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
@@ -492,10 +492,8 @@ ni_do_ifup(int argc, char **argv)
 	ni_assert(fsm);
 	ni_fsm_require_register_type("reachable", ni_ifworker_reachability_check_new);
 
-	memset(&ifmatch, 0, sizeof(ifmatch));
-	memset(&ifmarked, 0, sizeof(ifmarked));
-
 	/* Allow ifup on all interfaces we have config for */
+	memset(&ifmatch, 0, sizeof(ifmatch));
 	ifmatch.require_configured = FALSE;
 	ifmatch.allow_persistent = TRUE;
 	ifmatch.require_config = TRUE;

--- a/client/suse/scripts/ifup.in
+++ b/client/suse/scripts/ifup.in
@@ -52,13 +52,15 @@ usage ()
 	echo "Usage: if{up,down,status,probe} [<config>] <interface> [-o <options>]"
 	echo ""
 	echo "Common options are:"
-	echo "    debug    : be verbose"
+	echo "    debug      : be verbose"
 	echo ""
 	echo "Options for if{status,probe} are:"
-	echo "    quiet    : Do not print out errors, but just signal the result through exit status"
+	echo "    quiet      : Do not print out errors, but just signal the result through exit status"
 	echo ""
 	echo "Options for ifdown are:"
-	echo "    force    : Forces persistent (nfsroot type) interface down"
+	echo "    force      : Forces persistent (nfsroot type) interface down"
+	echo "    release    : Override active config to force a lease release"
+	echo "    no-release : Override active config to skip a lease release"
 	echo ""
 	echo "Unknown options are simply ignored, so be careful."
 	echo ""
@@ -115,7 +117,7 @@ esac
 #
 SCRIPTNAME="${0##*/}"
 case $SCRIPTNAME in
-	ifup|ifstatus|ifdown|ifprobe)				;;
+	ifup|ifdown|ifstatus|ifprobe)				;;
 	*)		usage					;;
 esac
 
@@ -138,12 +140,15 @@ OPTIONS=$@
 opt_debug=""
 opt_quiet=""
 opt_force=""
+opt_release=""
 while [ $# -gt 0 ]; do
 	case $1 in
 	debug)		DEBUG="yes"				;;
 	debug=*)	DEBUG="${1#debug=}"			;;
 	quiet)		opt_quiet="--quiet"			;;
 	force)          opt_force="--force device-exists"	;;
+	release)	opt_release="--release"			;;
+	no-release)	opt_release="--no-release"		;;
 	*)		debug "unknown option \"$1\""		;;
 	esac
 	shift
@@ -241,6 +246,7 @@ case $SCRIPTNAME in
 			${opt_debug} \
 			ifdown \
 			  ${opt_force} \
+			  ${opt_release} \
 			  "$INTERFACE"
 		rc=$(rc_map_return "$?")
 	;;

--- a/dhcp4/dbus-api.c
+++ b/dhcp4/dbus-api.c
@@ -23,6 +23,8 @@
 #include <wicked/dbus-service.h>
 #include <wicked/dbus-errors.h>
 #include <wicked/objectmodel.h>
+#include <wicked/dbus.h>
+#include "dbus-common.h"
 #include "appconfig.h"
 #include "dhcp4/dhcp4.h"
 #include "dhcp.h"
@@ -194,6 +196,20 @@ failed:
 	return ret;
 }
 
+static dbus_bool_t
+ni_objectmodel_dhcp4_drop_request_from_dict(ni_dhcp4_drop_request_t *req, const ni_dbus_variant_t *dict)
+{
+	dbus_bool_t b;
+
+	if (!req || !dict || !ni_dbus_variant_is_dict(dict))
+		return FALSE;
+
+	if (ni_dbus_dict_get_bool(dict, "release", &b))
+		ni_tristate_set(&req->release, b);
+
+	return TRUE;
+}
+
 /*
  * Interface.drop(void)
  * Drop a DHCP4 lease
@@ -203,30 +219,37 @@ __ni_objectmodel_dhcp4_drop_svc(ni_dbus_object_t *object, const ni_dbus_method_t
 			unsigned int argc, const ni_dbus_variant_t *argv,
 			ni_dbus_message_t *reply, DBusError *error)
 {
+	ni_dhcp4_drop_request_t req;
 	ni_dhcp4_device_t *dev;
 	dbus_bool_t ret = FALSE;
-	ni_uuid_t uuid;
 	int rv;
 
 	if ((dev = ni_objectmodel_unwrap_dhcp4_device(object, error)) == NULL)
 		goto failed;
 
-	ni_debug_dhcp("%s(dev=%s)", __func__, dev->ifname);
+	ni_debug_dhcp("%s(dev=%s, argc=%u)", __func__, dev->ifname, argc);
 
-	memset(&uuid, 0, sizeof(uuid));
-	if (argc == 1) {
-		/* Extract the lease uuid and pass that along to ni_dhcp4_release.
+	ni_dhcp4_drop_request_init(&req);
+	if (argc >= 1) {
+		/* Extract the lease uuid and pass that along to ni_dhcp4_drop.
 		 * This makes sure we don't cancel the wrong lease.
 		 */
-		if (!ni_dbus_variant_get_uuid(&argv[0], &uuid)) {
-			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad uuid argument");
+		if (!ni_dbus_variant_get_uuid(&argv[0], &req.uuid)) {
+			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad drop request uuid argument");
+			goto failed;
+		}
+		/* Extract the drop request arguments */
+		if (argc == 2 &&
+		    !ni_objectmodel_dhcp4_drop_request_from_dict(&req, &argv[1])) {
+			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad drop request options argument");
 			goto failed;
 		}
 	}
 
-	if ((rv = ni_dhcp4_release(dev, &uuid)) < 0) {
+	if ((rv = ni_dhcp4_drop(dev, &req)) < 0) {
 		ni_dbus_set_error_from_code(error, rv,
-				"Unable to drop DHCP4 lease for interface %s", dev->ifname);
+				"%s: Unable to drop DHCP4 lease with UUID %s",
+				dev->ifname, ni_uuid_print(&req.uuid));
 		goto failed;
 	}
 
@@ -238,7 +261,7 @@ failed:
 
 static ni_dbus_method_t		ni_objectmodel_dhcp4_methods[] = {
 	{ "acquire",		"aya{sv}",	.handler = __ni_objectmodel_dhcp4_acquire_svc },
-	{ "drop",		"ay",		.handler = __ni_objectmodel_dhcp4_drop_svc },
+	{ "drop",		"aya{sv}",	.handler = __ni_objectmodel_dhcp4_drop_svc },
 	{ NULL }
 };
 

--- a/dhcp6/dbus-api.c
+++ b/dhcp6/dbus-api.c
@@ -218,6 +218,20 @@ failed:
 	return FALSE;
 }
 
+static dbus_bool_t
+ni_objectmodel_dhcp6_drop_request_from_dict(ni_dhcp6_drop_request_t *req, const ni_dbus_variant_t *dict)
+{
+	dbus_bool_t b;
+
+	if (!req || !dict || !ni_dbus_variant_is_dict(dict))
+		return FALSE;
+
+	if (ni_dbus_dict_get_bool(dict, "release", &b))
+		ni_tristate_set(&req->release, b);
+
+	return TRUE;
+}
+
 /*
  * Interface.drop(void)
  * Drop a DHCP lease
@@ -227,31 +241,37 @@ ni_objectmodel_dhcp6_drop_svc(ni_dbus_object_t *object, const ni_dbus_method_t *
 			unsigned int argc, const ni_dbus_variant_t *argv,
 			ni_dbus_message_t *reply, DBusError *error)
 {
+	ni_dhcp6_drop_request_t req;
 	ni_dhcp6_device_t *dev;
 	dbus_bool_t ret = FALSE;
-	ni_uuid_t uuid;
 	int rv;
 
 	if ((dev = ni_objectmodel_dhcp6_device_unwrap(object, error)) == NULL)
 		goto failed;
 
-	ni_debug_dhcp("%s(dev=%s)", __func__, dev->ifname);
+	ni_debug_dhcp("%s(dev=%s, argc=%u)", __func__, dev->ifname, argc);
 
-	memset(&uuid, 0, sizeof(uuid));
-	if (argc == 1) {
-		/* Extract the lease uuid and pass that along to ni_dhcp_release.
+	ni_dhcp6_drop_request_init(&req);
+	if (argc >= 1) {
+		/* Extract the lease uuid and pass that along to ni_dhcp6_drop.
 		 * This makes sure we don't cancel the wrong lease.
 		 */
-		if (!ni_dbus_variant_get_uuid(&argv[0], &uuid)) {
-			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad uuid argument");
+		if (!ni_dbus_variant_get_uuid(&argv[0], &req.uuid)) {
+			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad drop request uuid argument");
+			goto failed;
+		}
+		/* Extract the drop request arguments */
+		if (argc == 2 &&
+		    !ni_objectmodel_dhcp6_drop_request_from_dict(&req, &argv[1])) {
+			dbus_set_error(error, DBUS_ERROR_INVALID_ARGS, "bad drop request options argument");
 			goto failed;
 		}
 	}
 
-	if ((rv = ni_dhcp6_release(dev, &uuid)) < 0) {
+	if ((rv = ni_dhcp6_drop(dev, &req)) < 0) {
 		ni_dbus_set_error_from_code(error, rv,
 				"%s: Unable to drop DHCPv6 lease with UUID %s",
-				dev->ifname, ni_uuid_print(&uuid));
+				dev->ifname, ni_uuid_print(&req.uuid));
 		goto failed;
 	}
 
@@ -263,7 +283,7 @@ failed:
 
 static ni_dbus_method_t		ni_objectmodel_dhcp6_methods[] = {
 	{ "acquire",		"aya{sv}",	.handler = ni_objectmodel_dhcp6_acquire_svc },
-	{ "drop",		"ay",		.handler = ni_objectmodel_dhcp6_drop_svc },
+	{ "drop",		"aya{sv}",	.handler = ni_objectmodel_dhcp6_drop_svc },
 	{ NULL }
 };
 

--- a/include/wicked/dbus.h
+++ b/include/wicked/dbus.h
@@ -427,6 +427,8 @@ typedef struct ni_dbus_xml_validate_context {
 extern ni_xs_scope_t *		ni_dbus_xml_init(void);
 extern int			ni_dbus_xml_register_services(ni_xs_scope_t *);
 extern unsigned int		ni_dbus_xml_method_num_args(const ni_dbus_method_t *);
+extern const char *		ni_dbus_xml_get_argument_name(const ni_dbus_method_t *, unsigned int);
+extern ni_xs_type_t *		ni_dbus_xml_get_argument_type(const ni_dbus_method_t *method, unsigned int narg);
 extern const xml_node_t *	ni_dbus_xml_get_argument_metadata(const ni_dbus_method_t *, unsigned int);
 extern int			ni_dbus_xml_map_method_argument(const ni_dbus_method_t *method, unsigned int index,
 						xml_node_t *doc_node, xml_node_t **ret_node, ni_bool_t *skip_call);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -164,6 +164,10 @@ struct ni_ifworker {
 		xml_node_t *			node;
 	}			state;
 
+	struct {
+		ni_tristate_t			release;
+	}			args;
+
 	/* The security ID can be used as a set of identifiers
 	 * to look up user name/password/pin type info in a
 	 * database.

--- a/man/ifup.8.in
+++ b/man/ifup.8.in
@@ -81,7 +81,8 @@ Be verbose.
 Silent mode. Feedback only via return code.
 .IP force
 Applicable to ifdown only. Forces persistent (nfsroot type) interface down.
-
+.IP release\ no-release
+Overrides active configuration to force or skip a lease release on ifdown.
 .SH FILES
 .I /sbin/ifup
 .RS

--- a/man/wicked.8.in
+++ b/man/wicked.8.in
@@ -282,6 +282,12 @@ Brings the specified interface to device-exists state. In other
 words, the interface is down, but not deleted. Persistent
 interfaces are ignored.
 .TP
+.BI "\-\-release
+Overrides active configuration to force a lease release.
+.TP
+.BI "\-\-no-release
+Overrides active configuration to skip a lease release.
+.TP
 .BI "\-\-timeout " seconds
 The default timeout for bringing down a network device is 5 seconds. If
 the interface fails to shut down within this time, \fBwicked\fP will fail
@@ -310,7 +316,7 @@ There are 4 potential ifreload use cases:
     performs ifdown followed by ifup with the new configuration on the 
     specified interfaces.
 .BI "3. Configuration deleted
-    performs ifdown --delete in order to remove the specified interfaces.
+    performs ifdown in order to shut down the specified interfaces.
 .BI "4. New configuration added
     performs regular ifup on specified interfaces.
 .fi
@@ -340,7 +346,15 @@ The special name \fBfirmware:\fP can be used to obtain the interface
 definition(s) from firmware services like iBFT.
 .TP
 .BI "\-\-persistent
-Set interface into persistent mode (no regular ifdown allowed).
+Set interface into persistent mode (no regular ifdown allowed) in ifup run.
+.TP
+.BI "\-\-release
+Overrides active configuration to force a lease release for interfaces being
+shut down.
+.TP
+.BI "\-\-no-release
+Overrides active configuration to skip a lease release for interfaces being
+shut down.
 .PP
 .\" ----------------------------------------
 .SH ifstatus/show - displays detailed interface information.

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -226,6 +226,9 @@
 
     <request-options class="array" element-type="string" element-name="option" />
   </define>
+  <define name="drop-options" class="dict">
+      <release type="boolean"/>
+  </define>
   <define name="properties" type="interface:addrconf-lease"/>
 
   <method name="requestLease">
@@ -240,6 +243,11 @@
   </method>
 
   <method name="dropLease">
+    <arguments>
+      <options type="drop-options">
+        <meta:mapping document-node="ipv4:dhcp/options" generate="true"/>
+      </options>
+    </arguments>
     <return>
       <addrconf:callback-info/>
     </return>
@@ -288,6 +296,9 @@
 
     <request-options class="array" element-type="string" element-name="option" />
   </define>
+  <define name="drop-options" class="dict">
+    <release type="boolean"/>
+  </define>
   <define name="properties" type="interface:addrconf-lease"/>
 
   <method name="requestLease">
@@ -302,6 +313,11 @@
   </method>
 
   <method name="dropLease">
+    <arguments>
+      <options type="drop-options">
+        <meta:mapping document-node="ipv6:dhcp/options" generate="true"/>
+      </options>
+    </arguments>
     <return>
       <addrconf:callback-info/>
     </return>

--- a/src/dbus-objects/addrconf.c
+++ b/src/dbus-objects/addrconf.c
@@ -673,7 +673,7 @@ ni_objectmodel_addrconf_forward_release(ni_dbus_addrconf_forwarder_t *forwarder,
 		return TRUE;
 	}
 
-	if (!ni_objectmodel_addrconf_forwarder_call(forwarder, dev, "drop", &uuid, NULL, error)) {
+	if (!ni_objectmodel_addrconf_forwarder_call(forwarder, dev, "drop", &uuid, dict, error)) {
 		switch (ni_dbus_get_error(error, NULL)) {
 		case -NI_ERROR_ADDRCONF_NO_LEASE:
 			ni_debug_objectmodel("%s: no %s:%s lease to release by supplicant",
@@ -835,12 +835,13 @@ ni_objectmodel_addrconf_ipv4_dhcp_drop(ni_dbus_object_t *object, const ni_dbus_m
 			unsigned int argc, const ni_dbus_variant_t *argv,
 			ni_dbus_message_t *reply, DBusError *error)
 {
+	const ni_dbus_variant_t *req = argc ? &argv[0] : NULL;
 	ni_netdev_t *dev;
 
 	if (!(dev = ni_objectmodel_unwrap_netif(object, error)))
 		return FALSE;
 
-	return ni_objectmodel_addrconf_forward_release(&dhcp4_forwarder, dev, NULL, reply, error);
+	return ni_objectmodel_addrconf_forward_release(&dhcp4_forwarder, dev, req, reply, error);
 }
 
 /*
@@ -893,12 +894,13 @@ ni_objectmodel_addrconf_ipv6_dhcp_drop(ni_dbus_object_t *object, const ni_dbus_m
 			unsigned int argc, const ni_dbus_variant_t *argv,
 			ni_dbus_message_t *reply, DBusError *error)
 {
+	const ni_dbus_variant_t *req = argc ? &argv[0] : NULL;
 	ni_netdev_t *dev;
 
 	if (!(dev = ni_objectmodel_unwrap_netif(object, error)))
 		return FALSE;
 
-	return ni_objectmodel_addrconf_forward_release(&dhcp6_forwarder, dev, NULL, reply, error);
+	return ni_objectmodel_addrconf_forward_release(&dhcp6_forwarder, dev, req, reply, error);
 }
 
 /*
@@ -1532,13 +1534,13 @@ static const ni_dbus_method_t		ni_objectmodel_addrconf_ipv6_static_methods[] = {
 
 static const ni_dbus_method_t		ni_objectmodel_addrconf_ipv4_dhcp_methods[] = {
 	{ "requestLease",	"a{sv}",	.handler = ni_objectmodel_addrconf_ipv4_dhcp_request },
-	{ "dropLease",		"",		.handler = ni_objectmodel_addrconf_ipv4_dhcp_drop },
+	{ "dropLease",		"a{sv}",	.handler = ni_objectmodel_addrconf_ipv4_dhcp_drop },
 	{ NULL }
 };
 
 static const ni_dbus_method_t		ni_objectmodel_addrconf_ipv6_dhcp_methods[] = {
 	{ "requestLease",	"a{sv}",	.handler = ni_objectmodel_addrconf_ipv6_dhcp_request },
-	{ "dropLease",		"",		.handler = ni_objectmodel_addrconf_ipv6_dhcp_drop },
+	{ "dropLease",		"a{sv}",	.handler = ni_objectmodel_addrconf_ipv6_dhcp_drop },
 	{ NULL }
 };
 

--- a/src/dbus-xml.c
+++ b/src/dbus-xml.c
@@ -266,6 +266,17 @@ ni_dbus_xml_validate_argument(const ni_dbus_method_t *method, unsigned int narg,
 	return ni_dbus_validate_xml(node, xs_method->arguments.data[narg].type, ctx);
 }
 
+const char *
+ni_dbus_xml_get_argument_name(const ni_dbus_method_t *method, unsigned int narg)
+{
+	const ni_xs_method_t *xs_method = method->schema;
+
+	if (!xs_method || narg >= xs_method->arguments.count)
+		return NULL;
+
+	return xs_method->arguments.data[narg].name;
+}
+
 ni_xs_type_t *
 ni_dbus_xml_get_argument_type(const ni_dbus_method_t *method, unsigned int narg)
 {

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -29,9 +29,10 @@ enum fsm_state {
 	__NI_DHCP4_STATE_MAX,
 };
 
-typedef struct ni_dhcp4_message ni_dhcp4_message_t;
-typedef struct ni_dhcp4_config ni_dhcp4_config_t;
-typedef struct ni_dhcp4_request	ni_dhcp4_request_t;
+typedef struct ni_dhcp4_message		ni_dhcp4_message_t;
+typedef struct ni_dhcp4_config		ni_dhcp4_config_t;
+typedef struct ni_dhcp4_request		ni_dhcp4_request_t;
+typedef struct ni_dhcp4_drop_request	ni_dhcp4_drop_request_t;
 
 typedef struct ni_dhcp4_device {
 	struct ni_dhcp4_device *	next;
@@ -130,7 +131,8 @@ typedef enum
 
 
 /*
- * This is the on-the wire request we receive from clients.
+ * This is the on-the wire request we receive from clients
+ * to (re-)acquire a lease.
  */
 struct ni_dhcp4_request {
 	ni_bool_t		enabled;
@@ -165,6 +167,16 @@ struct ni_dhcp4_request {
 	 * NI_ADDRCONF_UPDATE_* (this is an index enum, not a bitmask) */
 	unsigned int		update;
 	ni_tristate_t		broadcast;
+};
+
+/*
+ * This is the on-the wire request we receive from clients
+ * to drop a lease from interface.
+ */
+struct ni_dhcp4_drop_request {
+	ni_uuid_t		uuid;
+	ni_tristate_t		release;	/* override (acquire request/config) *
+						 * defaults to release lease or not. */
 };
 
 /*
@@ -222,7 +234,7 @@ extern ni_dhcp4_device_t *ni_dhcp4_active;
 extern void		ni_dhcp4_set_event_handler(ni_dhcp4_event_handler_t);
 
 extern int		ni_dhcp4_acquire(ni_dhcp4_device_t *, const ni_dhcp4_request_t *);
-extern int		ni_dhcp4_release(ni_dhcp4_device_t *, const ni_uuid_t *);
+extern int		ni_dhcp4_drop(ni_dhcp4_device_t *, const ni_dhcp4_drop_request_t *);
 extern void		ni_dhcp4_restart_leases(void);
 
 extern const char *	ni_dhcp4_fsm_state_name(enum fsm_state);
@@ -285,6 +297,7 @@ extern void		ni_dhcp4_config_free(ni_dhcp4_config_t *);
 
 extern ni_dhcp4_request_t *ni_dhcp4_request_new(void);
 extern void		ni_dhcp4_request_free(ni_dhcp4_request_t *);
+extern void		ni_dhcp4_drop_request_init(ni_dhcp4_drop_request_t *);
 
 extern void		ni_objectmodel_dhcp4_init(void);
 

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -1225,13 +1225,23 @@ ni_dhcp6_start_release(void *user_data, const ni_timer_t *timer)
 }
 
 int
-ni_dhcp6_release(ni_dhcp6_device_t *dev, const ni_uuid_t *req_uuid)
+ni_dhcp6_drop(ni_dhcp6_device_t *dev, const ni_dhcp6_drop_request_t *req)
 {
 	char *rel_uuid = NULL;
+	const char *action = "drop";
 
-	ni_string_dup(&rel_uuid, ni_uuid_print(req_uuid));
+	if (ni_tristate_is_set(req->release)) {
+		if (ni_tristate_is_enabled(req->release))
+			action = "release";
+	} else {
+		if (dev->config && dev->config->release_lease)
+			action = "release";
+	}
+
+	ni_string_dup(&rel_uuid, ni_uuid_print(&req->uuid));
 	if (dev->lease == NULL || dev->config == NULL) {
-		ni_info("%s: Request to release DHCPv6 lease%s%s: no lease", dev->ifname,
+		ni_info("%s: Request to %s DHCPv6 lease%s%s: no lease",
+			dev->ifname, action,
 			rel_uuid ? " using UUID " : "", rel_uuid ? rel_uuid : "");
 		ni_string_free(&rel_uuid);
 
@@ -1241,12 +1251,18 @@ ni_dhcp6_release(ni_dhcp6_device_t *dev, const ni_uuid_t *req_uuid)
 		return -NI_ERROR_ADDRCONF_NO_LEASE;
 	}
 
-	ni_note("%s: Request to release DHCPv6 lease%s%s: releasing...", dev->ifname,
+	ni_note("%s: Request to %s DHCPv6 lease%s%s: starting...",
+			dev->ifname, action,
 			rel_uuid ? " using UUID " : "", rel_uuid ? rel_uuid : "");
 	ni_string_free(&rel_uuid);
 
-	dev->lease->uuid = *req_uuid;
-	dev->config->uuid = *req_uuid;
+	dev->lease->uuid = req->uuid;
+	dev->config->uuid = req->uuid;
+	if (ni_tristate_is_enabled(req->release))
+		dev->config->release_lease = TRUE;
+	else
+	if (ni_tristate_is_disabled(req->release))
+		dev->config->release_lease = FALSE;
 
 	ni_dhcp6_device_start_timer_cancel(dev);
 	ni_dhcp6_fsm_reset(dev);
@@ -1612,6 +1628,13 @@ ni_dhcp6_request_free(ni_dhcp6_request_t *req)
 		 */
 		free(req);
 	}
+}
+
+void
+ni_dhcp6_drop_request_init(ni_dhcp6_drop_request_t *req)
+{
+	ni_uuid_init(&req->uuid);
+	req->release = NI_TRISTATE_DEFAULT;
 }
 
 ni_dhcp6_prefix_req_t *

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -33,15 +33,16 @@
 /*
  * -- type definitions
  */
-typedef struct ni_dhcp6_request	ni_dhcp6_request_t;
-typedef struct ni_dhcp6_config	ni_dhcp6_config_t;
-typedef struct ni_dhcp6_device	ni_dhcp6_device_t;
+typedef struct ni_dhcp6_request		ni_dhcp6_request_t;
+typedef struct ni_dhcp6_config		ni_dhcp6_config_t;
+typedef struct ni_dhcp6_device		ni_dhcp6_device_t;
+typedef struct ni_dhcp6_drop_request	ni_dhcp6_drop_request_t;
 
 /*
  * -- supplicant actions
  */
 extern int			ni_dhcp6_acquire(ni_dhcp6_device_t *, const ni_dhcp6_request_t *, char **);
-extern int			ni_dhcp6_release(ni_dhcp6_device_t *, const ni_uuid_t *);
+extern int			ni_dhcp6_drop(ni_dhcp6_device_t *, const ni_dhcp6_drop_request_t *);
 extern void			ni_dhcp6_restart(void);
 extern ni_bool_t		ni_dhcp6_supported(const ni_netdev_t *);
 
@@ -55,9 +56,10 @@ typedef enum {
 } ni_dhcp6_run_t;
 
 /*
- * -- supplicant request
+ * -- supplicant acquire request
  *
- * This is the on-the wire request we receive from supplicant.
+ * This is the on-the wire request we receive from clients
+ * to (re-)acquire a lease.
  */
 struct ni_dhcp6_request {
 	ni_bool_t		enabled;
@@ -98,8 +100,21 @@ struct ni_dhcp6_request {
 	ni_string_array_t	request_options;
 };
 
+/*
+ * -- supplicant drop request
+ *
+ * This is the on-the wire request we receive from clients
+ * to drop a lease from interface.
+ */
+struct ni_dhcp6_drop_request {
+	ni_uuid_t		uuid;
+	ni_tristate_t		release;	/* override (acquire request/config) *
+						 * defaults to release lease or not. */
+};
+
 extern ni_dhcp6_request_t *	ni_dhcp6_request_new(void);
 extern void			ni_dhcp6_request_free(ni_dhcp6_request_t *);
+extern void			ni_dhcp6_drop_request_init(ni_dhcp6_drop_request_t *);
 
 /*
  * -- device config timing defaults


### PR DESCRIPTION
Add `wicked <ifdown|ifreload> --[no-]release ..` option, that overrides the configured
release behavior previously applied by ifup and force to (not) release dhcp leases.