### PR TITLE
client: add firmware extensions|interfaces command (jsc#PED-3132)

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -59,6 +59,7 @@ wicked_SOURCES			= \
 	convert.c		\
 	duid.c			\
 	ethtool.c		\
+	firmware.c		\
 	iaid.c			\
 	ifup.c			\
 	ifdown.c		\

--- a/client/firmware.c
+++ b/client/firmware.c
@@ -1,0 +1,262 @@
+/*
+ *	wicked firmware -- utils to firmware config discovery
+ *
+ *	Copyright (C) 2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Marius Tomaschewski
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <wicked/util.h>
+#include <wicked/logging.h>
+
+#include "appconfig.h"
+#include "firmware.h"
+#include "process.h"
+#include "buffer.h"
+
+#include <unistd.h>
+#include <getopt.h>
+
+/*
+ * wicked --root-directory <path> option argument in main
+ */
+extern char *		opt_global_rootdir;
+
+static int
+ni_wicked_firmware_extensions(const char *caller, int argc, char **argv)
+{
+	enum {
+		OPTION_HELP	= 'h',
+	};
+	static const struct option	options[] = {
+		{ "help",		no_argument,		NULL,	OPTION_HELP	},
+		{ NULL }
+	};
+	int opt, status = NI_WICKED_RC_USAGE;
+	char *argv0, *command = NULL;
+	const ni_extension_t *ex;
+
+	ni_string_printf(&command, "%s %s", caller, argv[0]);
+	argv0 = argv[0];
+	argv[0] = command;
+	optind = 1;
+	while ((opt = getopt_long(argc, argv, "+h", options, NULL))  != -1) {
+		switch (opt) {
+		case OPTION_HELP:
+			status = NI_WICKED_RC_SUCCESS;
+			/* fall through */
+		default:
+		usage:
+			fprintf(stderr,
+				"\nUsage:\n"
+				"%s [options]\n"
+				"\n"
+				"Options:\n"
+				"  --help, -h		show this help text and exit.\n"
+				"\n", command);
+			goto cleanup;
+		}
+	}
+
+	if (argc > optind)
+		goto usage;
+
+	if (!ni_global.config) {
+		fprintf(stderr, "%s: application config is not initialized\n", command);
+		status = NI_WICKED_RC_ERROR;
+		goto cleanup;
+	}
+
+	status = NI_WICKED_RC_SUCCESS;
+	for (ex = ni_global.config->fw_extensions; ex; ex = ex->next) {
+		const ni_script_action_t *script;
+
+		/* builtins are not supported in netif-firmware-discovery */
+
+		for (script = ex->actions; script; script = script->next) {
+			const char *enabled;
+
+			if (ni_string_empty(script->name) || !script->process)
+				continue;
+
+			if (ni_string_empty(script->process->command))
+				continue;
+
+			/*
+			 * all enabled until we've added an enabled/disabled
+			 * flag to extension script actions in appconfig...
+			 * for now, use missing x-bit to emulate disabled...
+			 */
+			if (ni_file_executable(script->process->command))
+				enabled = "enabled";
+			else
+				enabled = "disabled";
+
+			printf("%-15s %s\n", script->name, enabled);
+		}
+	}
+
+cleanup:
+	argv[0] = argv0;
+	ni_string_free(&command);
+	return status;
+}
+
+static int
+ni_wicked_firmware_interfaces(const char *caller, int argc, char **argv)
+{
+	enum {
+		OPTION_HELP	= 'h',
+	};
+	static const struct option	options[] = {
+		{ "help",		no_argument,		NULL,	OPTION_HELP	},
+		{ NULL }
+	};
+	int opt, status = NI_WICKED_RC_USAGE;
+	char *argv0, *command = NULL;
+	ni_netif_firmware_ifnames_t *list = NULL;
+	ni_netif_firmware_ifnames_t *item = NULL;
+
+	ni_string_printf(&command, "%s %s", caller, argv[0]);
+	argv0 = argv[0];
+	argv[0] = command;
+	optind = 1;
+	while ((opt = getopt_long(argc, argv, "+h", options, NULL))  != -1) {
+		switch (opt) {
+		case OPTION_HELP:
+			status = NI_WICKED_RC_SUCCESS;
+			/* fall through */
+		default:
+		usage:
+			fprintf(stderr,
+				"\nUsage:\n"
+				"%s [options]\n"
+				"\n"
+				"Options:\n"
+				"  --help, -h		show this help text and exit.\n"
+				"\n", command);
+			goto cleanup;
+		}
+	}
+
+	if (argc > optind)
+		goto usage;
+
+	if (!ni_netif_firmware_discover_ifnames(&list, NULL, opt_global_rootdir, NULL)) {
+		status = NI_WICKED_RC_ERROR;
+	} else {
+		for (item = list; item; item = item->next) {
+			ni_stringbuf_t ifnames = NI_STRINGBUF_INIT_DYNAMIC;
+
+			if (ni_string_empty(item->fwname) || !item->ifnames.count)
+				continue;
+
+			ni_stringbuf_join(&ifnames, &item->ifnames, " ");
+			if (ifnames.len)
+				printf("%-15s %s\n", item->fwname, ifnames.string);
+			ni_stringbuf_destroy(&ifnames);
+		}
+		status = NI_WICKED_RC_SUCCESS;
+	}
+
+cleanup:
+	argv[0] = argv0;
+	ni_string_free(&command);
+	ni_netif_firmware_ifnames_list_destroy(&list);
+	return status;
+}
+
+int
+ni_wicked_firmware(const char *caller, int argc, char **argv)
+{
+	enum {
+		OPTION_HELP	= 'h',
+	};
+	enum {
+		ACTION_EXTENSIONS,
+		ACTION_INTERFACES,
+	};
+	static const struct option	options[] = {
+		{ "help",		no_argument,		NULL,	OPTION_HELP	},
+		{ NULL }
+	};
+	static const ni_intmap_t	actions[] = {
+		{ "extensions",		ACTION_EXTENSIONS	},
+		{ "interfaces",		ACTION_INTERFACES	},
+		{ NULL,			-1U			}
+	};
+	int opt, status = NI_WICKED_RC_USAGE;
+	char *argv0, *command = NULL;
+	unsigned int action = -1U;
+
+	ni_string_printf(&command, "%s %s", caller, argv[0]);
+	argv0 = argv[0];
+	argv[0] = command;
+	optind = 1;
+	while ((opt = getopt_long(argc, argv, "+h", options, NULL))  != -1) {
+		switch (opt) {
+		case OPTION_HELP:
+			status = NI_WICKED_RC_SUCCESS;
+			/* fall through */
+		default:
+		usage:
+			fprintf(stderr,
+				"\nUsage:\n"
+				"%s [options] <action>\n"
+				"\n"
+				"Options:\n"
+				"  --help, -h		show this help text and exit.\n"
+				"\n"
+				"Actions:\n"
+				"  extensions		list firmware config extensions and status\n"
+				"  interfaces		list firmware and interface names it configures\n"
+				"\n", command);
+			goto cleanup;
+		}
+	}
+
+	if (optind >= argc || ni_string_empty(argv[optind]) ||
+	    ni_parse_uint_mapped(argv[optind], actions, &action)) {
+		fprintf(stderr, "%s: please specify an action\n", command);
+		goto usage;
+	}
+
+	/* execute actions that do not need decoding */
+	switch (action) {
+		case ACTION_EXTENSIONS:
+			status = ni_wicked_firmware_extensions(command,
+					argc - optind, argv + optind);
+			goto cleanup;
+
+		case ACTION_INTERFACES:
+			status = ni_wicked_firmware_interfaces(command,
+					argc - optind, argv + optind);
+			goto cleanup;
+
+		default:
+			break;
+	}
+
+cleanup:
+	argv[0] = argv0;
+	ni_string_free(&command);
+	return status;
+}

--- a/client/main.c
+++ b/client/main.c
@@ -173,6 +173,7 @@ main(int argc, char **argv)
 				"  convert     [options] [<ifname ...>|all]\n"
 				"  ethtool     [options] <ifname> <...>\n"
 				"  redfish     [options] <action>\n"
+				"  firmware    [options] <action>\n"
 				"  getnames    [options]\n"
 				"  xpath       [options] expr ...\n"
 				"  nanny       <action> ...\n"
@@ -339,6 +340,9 @@ main(int argc, char **argv)
 	} else
 	if (!strcmp(cmd, "redfish")) {
 		 status = ni_wicked_redfish(program, argc - optind, argv + optind);
+	} else
+	if (!strcmp(cmd, "firmware")) {
+		 status = ni_wicked_firmware(program, argc - optind, argv + optind);
 	} else {
 		fprintf(stderr, "Unsupported command %s\n", cmd);
 		goto usage;

--- a/client/main.h
+++ b/client/main.h
@@ -32,5 +32,6 @@ extern int	ni_do_ethtool(const char *caller, int argc, char **argv);
 
 extern int	ni_wicked_convert(const char *caller, int argc, char **argv);
 extern int	ni_wicked_redfish(const char *caller, int argc, char **argv);
+extern int	ni_wicked_firmware(const char *caller, int argc, char **argv);
 
 #endif /* WICKED_CLIENT_MAIN_H */

--- a/client/read-config.c
+++ b/client/read-config.c
@@ -204,6 +204,30 @@ ni_ifconfig_kind_guess(ni_ifconfig_kind_t kind)
 	}
 }
 
+static const ni_intmap_t	ni_ifconfig_kind_map[] = {
+	{ "policy",		NI_IFCONFIG_KIND_POLICY		},
+	{ "config",		NI_IFCONFIG_KIND_CONFIG		},
+	{ NULL,			NI_IFCONFIG_KIND_DEFAULT	}
+};
+
+const char *
+ni_ifconfig_kind_to_name(ni_ifconfig_kind_t kind)
+{
+	return ni_format_uint_mapped(kind, ni_ifconfig_kind_map);
+}
+
+ni_bool_t
+ni_ifconfig_kind_by_name(const char *name, ni_ifconfig_kind_t *kind)
+{
+	unsigned int type;
+
+	if (!kind || ni_parse_uint_mapped(name, ni_ifconfig_kind_map, &type) < 0)
+		return FALSE;
+
+	*kind = type;
+	return TRUE;
+}
+
 const ni_ifconfig_type_t *
 ni_ifconfig_guess_wicked_type(const ni_ifconfig_type_t *map,
 			const char *root, const char *path)

--- a/client/read-config.c
+++ b/client/read-config.c
@@ -47,6 +47,7 @@
 #include "client/ifconfig.h"
 #include "client/read-config.h"
 #include "dracut/dracut.h"
+#include "firmware.h"
 
 #if defined(COMPAT_AUTO) || defined(COMPAT_SUSE)
 extern ni_bool_t	__ni_suse_get_ifconfig(const char *, const char *,
@@ -341,7 +342,7 @@ ni_ifconfig_origin_get_prio(const char *origin)
 /*
  * Parse name node and its namespace from xml config.
  *
- * Return true when inteface name is available/can be resolved.
+ * Return true when interface name is available/can be resolved.
  */
 static ni_bool_t
 ni_ifconfig_read_get_ifname(xml_node_t *ifnode, char **ifname)
@@ -389,7 +390,7 @@ ni_ifconfig_read_get_ifname(xml_node_t *ifnode, char **ifname)
 	}
 	else {
 		/* TODO: Implement other namespaces */;
-		ni_error("unable to resolve interace name from namespace '%s'",
+		ni_error("unable to resolve interface name from namespace '%s'",
 			namespace);
 		return FALSE;
 	}
@@ -655,14 +656,14 @@ ni_ifconfig_read_firmware(xml_document_array_t *array,
 			const char *type, const char *root, const char *path,
 			ni_ifconfig_kind_t kind, ni_bool_t check_prio, ni_bool_t raw)
 {
-	xml_document_t *config_doc;
 	ni_client_state_config_t conf = NI_CLIENT_STATE_CONFIG_INIT;
+	xml_document_array_t docs = XML_DOCUMENT_ARRAY_INIT;
 	xml_node_t *rnode, *cnode, *next;
+	unsigned int i;
 
-	config_doc = ni_netconfig_firmware_discovery(root, path);
-	if (!config_doc) {
+	if (!ni_netif_firmware_discover_ifconfig(&docs, type, root, path)) {
 		ni_error("unable to get firmware interface definitions from %s:%s",
-			type, path);
+				type, path);
 		return FALSE;
 	}
 
@@ -670,35 +671,43 @@ ni_ifconfig_read_firmware(xml_document_array_t *array,
 	 * Firmware is expected to provide a more exact origin
 	 * than we can set here, just read it from the nodes.
 	 */
-	rnode = xml_document_root(config_doc);
-	for (cnode = rnode->children; cnode; cnode = next) {
-		xml_document_t *doc;
-		xml_node_t *node;
+	for (i = 0; i < docs.count; ++i) {
+		xml_document_t *doc = docs.data[i];
 
-		next = cnode->next;
-		doc = xml_document_new();
-		node = xml_document_root(doc);
+		if (xml_document_is_empty(doc))
+			continue;
 
-		if (!ni_ifconfig_metadata_get_from_node(&conf, rnode))
-			ni_ifconfig_format_origin(&conf.origin, type, path);
+		rnode = xml_document_root(doc);
+		for (cnode = rnode->children; cnode; cnode = next) {
+			xml_document_t *config;
+			xml_node_t *node;
 
-		xml_node_reparent(node, cnode);
-		xml_node_location_relocate(node, conf.origin);
+			next = cnode->next;
+			if (!(config = xml_document_new()))
+				continue;
+			node = xml_document_root(config);
 
-		ni_ifconfig_metadata_clear(node);
-		if (!raw)
-			ni_ifconfig_metadata_add_to_node(node, &conf);
+			if (!ni_ifconfig_metadata_get_from_node(&conf, rnode))
+				ni_ifconfig_format_origin(&conf.origin, type, path);
 
-		if (ni_ifconfig_validate_adding_doc(doc, check_prio)) {
-			ni_debug_ifconfig("%s: %s", __func__, xml_node_location(node));
-			xml_document_array_append(array, doc);
-		} else {
-			xml_document_free(doc);
+			xml_node_reparent(node, cnode);
+			xml_node_location_relocate(node, conf.origin);
+
+			ni_ifconfig_metadata_clear(node);
+			if (!raw)
+				ni_ifconfig_metadata_add_to_node(node, &conf);
+
+			if (ni_ifconfig_validate_adding_doc(config, check_prio)) {
+				ni_debug_ifconfig("%s: %s", __func__, xml_node_location(node));
+				xml_document_array_append(array, config);
+			} else {
+				xml_document_free(config);
+			}
 		}
 	}
 
 	ni_client_state_config_reset(&conf);
-	xml_document_free(config_doc);
+	xml_document_array_destroy(&docs);
 
 	return TRUE;
 }

--- a/client/read-config.h
+++ b/client/read-config.h
@@ -63,4 +63,7 @@ extern ni_bool_t			ni_ifconfig_read_subtype(xml_document_array_t *,
 extern ni_bool_t			ni_ifconfig_read(xml_document_array_t *, const char *,
 					const char *, ni_ifconfig_kind_t, ni_bool_t, ni_bool_t);
 
+extern const char *			ni_ifconfig_kind_to_name(ni_ifconfig_kind_t);
+extern ni_bool_t			ni_ifconfig_kind_by_name(const char *, ni_ifconfig_kind_t *);
+
 #endif /* WICKED_CLIENT_READ_CONFIG_H */

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -162,7 +162,6 @@ extern void		ni_netconfig_free(ni_netconfig_t *);
 extern void		ni_netconfig_init(ni_netconfig_t *);
 extern void		ni_netconfig_destroy(ni_netconfig_t *);
 extern ni_netdev_t *	ni_netconfig_devlist(ni_netconfig_t *nic);
-extern xml_document_t *	ni_netconfig_firmware_discovery(const char *, const char *);
 
 extern ni_modem_t *	ni_netconfig_modem_list(ni_netconfig_t *);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -216,6 +216,7 @@ wicked_headers			= \
 	dhcp6/tester.h		\
 	dhcp.h			\
 	duid.h			\
+	firmware.h		\
 	iaid.h			\
 	ibft.h			\
 	ipv6_priv.h		\

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -1,124 +1,264 @@
 /*
- * Discover network interfaces configured by the firmware (eg iBFT)
+ *	Discover network interfaces config provided by firmware (eg iBFT)
  *
- * Copyright (C) 2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
+ *
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
+#include <wicked/util.h>
+#include <wicked/logging.h>
 #include <wicked/xml.h>
-#include "buffer.h"
+
 #include "appconfig.h"
+#include "firmware.h"
 #include "process.h"
-#include "debug.h"
+#include "buffer.h"
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
 
 /*
- * Run all the netif firmware discovery scripts and return their output
- * as one large buffer.
+ * Check if extension script contains name and executable command
  */
-static ni_buffer_t *
-__ni_netconfig_firmware_discovery(const char *root, const char *type, const char *path)
+ni_bool_t
+ni_netif_firmware_extension_script_usable(const ni_script_action_t *script)
 {
-	ni_buffer_t *result;
-	ni_config_t *config = ni_global.config;
-	ni_extension_t *ex;
+	if (!script || ni_string_empty(script->name))
+		return FALSE;
 
-	ni_assert(config);
+	if (!script->process || ni_string_empty(script->process->command))
+		return FALSE;
 
-	result = ni_buffer_new_dynamic(1024);
+	if (!ni_file_executable(script->process->command))
+		return FALSE;
 
-	for (ex = config->fw_extensions; ex; ex = ex->next) {
-		ni_script_action_t *script;
+	return TRUE;
+}
 
-		if (ex->c_bindings)
-			ni_warn("builtins specified in a netif-firmware-discovery element: not supported");
+static int
+ni_netif_firmware_discovery_script_exec(int argc, char *const argv[], char *const envp[])
+{
+	if (argc < 1 || !argv)
+		return EXIT_FAILURE;
 
-		for (script = ex->actions; script; script = script->next) {
-			ni_process_t *process;
-			int rv;
+	if (!freopen("/dev/null", "w", stderr))
+		{}
 
-			/* Check if requested to use specific type/name only (e.g. "ibft") */
-			if (type && !ni_string_eq_nocase(type, script->name))
-				continue;
+	(void)execve(argv[0], argv, envp);
 
-			ni_debug_ifconfig("trying to discover netif config via firmware service \"%s\"", script->name);
+	ni_error("%s: cannot execute %s: %m", __func__, argv[0]);
+	exit(EXIT_FAILURE);
+}
 
-			/* Create an instance of this command */
-			process = ni_process_new(script->process);
+static int
+ni_netif_firmware_discovery_script_call(ni_buffer_t *buf, ni_script_action_t *script,
+		const char *type, const char *root, const char *path, ni_bool_t list)
+{
+	ni_process_t *pi;
+	int status;
 
-			/* Add root directory argument if given */
-			if (root) {
-				ni_string_array_append(&process->argv, "-r");
-				ni_string_array_append(&process->argv, root);
-			}
+	ni_assert(buf && script);
 
-			/* Add firmware type specific path argument if given */
-			if (type && path) {
-				ni_string_array_append(&process->argv, "-p");
-				ni_string_array_append(&process->argv, path);
-			}
+	ni_debug_ifconfig("trying to discover %s netif config from extension", type);
 
-			rv = ni_process_run_and_capture_output(process, result);
-			ni_process_free(process);
-			if (rv) {
-				ni_error("unable to discover firmware (script \"%s\")",
-						script->name);
-				ni_buffer_free(result);
-				return NULL;
-			}
-		}
+	/* Create an instance for this script command process */
+	if (!(pi = ni_process_new(script->process))) {
+		ni_error("%s discovery process allocation failure: %m", type);
+		return NI_PROCESS_FAILURE;
 	}
 
-	return result;
+	/* Add root directory argument if given */
+	if (!ni_string_empty(root)) {
+		ni_string_array_append(&pi->argv, "-r");
+		ni_string_array_append(&pi->argv, root);
+	}
+
+	/* Add firmware type specific path argument if given */
+	if (!ni_string_empty(path)) {
+		ni_string_array_append(&pi->argv, "-p");
+		ni_string_array_append(&pi->argv, path);
+	}
+
+	/* Enable list-interfaces only mode */
+	if (list) {
+		ni_string_array_append(&pi->argv, "-l");
+	}
+
+	pi->exec = ni_netif_firmware_discovery_script_exec;
+	status = ni_process_run_and_capture_output(pi, buf);
+	ni_process_free(pi);
+
+	if (status > NI_PROCESS_SUCCESS) {
+		/* (post-fork) exit codes returned by extension sub-process */
+		ni_info("%s discovery script failure: exit status %d", type, status);
+		return status;
+	}
+	if (status < NI_PROCESS_SUCCESS) {
+		/* we log / report an error for most of the exec errors ... */
+		ni_warn("%s discovery script execution failure: %d", type, status);
+		return status;
+	}
+
+	ni_debug_extension("%s discovery script output has %zu bytes",
+			type, ni_buffer_count(buf));
+
+	return status;
+}
+
+static int
+ni_netif_firmware_discovery_script_ifconfig(xml_document_t **doc,
+		ni_script_action_t *script, const char *type,
+		const char *root, const char *path)
+{
+	char buffer[BUFSIZ];
+	ni_buffer_t buf;
+	int status;
+
+	ni_assert(doc && !*doc && script);
+
+	/* Use an initial static (8k) buffer, that should be sufficient.
+	 * When it gets full, it will be automatically reallocated... */
+	memset(buffer, 0, sizeof(buffer));
+	ni_buffer_init(&buf, &buffer, sizeof(buffer));
+
+	status = ni_netif_firmware_discovery_script_call(&buf, script,
+					type, root, path, FALSE);
+
+	if (status == NI_PROCESS_SUCCESS && ni_buffer_count(&buf)) {
+
+		if (!(*doc = xml_document_from_buffer(&buf, type))) {
+			ni_warn("%s discovery script failure: can't parse xml output", type);
+			/* hmm... NI_ERROR_DOCUMENT_ERROR? */
+			status = NI_WICKED_RC_ERROR;
+		} else if (xml_document_is_empty(*doc)) {
+			/* bunch of spaces?! */
+			ni_debug_ifconfig("%s discovery script xml output: empty", type);
+			xml_document_free(*doc);
+			*doc = NULL;
+		} else if (ni_log_level_at(NI_LOG_DEBUG2)) {
+			ni_debug_ifconfig("%s discovery script xml output:", type);
+			xml_node_print_debug(xml_document_root(*doc), NI_TRACE_IFCONFIG);
+		}
+	}
+	ni_buffer_destroy(&buf);
+	return status;
+}
+
+static ni_bool_t
+ni_netif_firmware_name_from_path(char **name, const char **path)
+{
+	if (!name || !path)
+		return FALSE;
+
+	/*
+	 * get firmware:X specific type name and path:
+	 * path: (empty)      => name: NULL, path: (empty)
+	 * path: ibft         => name: ibft, path: (empty)
+	 * path: ibft:        => name: ibft, path: (empty)
+	 * path: ibft:foo-bar => name: ibft, path: foo
+	 */
+	if (!ni_string_empty(*path)) {
+		char *ptr;
+
+		if (!ni_string_dup(name, *path))
+			return FALSE;
+
+		if ((ptr = strchr(*name, ':')))
+			*ptr++ = '\0';
+		*path = ptr;
+	}
+	if (ni_string_empty(*path))
+		*path = NULL;
+
+	return TRUE;
 }
 
 /*
- * Run the netif firmware discovery scripts and return their output
- * as an XML document.
+ * Run the netif firmware discovery scripts and return their xml output
+ * as an XML document array.
  * The optional from parameter allow to specify the firmware extension
  * type (e.g. ibft) and a firmware type specific path (e.g. ethernet0),
  * passed as last argument to the discovery script.
  */
-xml_document_t *
-ni_netconfig_firmware_discovery(const char *root, const char *from)
+ni_bool_t
+ni_netif_firmware_discover_ifconfig(xml_document_array_t *docs,
+		const char *type, const char *root, const char *path)
 {
-	ni_buffer_t *buffer;
-	xml_document_t *doc;
-	char *path = NULL;
-	char *type = NULL;
+	unsigned int success = 0;
+	unsigned int failure = 0;
+	ni_extension_t *ex;
+	char *name = NULL;
+
+	if (!docs || !ni_global.config)
+		return FALSE;
 
 	/* sanity adjustments... */
 	if (ni_string_empty(root))
 		root = NULL;
+	if (ni_string_empty(type))
+		type = "firmware";
 
-	if (ni_string_empty(from))
-		from = NULL;
-	else {
-		ni_string_dup(&type, from);
+	if (!ni_netif_firmware_name_from_path(&name, &path))
+		return FALSE;
 
-		if ((path = strchr(type, ':')))
-			*path++ = '\0';
+	for (ex = ni_global.config->fw_extensions; ex; ex = ex->next) {
+		ni_script_action_t *script;
 
-		if (ni_string_empty(path))
-			path = NULL;
+		/* builtins are not supported in netif-firmware-discovery */
+
+		for (script = ex->actions; script; script = script->next) {
+			xml_document_t *doc = NULL;
+			char *full = NULL;
+
+			/* Check if script is usable/non-empty and executable */
+			if (!ni_netif_firmware_extension_script_usable(script))
+				continue;
+
+			/* Check if to use specific type/name only (e.g. "ibft") */
+			if (name && !ni_string_eq_nocase(name, script->name))
+				continue;
+
+			/* Construct full firmware type name, e.g. firmware:ibft */
+			if (!ni_string_printf(&full, "%s:%s", type, script->name))
+				continue;
+
+			if (ni_netif_firmware_discovery_script_ifconfig(&doc,
+						script, full, root, path) == 0) {
+				xml_document_array_append(docs, doc);
+				success++;
+			} else {
+				failure++;
+			}
+
+			ni_string_free(&full);
+		}
 	}
+	ni_string_free(&name);
 
-	buffer = __ni_netconfig_firmware_discovery(root, type, path);
-	if (buffer == NULL) {
-		ni_string_free(&type);
-		return NULL;
-	}
-
-	ni_debug_ifconfig("%s: %s%sbuffer has %zu bytes", __func__,
-			(from ? from : ""), (from ? " ": ""),
-			ni_buffer_count(buffer));
-	doc = xml_document_from_buffer(buffer, from);
-	ni_buffer_free(buffer);
-	ni_string_free(&type);
-
-	if (doc == NULL)
-		ni_error("%s: error processing document", __func__);
-
-	return doc;
+	if (failure && !success)
+		return FALSE;
+	else
+		return TRUE;
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -262,3 +262,194 @@ ni_netif_firmware_discover_ifconfig(xml_document_array_t *docs,
 	else
 		return TRUE;
 }
+
+/*
+ * Run the netif firmware discovery scripts and return interface names
+ * the firmware configures.
+ */
+void
+ni_netif_firmware_ifnames_free(ni_netif_firmware_ifnames_t *nfi)
+{
+	if (nfi) {
+		ni_string_free(&nfi->fwname);
+		ni_string_array_destroy(&nfi->ifnames);
+		free(nfi);
+	}
+}
+
+ni_netif_firmware_ifnames_t *
+ni_netif_firmware_ifnames_new(const char *fwname)
+{
+	ni_netif_firmware_ifnames_t *nfi;
+
+	if (!(nfi = calloc(1, sizeof(*nfi))))
+		return NULL;
+
+	if (ni_string_dup(&nfi->fwname, fwname))
+		return nfi;
+
+	ni_netif_firmware_ifnames_free(nfi);
+	return NULL;
+}
+
+ni_bool_t
+ni_netif_firmware_ifnames_list_append(ni_netif_firmware_ifnames_t **list, ni_netif_firmware_ifnames_t *item)
+{
+	if (list && item) {
+		while (*list)
+			list = &(*list)->next;
+		*list = item;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+void
+ni_netif_firmware_ifnames_list_destroy(ni_netif_firmware_ifnames_t **list)
+{
+	ni_netif_firmware_ifnames_t *item;
+
+	if (list) {
+		while ((item = *list)) {
+			*list = item->next;
+			ni_netif_firmware_ifnames_free(item);
+		}
+	}
+}
+
+static ni_bool_t
+ni_netif_firmware_ifnames_parse(ni_netif_firmware_ifnames_t **list,
+		const char *fwname, ni_buffer_t *buf)
+{
+	ni_stringbuf_t line = NI_STRINGBUF_INIT_DYNAMIC;
+	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
+	ni_netif_firmware_ifnames_t *item = NULL;
+	ni_bool_t ret = TRUE;
+	ni_buffer_t rbuf;
+	int c;
+
+	if (!list || !buf || !fwname)
+		return FALSE;
+
+	if (!ni_buffer_init_reader(&rbuf, ni_buffer_head(buf), ni_buffer_count(buf)))
+		return FALSE;
+
+	while (ret && ni_buffer_count(&rbuf)) {
+		while ((c = ni_buffer_getc(&rbuf)) != EOF) {
+			if (c == '\n')
+				break;
+			ni_stringbuf_putc(&line, c);
+		}
+
+		if (!ni_string_split(&ifnames, line.string, "\t ", 0)) {
+			ni_stringbuf_truncate(&line, 0);
+			continue;
+		}
+		ni_stringbuf_truncate(&line, 0);
+
+		if ((item = ni_netif_firmware_ifnames_new(fwname))) {
+			ni_string_array_move(&item->ifnames, &ifnames);
+			ret = ni_netif_firmware_ifnames_list_append(list, item);
+		} else {
+			ret = FALSE;
+		}
+	}
+
+	ni_buffer_destroy(&rbuf);
+	ni_stringbuf_destroy(&line);
+	ni_string_array_destroy(&ifnames);
+	return ret;
+}
+
+int
+ni_netif_firmware_discover_script_ifnames(ni_netif_firmware_ifnames_t **list,
+		ni_script_action_t *script, const char *type,
+		const char *root, const char *path)
+{
+	char buffer[BUFSIZ];
+	ni_buffer_t buf;
+	int status;
+
+	ni_assert(list && script);
+
+	/* Use an initial static (8k) buffer, that should be sufficient.
+	 * When it gets full, it will be automatically reallocated... */
+	memset(buffer, 0, sizeof(buffer));
+	ni_buffer_init(&buf, &buffer, sizeof(buffer));
+
+	status = ni_netif_firmware_discovery_script_call(&buf, script,
+					type, root, path, TRUE);
+
+	if (status == NI_PROCESS_SUCCESS && ni_buffer_count(&buf)) {
+
+		if (!ni_netif_firmware_ifnames_parse(list, script->name, &buf)) {
+			ni_debug_ifconfig("%s discovery script failure: invalid list output", type);
+			ni_netif_firmware_ifnames_list_destroy(list);
+			/* hmm... NI_ERROR_DOCUMENT_ERROR? */
+			status = NI_WICKED_RC_ERROR;
+		}
+	}
+	ni_buffer_destroy(&buf);
+	return status;
+}
+
+ni_bool_t
+ni_netif_firmware_discover_ifnames(ni_netif_firmware_ifnames_t **list,
+		const char *type, const char *root, const char *path)
+{
+	unsigned int success = 0;
+	unsigned int failure = 0;
+	ni_extension_t *ex;
+	char *name = NULL;
+
+	if (!list || !ni_global.config)
+		return FALSE;
+
+	/* sanity adjustments... */
+	if (ni_string_empty(root))
+		root = NULL;
+	if (ni_string_empty(type))
+		type = "firmware";
+
+	if (!ni_netif_firmware_name_from_path(&name, &path))
+		return FALSE;
+
+	for (ex = ni_global.config->fw_extensions; ex; ex = ex->next) {
+		ni_script_action_t *script;
+
+		/* builtins are not supported in netif-firmware-discovery */
+
+		for (script = ex->actions; script; script = script->next) {
+			ni_netif_firmware_ifnames_t *curr = NULL;
+			char *full = NULL;
+
+			/* Check if script is usable/non-empty and executable */
+			if (!ni_netif_firmware_extension_script_usable(script))
+				continue;
+
+			/* Check if to use specific type/name only (e.g. "ibft") */
+			if (name && !ni_string_eq_nocase(name, script->name))
+				continue;
+
+			/* Construct full firmware type name, e.g. firmware:ibft */
+			if (!ni_string_printf(&full, "%s:%s", type, script->name))
+				continue;
+
+			if (ni_netif_firmware_discover_script_ifnames(&curr,
+					script, full, root, path) == 0) {
+				ni_netif_firmware_ifnames_list_append(list, curr);
+				success++;
+			} else {
+				failure++;
+			}
+
+			ni_string_free(&full);
+		}
+	}
+	ni_string_free(&name);
+
+	if (failure && !success)
+		return FALSE;
+	else
+		return TRUE;
+}

--- a/src/firmware.h
+++ b/src/firmware.h
@@ -25,6 +25,23 @@
 #ifndef   WICKED_FIRMWARE_UTILS_H
 #define   WICKED_FIRMWARE_UTILS_H
 
+typedef struct ni_netif_firmware_ifnames	ni_netif_firmware_ifnames_t;
+
+struct ni_netif_firmware_ifnames {
+	ni_netif_firmware_ifnames_t *	next;
+	char *				fwname;
+	ni_string_array_t 		ifnames;
+};
+
+extern void				ni_netif_firmware_ifnames_free(ni_netif_firmware_ifnames_t *);
+extern ni_netif_firmware_ifnames_t *	ni_netif_firmware_ifnames_new(const char *);
+extern ni_bool_t			ni_netif_firmware_ifnames_list_append(ni_netif_firmware_ifnames_t **,
+									ni_netif_firmware_ifnames_t *);
+extern void				ni_netif_firmware_ifnames_list_destroy(ni_netif_firmware_ifnames_t **);
+
+extern ni_bool_t			ni_netif_firmware_discover_ifnames(ni_netif_firmware_ifnames_t **,
+							const char *, const char *, const char *);
+
 extern ni_bool_t			ni_netif_firmware_discover_ifconfig(xml_document_array_t *,
 							const char *, const char *, const char *);
 

--- a/src/firmware.h
+++ b/src/firmware.h
@@ -1,0 +1,31 @@
+/*
+ *	Discover network interfaces config provided by firmware (eg iBFT)
+ *
+ *	Copyright (C) 2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
+ *
+ */
+#ifndef   WICKED_FIRMWARE_UTILS_H
+#define   WICKED_FIRMWARE_UTILS_H
+
+extern ni_bool_t			ni_netif_firmware_discover_ifconfig(xml_document_array_t *,
+							const char *, const char *, const char *);
+
+#endif /* WICKED_FIRMWARE_UTILS_H */


### PR DESCRIPTION
- `wicked firmware extensions` shows available firmware extensions table:
  ```
  ibft          enabled
  redfish       enabled
  ```
- `wicked firmware interfaces` shows interfaces configured by a firmware:
  ```
  ibft          eth1 eth1.10
  redfish       usb0
  ```

See also https://github.com/openSUSE/installation-images/pull/620