### PR TITLE
firewall-ext: Do not change firewalld setting on ifdown

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -88,7 +88,6 @@ substitute_vars			= \
 	-e "s|[@]wicked_configdir[@]|$(wicked_configdir)|g"	\
 	-e "s|[@]wicked_supplicantdir[@]|$(wicked_supplicantdir)|g"\
 	-e "s|[@]wicked_extensionsdir[@]|$(wicked_extensionsdir)|g"\
-	-e "s|[@]wicked_extension_statedir[@]|$(wicked_statedir)/extension|g"\
 	-e "s|[@]use_teamd[@]|$(use_teamd)|g"
 
 %.xml: %.xml.in $(top_builddir)/config.status

--- a/etc/server.xml.in
+++ b/etc/server.xml.in
@@ -55,8 +55,6 @@
    <putenv name="WICKED_OBJECT_PATH" value="$object-path"/>
    <putenv name="WICKED_INTERFACE_NAME" value="$property:name"/>
    <putenv name="WICKED_INTERFACE_INDEX" value="$property:index"/>
-   <putenv name="WICKED_EXTENSION_STATEDIR" value="@wicked_extension_statedir@/firewall"/>
-   <putenv name="WICKED_SBINDIR" value="@wicked_sbindir@"/>
   </dbus-service>
 
   <dbus-service interface="org.opensuse.Network.Scripts">

--- a/extensions/firewall
+++ b/extensions/firewall
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2012, Olaf Kirch <okir@suse.de>
-# Copyright (C) 2012-2022 SUSE LLC
+# Copyright (C) 2012-2017, SUSE LINUX GmbH, Nuernberg, Germany.
 #
 #       This program is free software; you can redistribute it and/or modify
 #       it under the terms of the GNU General Public License as published by
@@ -40,8 +40,7 @@
 #exec 2>/tmp/wicked-firewall.$$.trace
 #set -vx
 
-wicked="${WICKED_SBINDIR:-/usr/sbin}/wicked"
-wicked_extension_statedir=${WICKED_EXTENSION_STATEDIR:-/run/wicked/extension/firewall}
+wicked="/usr/sbin/wicked"
 systemctl="/usr/bin/systemctl"
 firewalld_cmd="/usr/bin/firewall-cmd"
 firewalld_service="firewalld.service"
@@ -65,7 +64,6 @@ firewalld_is_active()
 firewalld_up()
 {
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
-	mkdir -p -- "$wicked_extension_statedir/$WICKED_INTERFACE_NAME"
 
 	local ZONE=`wicked_config_get_zone "$WICKED_ARGFILE"`
 
@@ -78,8 +76,6 @@ firewalld_up()
 firewalld_down()
 {
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
-	test -d "$wicked_extension_statedir/$WICKED_INTERFACE_NAME" || return 0
-	rmdir -- "$wicked_extension_statedir/$WICKED_INTERFACE_NAME"
 
 	# Remove the firewalld zone assignment permanently.
 	"$firewalld_cmd" --permanent --remove-interface="$WICKED_INTERFACE_NAME" &>/dev/null

--- a/extensions/firewall
+++ b/extensions/firewall
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2012, Olaf Kirch <okir@suse.de>
-# Copyright (C) 2012-2017, SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (C) 2012-2022 SUSE LLC
 #
 #       This program is free software; you can redistribute it and/or modify
 #       it under the terms of the GNU General Public License as published by
@@ -67,9 +67,9 @@ firewalld_up()
 
 	local ZONE=`wicked_config_get_zone "$WICKED_ARGFILE"`
 
-	# Assign the firewalld zone permanently.
+	# Assign the firewalld zone permanently, this sync wicked with firewalld config files.
 	"$firewalld_cmd" --permanent --zone="$ZONE" --change-interface="$WICKED_INTERFACE_NAME" &>/dev/null
-	# And also temporarily, to not have to reload.
+	# Apply same rule to runtime config.
 	"$firewalld_cmd" --zone="$ZONE" --change-interface="$WICKED_INTERFACE_NAME" &>/dev/null
 }
 
@@ -77,10 +77,12 @@ firewalld_down()
 {
 	test "X$WICKED_INTERFACE_NAME" = "X" && return 1
 
-	# Remove the firewalld zone assignment permanently.
-	"$firewalld_cmd" --permanent --remove-interface="$WICKED_INTERFACE_NAME" &>/dev/null
-	# And also temporarily, to not have to reload.
-	"$firewalld_cmd" --remove-interface="$WICKED_INTERFACE_NAME" &>/dev/null
+	# Do not change firewalld settings on ifdown, neither for FIREWALL=yes
+	# nor for FIREWALL=no (bsc#1201053 and bsc#1189560).
+	# The problem is, that `firewall-cmd --permanent` also change ifcfg
+	# files, thus it would remove the ZONE= setting from ifcfg on ifdown.
+	# Changing only runtime firewall settings, trigger a unexpected
+	# inconsistency between runtime+persistent config.
 }
 
 case $action in


### PR DESCRIPTION
Do not change firewalld settings on ifdown, neither for FIREWALL=yes
nor for FIREWALL=no (bsc#1201053 and bsc#118950).
The problem is, that `firewall-cmd --permanent` also change ifcfg
files, thus it would remove the ZONE= setting from ifcfg on ifdown.
Changing only runtime firewall settings, trigger a unexpected
inconsistency between runtime+persistent config.