### PR TITLE
wireless: <auth-proto> prefer wpa/rsn values over wpa1/wpa2

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -4091,8 +4091,8 @@ __ni_wireless_parse_psk_auth(const ni_sysconfig_t *sc, ni_wireless_network_t *ne
 		goto psk_failure;
 
 	if (NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH == ap_scan) {
-		if (!(net->auth_proto & NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA2)))
-			net->auth_proto = NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA1);
+		if (!(net->auth_proto & NI_BIT(NI_WIRELESS_AUTH_PROTO_RSN)))
+			net->auth_proto = NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA);
 
 		if (!(net->pairwise_cipher & NI_BIT(NI_WIRELESS_CIPHER_CCMP)))
 			net->pairwise_cipher = NI_BIT(NI_WIRELESS_CIPHER_TKIP);
@@ -4190,8 +4190,8 @@ __ni_wireless_parse_eap_auth(const ni_sysconfig_t *sc, ni_wireless_network_t *ne
 		goto eap_failure;
 
 	if (NI_WIRELESS_AP_SCAN_SUPPLICANT_EXPLICIT_MATCH == ap_scan) {
-		if (!(net->auth_proto & NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA2)))
-			net->auth_proto = NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA1);
+		if (!(net->auth_proto & NI_BIT(NI_WIRELESS_AUTH_PROTO_RSN)))
+			net->auth_proto = NI_BIT(NI_WIRELESS_AUTH_PROTO_WPA);
 
 		if (!(net->pairwise_cipher & NI_BIT(NI_WIRELESS_CIPHER_CCMP)))
 			net->pairwise_cipher = NI_BIT(NI_WIRELESS_CIPHER_TKIP);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -107,8 +107,8 @@ typedef enum ni_wireless_eap_method {
  * file so we can reuse stuff for 802.1x
  */
 typedef enum ni_wireless_auth_proto {
-	NI_WIRELESS_AUTH_PROTO_WPA1,
-	NI_WIRELESS_AUTH_PROTO_WPA2,
+	NI_WIRELESS_AUTH_PROTO_WPA,
+	NI_WIRELESS_AUTH_PROTO_RSN,
 } ni_wireless_auth_proto_t;
 
 typedef enum ni_wireless_auth_algo {

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -111,8 +111,8 @@ static const ni_intmap_t			ni_wireless_wpa_key_mgmt_map[] = {
 
 static const ni_intmap_t			ni_wireless_wpa_protocol_map[] = {
 	/* as required for networks and also used in capabilities					*/
-	{ "RSN",				NI_WIRELESS_AUTH_PROTO_WPA2				},
-	{ "WPA",				NI_WIRELESS_AUTH_PROTO_WPA1				},
+	{ "RSN",				NI_WIRELESS_AUTH_PROTO_RSN				},
+	{ "WPA",				NI_WIRELESS_AUTH_PROTO_WPA				},
 
 	{ NULL }
 };
@@ -1456,10 +1456,10 @@ ni_wireless_name_to_mode(const char *string, unsigned int *value)
 }
 
 static const ni_intmap_t			ni_wireless_auth_proto_names[] = {
-	{ "wpa",		NI_WIRELESS_AUTH_PROTO_WPA1 },
-	{ "wpa1",		NI_WIRELESS_AUTH_PROTO_WPA1 },
-	{ "wpa2",		NI_WIRELESS_AUTH_PROTO_WPA2 },
-	{ "rsn",		NI_WIRELESS_AUTH_PROTO_WPA2 },
+	{ "wpa",		NI_WIRELESS_AUTH_PROTO_WPA },
+	{ "rsn",		NI_WIRELESS_AUTH_PROTO_RSN },
+	{ "wpa1",		NI_WIRELESS_AUTH_PROTO_WPA },
+	{ "wpa2",		NI_WIRELESS_AUTH_PROTO_RSN },
 	{ NULL }
 };
 

--- a/util/mkconst.c
+++ b/util/mkconst.c
@@ -61,7 +61,7 @@ static struct generic_map	generic_maps[] = {
 	MAP(ADDRCONF_UPDATE_FLAG, ni_addrconf_update_flag_to_name),
 	GETMAP(DHCP6_MODE_BIT, ni_dhcp6_mode_map),
 	MAP(WIRELESS_MODE, ni_wireless_mode_to_name),
-	MAP(WIRELESS_AUTH_PROTO, ni_wireless_auth_proto_to_name),
+	GETMAP(WIRELESS_AUTH_PROTO, ni_wireless_auth_proto_map),
 	MAP(WIRELESS_AUTH_ALGO, ni_wireless_auth_algo_to_name),
 	MAP(WIRELESS_CIPHER, ni_wireless_cipher_to_name),
 	MAP(WIRELESS_KEY_MGMT, ni_wireless_key_management_to_name),


### PR DESCRIPTION
The variable `WIRELESS_WPA_PROTO`, the field `<auth-proto>` and the capability
field `<wpa-protocols>` referencing all the same bitmap. And we would
like to see wpa/rsn instead of wpa1/wpa2.
For backward compatibility wpa1/wpa2 can still be used but
is not generated on converting ifcfg to XML.