### PR TITLE
testing: Null terminate map in bitmap-test

### DIFF
--- a/testing/bitmap-test.c
+++ b/testing/bitmap-test.c
@@ -40,6 +40,7 @@ ni_intmap_t map[] =  {
 	/* aliases */
 	{ "READ",	MY_GET},
 	{ "WRITE",	MY_SET},
+	{ NULL }
 };
 
 void string_array_set(ni_string_array_t *arr, ...)


### PR DESCRIPTION
Maps are supposed to end with a NULL element as otherwise out of bounds reads can occur.