### PR TITLE
schema: Make the rule to-selector handle network prefixes

### DIFF
--- a/schema/interface.xml
+++ b/schema/interface.xml
@@ -80,7 +80,7 @@
      <priority     type="uint32" />
      <invert       type="boolean"/>
      <from         type="network-address-prefix"/>
-     <to           type="network-address"/>
+     <to           type="network-address-prefix"/>
      <iif          type="string" />
      <oif          type="string" />
      <tos          type="uint32" />


### PR DESCRIPTION
Trying to create a static rule by creating /etc/sysconfig/network/ifrule-eth0 with
```
ipv4 from 1.2.3.4 to 3.4.5.6 priority 4 table main
```
does not work; the interface never comes up. wickedd-nanny says:
```
Nov 14 14:58:48 host-abc wickedd-nanny[947]: <buffer>:30: cannot parse array with notation "net-address", value="2.3.4.5/32"
Nov 14 14:58:48 host-abc wickedd-nanny[947]: device eth0: interface document error
Nov 14 14:58:48 host-abc wickedd-nanny[947]: eth0: failed to bring up device, still continuing
```

This change and a restart of wickedd fixes the issue. It also works when specifying a /24 (as an example).