### PR TITLE
wireless: minimize extension/type detection race on ifrename

### DIFF
--- a/src/iflist.c
+++ b/src/iflist.c
@@ -1101,6 +1101,25 @@ __ni_process_ifinfomsg_ovs_type(ni_iftype_t *type, const char *ifname, ni_netcon
 		*type = NI_IFTYPE_OVS_BRIDGE;
 }
 
+static ni_bool_t
+ni_is_wireless(const char *ifname, unsigned int ifindex)
+{
+	char ifname_tmp[IF_NAMESIZE];
+
+	/* rtnetlink does not tell us if the device has a
+	 * wireless extensions or not, but sysfs does. */
+	if ( ni_sysfs_netif_exists(ifname, "wireless"))
+		return TRUE;
+
+	/* There might be a race condition, where the iterface was renamed and the
+	 * directory in sysfs doesn't exists anymore */
+	if (if_indextoname(ifindex, ifname_tmp))
+		if (ni_sysfs_netif_exists(ifname_tmp, "wireless"))
+			return TRUE;
+
+	return FALSE;
+}
+
 static void
 __ni_process_ifinfomsg_linktype(ni_linkinfo_t *link, const char *ifname, ni_netconfig_t *nc)
 {
@@ -1138,9 +1157,7 @@ __ni_process_ifinfomsg_linktype(ni_linkinfo_t *link, const char *ifname, ni_netc
 			/* We're at the very least an ethernet. */
 			tmp_link_type = NI_IFTYPE_ETHERNET;
 
-			/* rtnetlink does not tell us if the device has a
-			 * wireless extensions or not, but sysfs does. */
-			if ( ni_sysfs_netif_exists(ifname, "wireless"))
+			if (ni_is_wireless(ifname, link->ifindex))
 				tmp_link_type = NI_IFTYPE_WIRELESS;
 
 			memset(&drv_info, 0, sizeof(drv_info));


### PR DESCRIPTION
If we process the ifinfomsg_linktype, but the interface was renamed
in the meantime, the corresponding sysfs path doesn't exists
anymore. Minimize the race possibility by requesting the new ifname.