### PR TITLE
dhcp6: add option to refresh lease instead to confirm it

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -137,6 +137,7 @@ ni_compat_netdev_new(const char *ifname)
 	compat->dhcp6.mode = NI_BIT(NI_DHCP6_MODE_AUTO);
 	compat->dhcp6.rapid_commit = TRUE;
 	compat->dhcp6.recover_lease = TRUE;
+	compat->dhcp6.refresh_lease = FALSE;
 	compat->dhcp6.release_lease = FALSE;
 	ni_dhcp_fqdn_init(&compat->dhcp6.fqdn);
 
@@ -2421,6 +2422,8 @@ __ni_compat_generate_dhcp6_addrconf(xml_node_t *ifnode, const ni_compat_netdev_t
 
 	xml_node_dict_set(dhcp, "recover-lease",
 				ni_format_boolean(compat->dhcp6.recover_lease));
+	xml_node_dict_set(dhcp, "refresh-lease",
+				ni_format_boolean(compat->dhcp6.refresh_lease));
 	xml_node_dict_set(dhcp, "release-lease",
 				ni_format_boolean(compat->dhcp6.release_lease));
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -5644,6 +5644,9 @@ __ni_suse_addrconf_dhcp6_options(const ni_sysconfig_t *sc, ni_compat_netdev_t *c
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_USE_LAST_LEASE")))
 		compat->dhcp6.recover_lease = !ni_string_eq(string, "no");
 
+	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_REFRESH_LEASE")))
+		compat->dhcp6.refresh_lease = ni_string_eq(string, "yes");
+
 	if ((string = ni_sysconfig_get_value(sc, "DHCLIENT6_RELEASE_BEFORE_QUIT")))
 		compat->dhcp6.release_lease = ni_string_eq(string, "yes");
 

--- a/client/suse/config/sysconfig.dhcp-wicked
+++ b/client/suse/config/sysconfig.dhcp-wicked
@@ -142,6 +142,26 @@ DHCLIENT6_CLIENT_ID=""
 #
 DHCLIENT6_UPDATE=""
 
+## Type:	yesno
+## Default:     no
+#
+# When ifup is called, the system or wickedd has been restarted or the
+# client may have moved to a new link (temporary carrier-lost) and there
+# is a valid lease available, DHCPv6 protocol is using (depending on
+# IPv6 router RA and DHCLIENT6_MODE variable):
+# - information-request in info mode ("other-config" without IP address)
+# - rebind message if the lease contains (also) a prefix for delegations
+# - confirm message if the lease contains an ("managed") IP address
+# While information-request and rebind provide "other-config" (dns,ntp
+# and other options) and extend the lifetimes, a confirm reply provides
+# only a status (code) whether the lease IP address(es) are still
+# appropriate to the link.
+#
+# Enabling this option causes to use rebind instead of a confirm and
+# thus to refresh lease options and extend the lifetimes.
+#
+DHCLIENT6_REFRESH_LEASE="no"
+
 #
 # Type:		integer
 # Default:	""

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -109,6 +109,7 @@ typedef struct ni_compat_netdev {
 
 		unsigned int	lease_time;
 		ni_bool_t	recover_lease;
+		ni_bool_t	refresh_lease;
 		ni_bool_t	release_lease;
 
 		unsigned int	update;

--- a/dhcp6/dbus-api.c
+++ b/dhcp6/dbus-api.c
@@ -495,6 +495,7 @@ static ni_dbus_property_t	dhcp6_request_properties[] = {
 	DHCP6REQ_UINT_PROPERTY(acquire-timeout, acquire_timeout, RO),
 	DHCP6REQ_UINT_PROPERTY(lease-time, lease_time, RO),
 	DHCP6REQ_BOOL_PROPERTY(recover-lease, recover_lease, RO),
+	DHCP6REQ_BOOL_PROPERTY(refresh-lease, refresh_lease, RO),
 	DHCP6REQ_BOOL_PROPERTY(release-lease, release_lease, RO),
 	DHCP6REQ_UINT_PROPERTY(update, update, RO),
 	DHCP6REQ_STRING_PROPERTY(hostname, hostname, RO),

--- a/man/ifcfg-dhcp.5.in
+++ b/man/ifcfg-dhcp.5.in
@@ -180,7 +180,7 @@ for the network connected to this interface.
 .TP
 .B auto
 .br
-Follow RA flags, remain silent when no RA flag is set.
+Follow IPv6 RA flags, remain silent when no RA flags are set.
 .TP
 .B info
 .br
@@ -271,6 +271,26 @@ This setting controls whether DHCPv6 client should try to use settings
 provided in its last lease when the DHCPv6-server is not reachable and
 the lease hasn't expired yet.
 Set this variable to "no" to disable the fallback to the last lease.
+.TP
+.BR DHCLIENT6_REFRESH_LEASE\ {yes,no*}
+When ifup is called, the system or wickedd has been restarted or the
+client may have moved to a new link (temporary carrier-lost) and there
+is a valid lease available, DHCPv6 protocol is using (depending on
+IPv6 router RA and DHCLIENT6_MODE variable):
+.IP
+.nf
+- information-request in info mode ("other-config" without IP address)
+- rebind message if the lease contains (also) a prefix for delegations
+- confirm message if the lease contains an ("managed") IP address
+.fi
+
+While information-request and rebind provide "other-config" (dns,ntp
+and other options) and extend the lifetimes, a confirm reply provides
+only a status (code) whether the lease IP address(es) are still
+appropriate to the link.
+
+Enabling this option causes to use rebind instead of a confirm and
+thus to refresh lease options and extend the lifetimes.
 .TP
 .BR DHCLIENT6_RELEASE_BEFORE_QUIT\  { yes | no* }
 Send a DHCPv6 RELEASE to the server (sign off the address)?

--- a/schema/addrconf.xml
+++ b/schema/addrconf.xml
@@ -276,6 +276,7 @@
 
     <lease-time type="seconds-type" />
     <recover-lease type="boolean" />
+    <refresh-lease type="boolean" />
     <release-lease type="boolean" />
 
     <update type="builtin-addrconf-update-mask" />

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -487,8 +487,7 @@ ni_dhcp6_device_start_auto_prefix(ni_dhcp6_device_t *dev)
 
 	/* refresh in case kernel forgot to send it
 	 * (we increment timeout between attempts) */
-	if (dev->config->dry_run != NI_DHCP6_RUN_NORMAL)
-		ni_dhcp6_device_refresh_mode(dev, ifp);
+	ni_dhcp6_device_refresh_mode(dev, ifp);
 
 	/* request prefix after 1/3 defer timeout */
 	ni_timer_get_time(&now);
@@ -524,8 +523,7 @@ ni_dhcp6_device_start_auto(ni_dhcp6_device_t *dev)
 
 	/* refresh in case kernel forgot to send it
 	 * (we increment timeout between attempts) */
-	if (dev->config->dry_run != NI_DHCP6_RUN_NORMAL)
-		ni_dhcp6_device_refresh_mode(dev, ifp);
+	ni_dhcp6_device_refresh_mode(dev, ifp);
 
 	if (dev->config->mode & NI_BIT(NI_DHCP6_MODE_AUTO))
 		return ni_dhcp6_device_start_timer_arm(dev);

--- a/src/dhcp6/device.c
+++ b/src/dhcp6/device.c
@@ -1080,6 +1080,7 @@ ni_dhcp6_acquire(ni_dhcp6_device_t *dev, const ni_dhcp6_request_t *req, char **e
 	config->lease_time	= __nondefault(req->lease_time,
 						NI_DHCP6_LEASE_TIME);
 	config->recover_lease	= req->recover_lease;
+	config->refresh_lease  	= req->refresh_lease;
 	config->release_lease	= req->release_lease;
 
 	if (!dev->lease && config->dry_run != NI_DHCP6_RUN_OFFER && config->recover_lease)

--- a/src/dhcp6/dhcp6.h
+++ b/src/dhcp6/dhcp6.h
@@ -78,6 +78,7 @@ struct ni_dhcp6_request {
 
 	unsigned int		lease_time;	/* to request specific IA T1 and T2	*/
 	ni_bool_t		recover_lease;	/* recover and reuse existing lease	*/
+	ni_bool_t		refresh_lease;  /* force lease rebind instead confirm	*/
 	ni_bool_t		release_lease;	/* release lease on drop request	*/
 
 	/* Options controlling what to put into the lease request */
@@ -152,6 +153,7 @@ struct ni_dhcp6_config {
 
 	unsigned int		lease_time;
 	ni_bool_t		recover_lease;
+	ni_bool_t		refresh_lease;
 	ni_bool_t		release_lease;
 
 	ni_opaque_t		client_duid;	/* raw client id to use		*/

--- a/src/dhcp6/fsm.c
+++ b/src/dhcp6/fsm.c
@@ -1911,7 +1911,7 @@ ni_dhcp6_fsm_confirm_prefix(ni_dhcp6_device_t *dev, const ni_addrconf_lease_t *l
 		if (deadline == NI_LIFETIME_EXPIRED)
 			return -1;
 
-		ni_debug_dhcp("%s: Initiating DHCPv6 Prefix Rebind Confirmation",
+		ni_debug_dhcp("%s: Initiating DHCPv6 Rebind Confirmation",
 				dev->ifname);
 
 		dev->dhcp6.xid = 0;
@@ -1940,6 +1940,9 @@ ni_dhcp6_fsm_confirm_address(ni_dhcp6_device_t *dev, const ni_addrconf_lease_t *
 		return -1;
 
 	if (dev->retrans.count == 0) {
+		if (dev->config->refresh_lease)
+			return ni_dhcp6_fsm_confirm_prefix(dev, lease);
+
 		ni_debug_dhcp("%s: Initiating DHCPv6 Address Confirmation",
 				dev->ifname);
 


### PR DESCRIPTION
Add config option to refresh a lease with (managed) IP address using
a rebind (like when it would contain a prefix) instead to confirm if it's
appropriate to the link only (jsc#SLE-9492,jsc#SLE-24307).