### PR TITLE
wpa_supplicant: Fix crash on unexpected restarts of wpa_supplicant

### DIFF
--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1074,7 +1074,7 @@ ni_wireless_on_wpa_supplicant_start(ni_netdev_t *dev)
 static void
 ni_wireless_on_wpa_supplicant_stop(ni_netdev_t *dev)
 {
-	ni_debug_wireless("%s: wpa_supplicant stopped!", dev->name);
+	ni_note("%s: wpa_supplicant stopped!", dev->name);
 	ni_wireless_set_state(dev, NI_WIRELESS_NOT_ASSOCIATED);
 }
 

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1348,6 +1348,7 @@ ni_wireless_sync_assoc_with_current_bss(ni_wireless_t *wlan, ni_wpa_nif_t *wif)
 		}
 
 		wlan->assoc.signal = bss->properties.signal;
+		ni_wpa_bss_drop(&bss);
 
 	} else {
 		ni_link_address_init(&wlan->assoc.bssid);

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1826,7 +1826,6 @@ ni_wpa_bss_destroy(ni_wpa_bss_t *bss)
 		object->handle = NULL;
 		ni_dbus_object_free(object);
 	}
-	bss->wif = NULL;
 
 	ni_wpa_bss_properties_destroy(&bss->properties);
 }
@@ -1921,8 +1920,9 @@ ni_wpa_bss_refresh(ni_wpa_bss_t * bss)
 		return -NI_ERROR_INVALID_ARGS;
 
 	if (!ni_dbus_object_refresh_properties(bss->object, &ni_objectmodel_wpa_bss_service, &error)) {
-		if (dbus_error_is_set(&error))
-			rv = ni_dbus_client_translate_error(bss->wif->client->dbus, &error);
+		if (dbus_error_is_set(&error) && bss->object)
+			rv = ni_dbus_object_translate_error(bss->object, &error);
+		dbus_error_free(&error);
 		return rv;
 	}
 	return 0;

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -2497,40 +2497,6 @@ static const ni_dbus_service_t			ni_objectmodel_wpa_nif_service = {
 	.compatible	= &ni_objectmodel_wpa_nif_class,
 };
 
-const char *
-__ni_print_string_array(const ni_string_array_t *array)
-{
-	static char buffer[256];
-	unsigned int i, pos, bufsize;
-
-	if (array->count == 0)
-		return "<>";
-
-	bufsize = sizeof(buffer);
-	for (i = pos = 0; i < array->count; ++i) {
-		const char *s = array->data[i];
-		unsigned int len;
-
-		if (i != 0) {
-			if (pos + 3 >= bufsize)
-				break;
-			strcpy(buffer + pos, ", ");
-			pos += 2;
-		}
-
-		if (s == NULL)
-			s = "\"\"";
-		len = strlen(s);
-		if (pos + len + 1 >= bufsize)
-			break;
-
-		strcpy(buffer + pos, s);
-		pos += len;
-	}
-
-	return buffer;
-}
-
 static void
 ni_wpa_signal_interface_added(ni_wpa_client_t *wpa, const char *member, ni_dbus_message_t *msg)
 {

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -8,6 +8,7 @@
 #define WICKED_WPA_SUPPLICANT_CLIENT_H
 
 #include <wicked/wireless.h>
+#include <wicked/refcount.h>
 #include "dbus-connection.h"
 
 
@@ -317,6 +318,7 @@ struct	ni_wpa_nif_properties {
 
 struct ni_wpa_nif {
 	ni_wpa_nif_t *				next;
+	ni_refcount_t				refcount;
 
 	ni_wpa_client_t *			client;
 	ni_dbus_object_t *			object;
@@ -395,6 +397,7 @@ extern int					ni_wpa_get_interface(ni_wpa_client_t *, const char *, unsigned in
 extern int					ni_wpa_add_interface(ni_wpa_client_t *, unsigned int,
 								ni_dbus_variant_t *, ni_wpa_nif_t **);
 extern int					ni_wpa_del_interface(ni_wpa_client_t *, const char *);
+extern						ni_refcounted_declare_drop(ni_wpa_nif);
 
 extern int					ni_wpa_nif_set_properties(ni_wpa_nif_t *, const ni_dbus_variant_t *);
 

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -370,7 +370,6 @@ struct ni_wpa_bss_properties {
 };
 
 struct ni_wpa_bss {
-	ni_wpa_nif_t *				wif;
 	ni_dbus_object_t *			object;
 	ni_wpa_bss_t *				next;
 	ni_refcount_t				refcount;

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -373,6 +373,7 @@ struct ni_wpa_bss {
 	ni_wpa_nif_t *				wif;
 	ni_dbus_object_t *			object;
 	ni_wpa_bss_t *				next;
+	ni_refcount_t				refcount;
 
 	ni_wpa_bss_properties_t			properties;
 };
@@ -418,6 +419,7 @@ extern int					ni_wpa_nif_trigger_scan(ni_wpa_nif_t *, ni_bool_t);
 extern ni_bool_t				ni_wpa_nif_retrieve_scan(ni_wpa_nif_t *, ni_wireless_scan_t *);
 extern int					ni_wpa_nif_flush_bss(ni_wpa_nif_t *wif, uint32_t max_age);
 extern ni_wpa_bss_t *				ni_wpa_nif_get_current_bss(ni_wpa_nif_t *);
+extern						ni_refcounted_declare_drop(ni_wpa_bss);
 
 extern const char *				ni_wpa_nif_property_name(ni_wpa_nif_property_type_t);
 extern ni_bool_t				ni_wpa_nif_property_type(const char *, ni_wpa_nif_property_type_t *);


### PR DESCRIPTION
Once wpa_supplicant restart unexpected, wickedd tend to crash, if the wpa_supplicant handler code was currently in one of the
DBus calls. To fix this, we need refcounting for the DBus objects of wpa_supplicant and be aware of such a situation in error handing.