### PR TITLE
firewall-ext: skip firewallDown action without previous firewallUp

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -88,6 +88,7 @@ substitute_vars			= \
 	-e "s|[@]wicked_configdir[@]|$(wicked_configdir)|g"	\
 	-e "s|[@]wicked_supplicantdir[@]|$(wicked_supplicantdir)|g"\
 	-e "s|[@]wicked_extensionsdir[@]|$(wicked_extensionsdir)|g"\
+	-e "s|[@]wicked_extension_statedir[@]|$(wicked_statedir)/extension|g"\
 	-e "s|[@]use_teamd[@]|$(use_teamd)|g"
 
 %.xml: %.xml.in $(top_builddir)/config.status

--- a/etc/server.xml.in
+++ b/etc/server.xml.in
@@ -55,6 +55,8 @@
    <putenv name="WICKED_OBJECT_PATH" value="$object-path"/>
    <putenv name="WICKED_INTERFACE_NAME" value="$property:name"/>
    <putenv name="WICKED_INTERFACE_INDEX" value="$property:index"/>
+   <putenv name="WICKED_EXTENSION_STATEDIR" value="@wicked_extension_statedir@/firewall"/>
+   <putenv name="WICKED_SBINDIR" value="@wicked_sbindir@"/>
   </dbus-service>
 
   <dbus-service interface="org.opensuse.Network.Scripts">

--- a/extensions/firewall
+++ b/extensions/firewall
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2012, Olaf Kirch <okir@suse.de>
-# Copyright (C) 2012-2017, SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (C) 2012-2022 SUSE LLC
 #
 #       This program is free software; you can redistribute it and/or modify
 #       it under the terms of the GNU General Public License as published by
@@ -40,7 +40,8 @@
 #exec 2>/tmp/wicked-firewall.$$.trace
 #set -vx
 
-wicked="/usr/sbin/wicked"
+wicked="${WICKED_SBINDIR:-/usr/sbin}/wicked"
+wicked_extension_statedir=${WICKED_EXTENSION_STATEDIR:-/run/wicked/extension/firewall}
 systemctl="/usr/bin/systemctl"
 firewalld_cmd="/usr/bin/firewall-cmd"
 firewalld_service="firewalld.service"
@@ -64,6 +65,7 @@ firewalld_is_active()
 firewalld_up()
 {
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
+	mkdir -p -- "$wicked_extension_statedir/$WICKED_INTERFACE_NAME"
 
 	local ZONE=`wicked_config_get_zone "$WICKED_ARGFILE"`
 
@@ -76,6 +78,8 @@ firewalld_up()
 firewalld_down()
 {
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
+	test -d "$wicked_extension_statedir/$WICKED_INTERFACE_NAME" || return 0
+	rmdir -- "$wicked_extension_statedir/$WICKED_INTERFACE_NAME"
 
 	# Remove the firewalld zone assignment permanently.
 	"$firewalld_cmd" --permanent --remove-interface="$WICKED_INTERFACE_NAME" &>/dev/null


### PR DESCRIPTION
Reference: bsc#1201053

If a interface configuration contains FIREWALL=no, wicked should not
touch the firewall configuration on firewallUp _and_ firewallDown.

The firewall schema contains a `skip-unless-present="true"` for the
method firewallUp. This avoid the calling of the firewallUp DBus method
on the specific state, as long as the configuration doesn't contain the
<firewall> node.

On firewallDown, we do not have the configuration, thus we cannot use
`skip-unless-present="true"` here. And the firewallDown state calls
the firewallDown DBus method regardless of FIREWALL configuration value.
To avoid unexpected firewall changes, the firewall extension handle
firewallDown events only, if a corresponding firewallUp event was
invoked before.