### PR TITLE
xpath-fmt: Fix segfault when formating an empty node

### DIFF
--- a/src/xpath-fmt.c
+++ b/src/xpath-fmt.c
@@ -209,7 +209,7 @@ xpath_format_eval(xpath_format_t *pieces, xml_node_t *xn, ni_string_array_t *res
 		}
 
 		/* FIXME: avoid extraneous strdup here? */
-		ni_string_array_append(result, formatted.string);
+		ni_string_array_append(result, formatted.string ?: "");
 		ni_stringbuf_destroy(&formatted);
 	}
 


### PR DESCRIPTION
If we try to format an empty node with xpath, we got a segfault
in the corresponding printf call, e.g.
```
echo "<foo><bar></bar><foo>" | \
  wicked xpath --reference '/foo' '%{bar}'
```