### PR TITLE
nanny: fix use-after-free in debug mode (bsc#1206447)

### DIFF
--- a/nanny/policy.c
+++ b/nanny/policy.c
@@ -240,17 +240,20 @@ ni_objectmodel_register_managed_policy(ni_dbus_server_t *server, ni_managed_poli
 dbus_bool_t
 ni_objectmodel_unregister_managed_policy(ni_dbus_server_t *server, ni_managed_policy_t *mpolicy)
 {
+	ni_fsm_policy_t *policy;
 	const char *name;
 
-	if (!server || !mpolicy || !mpolicy->fsm_policy)
+	if (!server || !mpolicy || !(policy = ni_fsm_policy_ref(mpolicy->fsm_policy)))
 		return FALSE;
 
-	name = ni_fsm_policy_name(mpolicy->fsm_policy);
+	name = ni_fsm_policy_name(policy);
 	if (ni_dbus_server_unregister_object(server, mpolicy)) {
 		ni_debug_dbus("policy \"%s\" unregistered", name);
+		ni_fsm_policy_free(policy);
 		return TRUE;
 	} else {
 		ni_debug_dbus("policy \"%s\" not registered", name);
+		ni_fsm_policy_free(policy);
 		return FALSE;
 	}
 }


### PR DESCRIPTION
Fix a use-after-free by getting a local mpolicy->fsm_policy reference in unregister_managed_policy to safely access the fsm policy name for a debug message logged after unregistering the mpolicy object, which is freeing the mpolicy (if it's the last reference).

A policy deletion is performed by wicked ifdown or ifreload and the execution is limited to root (uid 0) callers, so it does not bring additional privilege possibilities.