### PR TITLE
Add /etc/sysconfig/network to file list

### DIFF
--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -399,6 +399,7 @@ fi
 %_unitdir/wickedd.service
 %_unitdir/wicked.service
 %_unitdir/wickedd-pppd@.service
+%dir /etc/sysconfig/network
 %attr(0600,root,root) %config /etc/sysconfig/network/ifcfg-lo
 %_sbindir/ifup
 %if !0%{?usrmerged}


### PR DESCRIPTION
Add /etc/sysconfig/network to file list of wicked-service sub package to fix build failures with cleaned up filesystem package.