### PR TITLE
ifstatus: improve to show a no-carrier status

### DIFF
--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -93,6 +93,7 @@ ni_ifstatus_code_name(unsigned int status)
 		{ "no-device",			NI_WICKED_ST_NO_DEVICE		},
 		{ "device-not-running",		NI_WICKED_ST_NOT_RUNNING	},
 		{ "no-config",			NI_WICKED_ST_NO_CONFIG		},
+		{ "no-carrier",			NI_WICKED_ST_NO_CARRIER		},
 		{ "setup-in-progress",		NI_WICKED_ST_IN_PROGRESS	},
 		{ "config-changed",		NI_WICKED_ST_CHANGED_CONFIG	},
 		{ "enslaved",			NI_WICKED_ST_ENSLAVED		},
@@ -292,7 +293,7 @@ __ifstatus_of_device(ni_netdev_t *dev)
 
 	if (!ni_ifcheck_device_link_is_up(dev) &&
 	    ni_ifcheck_device_link_required(dev))
-		return NI_WICKED_ST_IN_PROGRESS;
+		return NI_WICKED_ST_NO_CARRIER;
 
 	__ifstatus_of_device_leases(dev, &st);
 #if 0

--- a/include/wicked/constants.h
+++ b/include/wicked/constants.h
@@ -292,6 +292,7 @@ typedef enum {
 	NI_WICKED_ST_NOT_IN_STATE	= 165,	/*!< ifcheck state lower than expected	*/
 	NI_WICKED_ST_PERSISTENT_ON	= 166,	/*!< interface is in persistent mode	*/
 	NI_WICKED_ST_USERCONTROL_ON	= 167,	/*!< user is allowed to configure the interface	*/
+	NI_WICKED_ST_NO_CARRIER		= 168,	/*!< dev is up, but there is no carrier */
 } ni_status_code_t;
 
 #endif /* __WICKED_CONSTANTS_H__ */


### PR DESCRIPTION
Split the transient `setup-in-progress` status and show `no-carrier` status
when the interface is set administratively up (device-up), but the (L2)
link is not up and running yet (link-up), including e.g. not-associated
wireless links. The following (L3) setup like IP / lease acquisition
continues to appear as setup-in-progress until the setup is sufficient
and we consider the interface it as up.