### PR TITLE
refcount: split declaration and definition macros

### DIFF
--- a/include/wicked/addrconf.h
+++ b/include/wicked/addrconf.h
@@ -232,13 +232,13 @@ enum ni_lease_event {
 	NI_EVENT_LEASE_LOST
 };
 
-extern				ni_refcounted_declare_new(ni_addrconf_lease,
+extern				ni_declare_refcounted_new(ni_addrconf_lease,
 							int type, int family);
-extern				ni_refcounted_declare_ref(ni_addrconf_lease);
-extern				ni_refcounted_declare_free(ni_addrconf_lease);
-extern				ni_refcounted_declare_hold(ni_addrconf_lease);
-extern				ni_refcounted_declare_drop(ni_addrconf_lease);
-extern				ni_refcounted_declare_move(ni_addrconf_lease);
+extern				ni_declare_refcounted_ref(ni_addrconf_lease);
+extern				ni_declare_refcounted_free(ni_addrconf_lease);
+extern				ni_declare_refcounted_hold(ni_addrconf_lease);
+extern				ni_declare_refcounted_drop(ni_addrconf_lease);
+extern				ni_declare_refcounted_move(ni_addrconf_lease);
 
 extern ni_addrconf_lease_t *	ni_addrconf_lease_clone(const ni_addrconf_lease_t *);
 extern void			ni_addrconf_lease_destroy(ni_addrconf_lease_t *);

--- a/include/wicked/address.h
+++ b/include/wicked/address.h
@@ -123,12 +123,12 @@ extern ni_bool_t	ni_af_sockaddr_info(int, unsigned int *, unsigned int *);
 extern unsigned int	ni_af_address_length(int af);
 extern unsigned int	ni_af_address_prefixlen(int af);
 
-extern			ni_refcounted_declare_new(ni_address);
-extern			ni_refcounted_declare_ref(ni_address);
-extern			ni_refcounted_declare_hold(ni_address);
-extern			ni_refcounted_declare_free(ni_address);
-extern			ni_refcounted_declare_drop(ni_address);
-extern			ni_refcounted_declare_move(ni_address);
+extern			ni_declare_refcounted_new(ni_address);
+extern			ni_declare_refcounted_ref(ni_address);
+extern			ni_declare_refcounted_hold(ni_address);
+extern			ni_declare_refcounted_free(ni_address);
+extern			ni_declare_refcounted_drop(ni_address);
+extern			ni_declare_refcounted_move(ni_address);
 
 extern ni_address_t *	ni_address_create(int af, unsigned int prefix_len,
 					const ni_sockaddr_t *local_addr,

--- a/include/wicked/refcount.h
+++ b/include/wicked/refcount.h
@@ -1,7 +1,7 @@
 /*
- *	refcount -- reference couting utils
+ *	refcount -- reference counting utils and declaration macros
  *
- *	Copyright (C) 2022 SUSE LLC
+ *	Copyright (C) 2022-2023 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -20,10 +20,11 @@
  *		Marius Tomaschewski
  *		Clemens Famulla-Conrad
  */
-#ifndef WICKED_REFCOUNT_H
-#define WICKED_REFCOUNT_H
+#ifndef NI_WICKED_REFCOUNT_DECL_H
+#define NI_WICKED_REFCOUNT_DECL_H
 
 #include <wicked/types.h>
+
 
 typedef unsigned int	ni_refcount_t;
 
@@ -50,103 +51,4 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 #define			ni_declare_refcounted_move(prefix)		\
 	ni_bool_t		prefix##_move(prefix##_t **, prefix##_t **)
 
-
-#define			ni_define_refcounted_new_xargs(prefix,		\
-					func_args, init_args)		\
-	prefix##_t *							\
-	prefix##_new func_args						\
-	{								\
-		prefix##_t *obj = malloc(sizeof(*obj));			\
-		if (obj) {						\
-			if (!prefix##_init init_args) {			\
-				free(obj);				\
-				return NULL;				\
-			}						\
-			if (!ni_refcount_init(&obj->refcount)) {	\
-				prefix##_destroy(obj);			\
-				free(obj);				\
-				return NULL;				\
-			}						\
-		}							\
-		return obj;						\
-	}
-#define			ni_define_refcounted_new0(prefix)		\
-			ni_define_refcounted_new_xargs(prefix,		\
-					(void), (obj))
-#define			ni_define_refcounted_new1(prefix, _1)		\
-			ni_define_refcounted_new_xargs(prefix,		\
-					(_1 a), (obj, a))
-#define			ni_define_refcounted_new2(prefix, _1, _2)	\
-			ni_define_refcounted_new_xargs(prefix,		\
-					(_1 a, _2 b), (obj, a, b))
-#define			ni_define_refcounted_new3(prefix, _1, _2, _3)	\
-			ni_define_refcounted_new_xargs(prefix,		\
-					(_1 a, _2 b, _3 c),		\
-					(obj, a, b, c))
-#define			ni_define_refcounted_new_macro(_1, _2, _3, _4,	\
-					NAME, ...) NAME
-
-#define			ni_define_refcounted_new(args...)		\
-			ni_define_refcounted_new_macro(args,		\
-				ni_define_refcounted_new3,		\
-				ni_define_refcounted_new2,		\
-				ni_define_refcounted_new1,		\
-				ni_define_refcounted_new0)(args)
-
-#define			ni_define_refcounted_ref(prefix)		\
-	prefix##_t *							\
-	prefix##_ref(prefix##_t *ref)					\
-	{								\
-		if (ref && ni_refcount_increment(&ref->refcount))	\
-			return ref;					\
-		return NULL;						\
-	}
-
-#define			ni_define_refcounted_free(prefix)		\
-	void								\
-	prefix##_free(prefix##_t *ref)					\
-	{								\
-		if (ref && ni_refcount_decrement(&ref->refcount)) {	\
-			prefix##_destroy(ref);				\
-			free(ref);					\
-		}							\
-	}
-
-#define			ni_define_refcounted_hold(prefix)		\
-	ni_bool_t							\
-	prefix##_hold(prefix##_t **tie, prefix##_t *ref)		\
-	{								\
-		prefix##_t *old;					\
-		if (tie && ref) {					\
-			old = *tie;					\
-			*tie = prefix##_ref(ref);			\
-			prefix##_free(old);				\
-			return TRUE;					\
-		}							\
-		return FALSE;						\
-	}
-
-#define			ni_define_refcounted_drop(prefix)		\
-	ni_bool_t							\
-	prefix##_drop(prefix##_t **tie)					\
-	{								\
-		prefix##_t *old;					\
-		if (tie) {						\
-			old = *tie;					\
-			*tie = NULL;					\
-			prefix##_free(old);				\
-			return TRUE;					\
-		}							\
-		return FALSE;						\
-	}
-
-#define			ni_define_refcounted_move(prefix)		\
-	ni_bool_t							\
-	prefix##_move(prefix##_t **dst, prefix##_t **src)		\
-	{								\
-		if (src && prefix##_hold(dst, *src))			\
-			return prefix##_drop(src);			\
-		return FALSE;						\
-	}
-
-#endif /* WICKED_REFCOUNT_H */
+#endif /* NI_WICKED_REFCOUNT_DECL_H */

--- a/include/wicked/refcount.h
+++ b/include/wicked/refcount.h
@@ -32,26 +32,26 @@ extern ni_bool_t	ni_refcount_increment(ni_refcount_t *refcount);
 extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 
 
-#define 		ni_refcounted_declare_new(prefix,args...)	\
+#define			ni_declare_refcounted_new(prefix, args...)	\
 	prefix##_t *		prefix##_new(args)
 
-#define			ni_refcounted_declare_ref(prefix)		\
+#define			ni_declare_refcounted_ref(prefix)		\
 	prefix##_t *		prefix##_ref(prefix##_t *)
 
-#define			ni_refcounted_declare_free(prefix)		\
+#define			ni_declare_refcounted_free(prefix)		\
 	void			prefix##_free(prefix##_t *)
 
-#define			ni_refcounted_declare_hold(prefix)		\
+#define			ni_declare_refcounted_hold(prefix)		\
 	ni_bool_t		prefix##_hold(prefix##_t **, prefix##_t *)
 
-#define			ni_refcounted_declare_drop(prefix)		\
+#define			ni_declare_refcounted_drop(prefix)		\
 	ni_bool_t		prefix##_drop(prefix##_t **)
 
-#define			ni_refcounted_declare_move(prefix)		\
+#define			ni_declare_refcounted_move(prefix)		\
 	ni_bool_t		prefix##_move(prefix##_t **, prefix##_t **)
 
 
-#define			ni_refcounted_define_new_xargs(prefix,		\
+#define			ni_define_refcounted_new_xargs(prefix,		\
 					func_args, init_args)		\
 	prefix##_t *							\
 	prefix##_new func_args						\
@@ -70,28 +70,30 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 		}							\
 		return obj;						\
 	}
-#define			ni_refcounted_define_new0(prefix)		\
-			ni_refcounted_define_new_xargs(prefix,		\
+#define			ni_define_refcounted_new0(prefix)		\
+			ni_define_refcounted_new_xargs(prefix,		\
 					(void), (obj))
-#define			ni_refcounted_define_new1(prefix, _1)		\
-			ni_refcounted_define_new_xargs(prefix,		\
+#define			ni_define_refcounted_new1(prefix, _1)		\
+			ni_define_refcounted_new_xargs(prefix,		\
 					(_1 a), (obj, a))
-#define			ni_refcounted_define_new2(prefix, _1, _2)	\
-			ni_refcounted_define_new_xargs(prefix,		\
+#define			ni_define_refcounted_new2(prefix, _1, _2)	\
+			ni_define_refcounted_new_xargs(prefix,		\
 					(_1 a, _2 b), (obj, a, b))
-#define			ni_refcounted_define_new3(prefix, _1, _2, _3)	\
-			ni_refcounted_define_new_xargs(prefix,		\
-					(_1 a, _2 b, _3 c), (obj, a, b, c))
-#define			ni_refcounted_macro(_1, _2, _3, _4, NAME, ...) NAME
+#define			ni_define_refcounted_new3(prefix, _1, _2, _3)	\
+			ni_define_refcounted_new_xargs(prefix,		\
+					(_1 a, _2 b, _3 c),		\
+					(obj, a, b, c))
+#define			ni_define_refcounted_new_macro(_1, _2, _3, _4,	\
+					NAME, ...) NAME
 
-#define			ni_refcounted_define_new(args...)		\
-			ni_refcounted_macro(args,			\
-				ni_refcounted_define_new3,		\
-				ni_refcounted_define_new2,		\
-				ni_refcounted_define_new1,		\
-				ni_refcounted_define_new0)(args)
+#define			ni_define_refcounted_new(args...)		\
+			ni_define_refcounted_new_macro(args,		\
+				ni_define_refcounted_new3,		\
+				ni_define_refcounted_new2,		\
+				ni_define_refcounted_new1,		\
+				ni_define_refcounted_new0)(args)
 
-#define			ni_refcounted_define_ref(prefix)		\
+#define			ni_define_refcounted_ref(prefix)		\
 	prefix##_t *							\
 	prefix##_ref(prefix##_t *ref)					\
 	{								\
@@ -100,7 +102,7 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 		return NULL;						\
 	}
 
-#define 		ni_refcounted_define_free(prefix)		\
+#define			ni_define_refcounted_free(prefix)		\
 	void								\
 	prefix##_free(prefix##_t *ref)					\
 	{								\
@@ -110,7 +112,7 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 		}							\
 	}
 
-#define 		ni_refcounted_define_hold(prefix)		\
+#define			ni_define_refcounted_hold(prefix)		\
 	ni_bool_t							\
 	prefix##_hold(prefix##_t **tie, prefix##_t *ref)		\
 	{								\
@@ -124,7 +126,7 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 		return FALSE;						\
 	}
 
-#define 		ni_refcounted_define_drop(prefix)		\
+#define			ni_define_refcounted_drop(prefix)		\
 	ni_bool_t							\
 	prefix##_drop(prefix##_t **tie)					\
 	{								\
@@ -138,7 +140,7 @@ extern ni_bool_t	ni_refcount_decrement(ni_refcount_t *refcount);
 		return FALSE;						\
 	}
 
-#define 		ni_refcounted_define_move(prefix)		\
+#define			ni_define_refcounted_move(prefix)		\
 	ni_bool_t							\
 	prefix##_move(prefix##_t **dst, prefix##_t **src)		\
 	{								\

--- a/include/wicked/route.h
+++ b/include/wicked/route.h
@@ -161,12 +161,12 @@ typedef struct ni_rule_array  {
 
 typedef int			ni_route_cmp_fn(const ni_route_t *, const ni_route_t *);
 
-extern 				ni_refcounted_declare_new(ni_route);
-extern 				ni_refcounted_declare_ref(ni_route);
-extern				ni_refcounted_declare_hold(ni_route);
-extern 				ni_refcounted_declare_free(ni_route);
-extern				ni_refcounted_declare_drop(ni_route);
-extern				ni_refcounted_declare_move(ni_route);
+extern				ni_declare_refcounted_new(ni_route);
+extern				ni_declare_refcounted_ref(ni_route);
+extern				ni_declare_refcounted_hold(ni_route);
+extern				ni_declare_refcounted_free(ni_route);
+extern				ni_declare_refcounted_drop(ni_route);
+extern				ni_declare_refcounted_move(ni_route);
 
 extern ni_route_t *		ni_route_create(unsigned int prefix_len,
 						const ni_sockaddr_t *dest,
@@ -284,12 +284,12 @@ extern ni_bool_t		ni_route_tables_empty(const ni_route_table_t *);
 extern ni_route_table_t *	ni_route_tables_get(ni_route_table_t **, unsigned int);
 extern void			ni_route_tables_destroy(ni_route_table_t **);
 
-extern 				ni_refcounted_declare_new(ni_rule);
-extern 				ni_refcounted_declare_ref(ni_rule);
-extern 				ni_refcounted_declare_hold(ni_rule);
-extern 				ni_refcounted_declare_free(ni_rule);
-extern 				ni_refcounted_declare_drop(ni_rule);
-extern 				ni_refcounted_declare_move(ni_rule);
+extern				ni_declare_refcounted_new(ni_rule);
+extern				ni_declare_refcounted_ref(ni_rule);
+extern				ni_declare_refcounted_hold(ni_rule);
+extern				ni_declare_refcounted_free(ni_rule);
+extern				ni_declare_refcounted_drop(ni_rule);
+extern				ni_declare_refcounted_move(ni_rule);
 
 extern ni_bool_t		ni_rule_copy(ni_rule_t *, const ni_rule_t *);
 extern ni_rule_t *		ni_rule_clone(const ni_rule_t *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -454,7 +454,7 @@ extern int				ni_rfkill_open(ni_rfkill_event_handler_t *, void *user_data);
 extern ni_bool_t			ni_rfkill_disabled(ni_rfkill_type_t);
 extern const char *			ni_rfkill_type_string(ni_rfkill_type_t type);
 
-extern					ni_refcounted_declare_new(ni_wireless_network);
-extern					ni_refcounted_declare_drop(ni_wireless_network);
+extern					ni_declare_refcounted_new(ni_wireless_network);
+extern					ni_declare_refcounted_drop(ni_wireless_network);
 
 #endif /* NI_WICKED_WIRELESS_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,7 @@ wicked_headers			= \
 	ovs.h			\
 	pppd.h			\
 	process.h		\
+	refcount_priv.h		\
 	socket_priv.h		\
 	sysfs.h			\
 	systemctl.h		\

--- a/src/addrconf.c
+++ b/src/addrconf.c
@@ -60,12 +60,12 @@ ni_addrconf_lease_init(ni_addrconf_lease_t *lease, int type, int family)
 	return FALSE;
 }
 
-extern ni_refcounted_define_new(ni_addrconf_lease, int, int);
-extern ni_refcounted_define_ref(ni_addrconf_lease);
-extern ni_refcounted_define_hold(ni_addrconf_lease);
-extern ni_refcounted_define_free(ni_addrconf_lease);
-extern ni_refcounted_define_drop(ni_addrconf_lease);
-extern ni_refcounted_define_move(ni_addrconf_lease);
+extern ni_define_refcounted_new(ni_addrconf_lease, int, int);
+extern ni_define_refcounted_ref(ni_addrconf_lease);
+extern ni_define_refcounted_hold(ni_addrconf_lease);
+extern ni_define_refcounted_free(ni_addrconf_lease);
+extern ni_define_refcounted_drop(ni_addrconf_lease);
+extern ni_define_refcounted_move(ni_addrconf_lease);
 
 static inline void
 ni_addrconf_lease_clone_dhcp4(struct ni_addrconf_lease_dhcp4 *clone, const struct ni_addrconf_lease_dhcp4 *orig)

--- a/src/addrconf.c
+++ b/src/addrconf.c
@@ -2,7 +2,7 @@
  *	Address configuration aka lease for wicked
  *
  *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
- *	Copyright (C) 2012-2022 SUSE LLC
+ *	Copyright (C) 2012-2023 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -25,10 +25,6 @@
 #include "config.h"
 #endif
 
-#include <stdlib.h>
-#include <sys/time.h>
-#include <time.h>
-
 #include <wicked/util.h>
 #include <wicked/address.h>
 #include <wicked/addrconf.h>
@@ -39,9 +35,14 @@
 
 #include "appconfig.h"
 #include "addrconf.h"
+#include "refcount_priv.h"
 #include "netinfo_priv.h"
 #include "dhcp6/options.h"
 #include "dhcp.h"
+
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
 
 
 extern void		ni_addrconf_updater_free(ni_addrconf_updater_t **);

--- a/src/address.c
+++ b/src/address.c
@@ -74,12 +74,12 @@ ni_address_destroy(ni_address_t *ap)
 	ni_string_free(&ap->label);
 }
 
-extern ni_refcounted_define_new(ni_address);
-extern ni_refcounted_define_ref(ni_address);
-extern ni_refcounted_define_hold(ni_address);
-extern ni_refcounted_define_free(ni_address);
-extern ni_refcounted_define_drop(ni_address);
-extern ni_refcounted_define_move(ni_address);
+extern ni_define_refcounted_new(ni_address);
+extern ni_define_refcounted_ref(ni_address);
+extern ni_define_refcounted_hold(ni_address);
+extern ni_define_refcounted_free(ni_address);
+extern ni_define_refcounted_drop(ni_address);
+extern ni_define_refcounted_move(ni_address);
 
 ni_address_t *
 ni_address_create(int af, unsigned int prefix_len, const ni_sockaddr_t *local_addr, ni_address_t **list_head)

--- a/src/address.c
+++ b/src/address.c
@@ -2,7 +2,7 @@
  *	Network and link layer addresses handling.
  *
  *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
- *	Copyright (C) 2012-2022 SUSE LLC
+ *	Copyright (C) 2012-2023 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -25,6 +25,14 @@
 #include "config.h"
 #endif
 
+#include <wicked/logging.h>
+#include <wicked/netinfo.h>
+#include <wicked/time.h>
+#include <wicked/route.h>
+
+#include "refcount_priv.h"
+#include "util_priv.h"
+
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -38,11 +46,6 @@
 #include <linux/if_infiniband.h>
 #include <netlink/netlink.h>
 
-#include <wicked/logging.h>
-#include <wicked/netinfo.h>
-#include <wicked/time.h>
-#include <wicked/route.h>
-#include "util_priv.h"
 
 #define	NI_ADDRESS_ARRAY_CHUNK		16
 

--- a/src/refcount.c
+++ b/src/refcount.c
@@ -1,5 +1,5 @@
 /*
- *	refcount -- reference couting utils
+ *	refcount -- reference counting utils
  *
  *	Copyright (C) 2022 SUSE LLC
  *

--- a/src/refcount_priv.h
+++ b/src/refcount_priv.h
@@ -1,0 +1,127 @@
+/*
+ *	refcount -- reference counting implementation macros
+ *
+ *	Copyright (C) 2022-2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Marius Tomaschewski
+ *		Clemens Famulla-Conrad
+ */
+#ifndef NI_WICKED_REFCOUNT_PRIV_H
+#define NI_WICKED_REFCOUNT_PRIV_H
+
+#include <wicked/refcount.h>
+
+
+#define			ni_define_refcounted_new_xargs(prefix,		\
+					func_args, init_args)		\
+	prefix##_t *							\
+	prefix##_new func_args						\
+	{								\
+		prefix##_t *obj = malloc(sizeof(*obj));			\
+		if (obj) {						\
+			if (!prefix##_init init_args) {			\
+				free(obj);				\
+				return NULL;				\
+			}						\
+			if (!ni_refcount_init(&obj->refcount)) {	\
+				prefix##_destroy(obj);			\
+				free(obj);				\
+				return NULL;				\
+			}						\
+		}							\
+		return obj;						\
+	}
+#define			ni_define_refcounted_new0(prefix)		\
+			ni_define_refcounted_new_xargs(prefix,		\
+					(void), (obj))
+#define			ni_define_refcounted_new1(prefix, _1)		\
+			ni_define_refcounted_new_xargs(prefix,		\
+					(_1 a), (obj, a))
+#define			ni_define_refcounted_new2(prefix, _1, _2)	\
+			ni_define_refcounted_new_xargs(prefix,		\
+					(_1 a, _2 b), (obj, a, b))
+#define			ni_define_refcounted_new3(prefix, _1, _2, _3)	\
+			ni_define_refcounted_new_xargs(prefix,		\
+					(_1 a, _2 b, _3 c),		\
+					(obj, a, b, c))
+#define			ni_define_refcounted_new_macro(_1, _2, _3, _4,	\
+					NAME, ...) NAME
+
+#define			ni_define_refcounted_new(args...)		\
+			ni_define_refcounted_new_macro(args,		\
+				ni_define_refcounted_new3,		\
+				ni_define_refcounted_new2,		\
+				ni_define_refcounted_new1,		\
+				ni_define_refcounted_new0)(args)
+
+#define			ni_define_refcounted_ref(prefix)		\
+	prefix##_t *							\
+	prefix##_ref(prefix##_t *ref)					\
+	{								\
+		if (ref && ni_refcount_increment(&ref->refcount))	\
+			return ref;					\
+		return NULL;						\
+	}
+
+#define			ni_define_refcounted_free(prefix)		\
+	void								\
+	prefix##_free(prefix##_t *ref)					\
+	{								\
+		if (ref && ni_refcount_decrement(&ref->refcount)) {	\
+			prefix##_destroy(ref);				\
+			free(ref);					\
+		}							\
+	}
+
+#define			ni_define_refcounted_hold(prefix)		\
+	ni_bool_t							\
+	prefix##_hold(prefix##_t **tie, prefix##_t *ref)		\
+	{								\
+		prefix##_t *old;					\
+		if (tie && ref) {					\
+			old = *tie;					\
+			*tie = prefix##_ref(ref);			\
+			prefix##_free(old);				\
+			return TRUE;					\
+		}							\
+		return FALSE;						\
+	}
+
+#define			ni_define_refcounted_drop(prefix)		\
+	ni_bool_t							\
+	prefix##_drop(prefix##_t **tie)					\
+	{								\
+		prefix##_t *old;					\
+		if (tie) {						\
+			old = *tie;					\
+			*tie = NULL;					\
+			prefix##_free(old);				\
+			return TRUE;					\
+		}							\
+		return FALSE;						\
+	}
+
+#define			ni_define_refcounted_move(prefix)		\
+	ni_bool_t							\
+	prefix##_move(prefix##_t **dst, prefix##_t **src)		\
+	{								\
+		if (src && prefix##_hold(dst, *src))			\
+			return prefix##_drop(src);			\
+		return FALSE;						\
+	}
+
+#endif /* NI_WICKED_REFCOUNT_PRIV_H */

--- a/src/route.c
+++ b/src/route.c
@@ -2,7 +2,7 @@
  *	Handling of ip routing.
  *
  *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
- *	Copyright (C) 2012-2022 SUSE LLC
+ *	Copyright (C) 2012-2023 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -19,11 +19,20 @@
  *
  *	Authors:
  *		Olaf Kirch
+ *		Karol Mroz
  *		Marius Tomaschewski
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <wicked/logging.h>
+#include <wicked/netinfo.h>
+#include <wicked/route.h>
+
+#include "refcount_priv.h"
+#include "util_priv.h"
+#include "debug.h"
 
 #include <stdlib.h>
 #include <limits.h>
@@ -32,11 +41,6 @@
 #include <linux/ipv6_route.h>
 #endif
 
-#include <wicked/logging.h>
-#include <wicked/netinfo.h>
-#include <wicked/route.h>
-#include "util_priv.h"
-#include "debug.h"
 
 #define NI_ROUTE_ARRAY_CHUNK		16
 #define NI_RULE_ARRAY_CHUNK		4

--- a/src/route.c
+++ b/src/route.c
@@ -172,12 +172,12 @@ ni_route_destroy(ni_route_t *rp)
 	memset(rp, 0, sizeof(*rp));
 }
 
-extern ni_refcounted_define_new(ni_route);
-extern ni_refcounted_define_ref(ni_route);
-extern ni_refcounted_define_hold(ni_route);
-extern ni_refcounted_define_free(ni_route);
-extern ni_refcounted_define_drop(ni_route);
-extern ni_refcounted_define_move(ni_route);
+extern ni_define_refcounted_new(ni_route);
+extern ni_define_refcounted_ref(ni_route);
+extern ni_define_refcounted_hold(ni_route);
+extern ni_define_refcounted_free(ni_route);
+extern ni_define_refcounted_drop(ni_route);
+extern ni_define_refcounted_move(ni_route);
 
 ni_route_t *
 ni_route_create(unsigned int prefixlen, const ni_sockaddr_t *dest,
@@ -1883,12 +1883,12 @@ ni_rule_destroy(ni_rule_t *rule)
 	memset(rule, 0, sizeof(*rule));
 }
 
-extern ni_refcounted_define_new(ni_rule);
-extern ni_refcounted_define_ref(ni_rule);
-extern ni_refcounted_define_hold(ni_rule);
-extern ni_refcounted_define_free(ni_rule);
-extern ni_refcounted_define_drop(ni_rule);
-extern ni_refcounted_define_move(ni_rule);
+extern ni_define_refcounted_new(ni_rule);
+extern ni_define_refcounted_ref(ni_rule);
+extern ni_define_refcounted_hold(ni_rule);
+extern ni_define_refcounted_free(ni_rule);
+extern ni_define_refcounted_drop(ni_rule);
+extern ni_define_refcounted_move(ni_rule);
 
 ni_bool_t
 ni_rule_copy(ni_rule_t *dst, const ni_rule_t *src)

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1,25 +1,48 @@
 /*
- * Routines for handling Wireless devices.
+ *	Routines for handling Wireless devices.
  *
- * Holie cowe, the desygne of thefe Wyreless Extensions is indisputablie baroque!
+ *	Holie cowe, the desygne of thefe Wyreless Extensions is indisputablie baroque!
  *
- * Copyright (C) 2010-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2010-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2012-2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
+ *		Pawel Wieczorkiewicz
+ *		Rubén Torrero Marijnissen
+ *		Clemens Famulla-Conrad
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <wicked/wireless.h>
+#include <wicked/socket.h>
+#include <wicked/netinfo.h>
+#include "refcount_priv.h"
+#include "socket_priv.h"
+#include "netinfo_priv.h"
+#include "wpa-supplicant.h"
 
 #include <limits.h>
 #include <time.h>
 #include <ctype.h>
 #include <net/if_arp.h>		/* For ARPHRD_ETHER */
 
-#include <wicked/wireless.h>
-#include <wicked/socket.h>
-#include <wicked/netinfo.h>
-#include "socket_priv.h"
-#include "netinfo_priv.h"
-#include "wpa-supplicant.h"
 
 #ifndef NI_WIRELESS_WPA_DRIVER_DEFAULT
 #define NI_WIRELESS_WPA_DRIVER_DEFAULT		"nl80211,wext"

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1986,10 +1986,10 @@ ni_wireless_network_destroy(ni_wireless_network_t *net)
 	memset(net, 0, sizeof(*net));
 }
 
-static ni_refcounted_define_ref(ni_wireless_network);
-static ni_refcounted_define_free(ni_wireless_network);
-extern ni_refcounted_define_new(ni_wireless_network);
-extern ni_refcounted_define_drop(ni_wireless_network);
+static ni_define_refcounted_ref(ni_wireless_network);
+static ni_define_refcounted_free(ni_wireless_network);
+extern ni_define_refcounted_new(ni_wireless_network);
+extern ni_define_refcounted_drop(ni_wireless_network);
 
 void
 ni_wireless_wep_key_array_destroy(char **array)

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -67,9 +67,9 @@ static int					ni_wpa_client_refresh(ni_wpa_client_t *);
 static ni_wpa_nif_t *				ni_wpa_nif_by_path(ni_wpa_client_t *wpa, const char *object_path);
 
 
-static						ni_refcounted_declare_new(ni_wpa_nif, const char *, unsigned int);
-static						ni_refcounted_declare_free(ni_wpa_nif);
-static						ni_refcounted_declare_ref(ni_wpa_nif);
+static						ni_declare_refcounted_new(ni_wpa_nif, const char *, unsigned int);
+static						ni_declare_refcounted_free(ni_wpa_nif);
+static						ni_declare_refcounted_ref(ni_wpa_nif);
 static ni_bool_t				ni_wpa_nif_init(ni_wpa_nif_t *, const char *, unsigned int);
 static void					ni_wpa_nif_destroy(ni_wpa_nif_t *);
 static int					ni_wpa_nif_refresh(ni_wpa_nif_t *);
@@ -83,9 +83,9 @@ static void					ni_wpa_dbus_signal(ni_dbus_connection_t *, ni_dbus_message_t *, 
 static void					ni_wpa_nif_signal(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
 static void					ni_wpa_signal(ni_dbus_connection_t *, ni_dbus_message_t *, void *);
 
-static						ni_refcounted_declare_new(ni_wpa_bss, ni_wpa_nif_t *, const char *);
-static						ni_refcounted_declare_free(ni_wpa_bss);
-static						ni_refcounted_declare_ref(ni_wpa_bss);
+static						ni_declare_refcounted_new(ni_wpa_bss, ni_wpa_nif_t *, const char *);
+static						ni_declare_refcounted_free(ni_wpa_bss);
+static						ni_declare_refcounted_ref(ni_wpa_bss);
 static ni_bool_t				ni_wpa_bss_init(ni_wpa_bss_t *bss, ni_wpa_nif_t *wif,
 								const char *object_path);
 static void					ni_wpa_bss_destroy(ni_wpa_bss_t *bss);
@@ -733,11 +733,11 @@ ni_wpa_nif_by_path(ni_wpa_client_t *wpa, const char *object_path)
 	return NULL;
 }
 
-static ni_refcounted_define_new(ni_wpa_nif, const char *, unsigned int);
-static ni_refcounted_define_ref(ni_wpa_nif);
-static ni_refcounted_define_hold(ni_wpa_nif);
-static ni_refcounted_define_free(ni_wpa_nif);
-extern ni_refcounted_define_drop(ni_wpa_nif);
+static ni_define_refcounted_new(ni_wpa_nif, const char *, unsigned int);
+static ni_define_refcounted_ref(ni_wpa_nif);
+static ni_define_refcounted_hold(ni_wpa_nif);
+static ni_define_refcounted_free(ni_wpa_nif);
+extern ni_define_refcounted_drop(ni_wpa_nif);
 
 static ni_bool_t
 ni_wpa_nif_init(ni_wpa_nif_t *wif, const char *ifname, unsigned int ifindex)
@@ -1810,10 +1810,10 @@ ni_wpa_bss_properties_init(ni_wpa_bss_properties_t *props)
 	ni_byte_array_init(&props->ies);
 }
 
-static ni_refcounted_define_free(ni_wpa_bss);
-static ni_refcounted_define_new(ni_wpa_bss, ni_wpa_nif_t *, const char *);
-static ni_refcounted_define_ref(ni_wpa_bss);
-extern ni_refcounted_define_drop(ni_wpa_bss);
+static ni_define_refcounted_free(ni_wpa_bss);
+static ni_define_refcounted_new(ni_wpa_bss, ni_wpa_nif_t *, const char *);
+static ni_define_refcounted_ref(ni_wpa_bss);
+extern ni_define_refcounted_drop(ni_wpa_bss);
 
 static void
 ni_wpa_bss_destroy(ni_wpa_bss_t *bss)

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1,20 +1,42 @@
 /*
- * Interfacing with wpa_supplicant through dbus interface
- * https://w1.fi/wpa_supplicant/devel/dbus.html
+ *	Interfacing with wpa_supplicant through dbus interface
+ *	https://w1.fi/wpa_supplicant/devel/dbus.html
  *
- * Copyright (C) 2011-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2011-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2012-2023 SUSE LLC
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors:
+ *		Olaf Kirch
+ *		Marius Tomaschewski
+ *		Pawel Wieczorkiewicz
+ *		Clemens Famulla-Conrad
  *
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
-#include <sys/time.h>
 #include <wicked/dbus-service.h>
 #include <wicked/dbus-errors.h>
 #include <wicked/netinfo.h>
 
+#include "refcount_priv.h"
 #include "wpa-supplicant.h"
+
+#include <sys/time.h>
 
 
 #define NI_WPA_BUS_NAME				"fi.w1.wpa_supplicant1"

--- a/src/wpa-supplicant.h
+++ b/src/wpa-supplicant.h
@@ -397,7 +397,7 @@ extern int					ni_wpa_get_interface(ni_wpa_client_t *, const char *, unsigned in
 extern int					ni_wpa_add_interface(ni_wpa_client_t *, unsigned int,
 								ni_dbus_variant_t *, ni_wpa_nif_t **);
 extern int					ni_wpa_del_interface(ni_wpa_client_t *, const char *);
-extern						ni_refcounted_declare_drop(ni_wpa_nif);
+extern						ni_declare_refcounted_drop(ni_wpa_nif);
 
 extern int					ni_wpa_nif_set_properties(ni_wpa_nif_t *, const ni_dbus_variant_t *);
 
@@ -418,7 +418,7 @@ extern int					ni_wpa_nif_trigger_scan(ni_wpa_nif_t *, ni_bool_t);
 extern ni_bool_t				ni_wpa_nif_retrieve_scan(ni_wpa_nif_t *, ni_wireless_scan_t *);
 extern int					ni_wpa_nif_flush_bss(ni_wpa_nif_t *wif, uint32_t max_age);
 extern ni_wpa_bss_t *				ni_wpa_nif_get_current_bss(ni_wpa_nif_t *);
-extern						ni_refcounted_declare_drop(ni_wpa_bss);
+extern						ni_declare_refcounted_drop(ni_wpa_bss);
 
 extern const char *				ni_wpa_nif_property_name(ni_wpa_nif_property_type_t);
 extern ni_bool_t				ni_wpa_nif_property_type(const char *, ni_wpa_nif_property_type_t *);


### PR DESCRIPTION
Changed to use ni_declare|ni_define as prefix
and split declaration and definition macros.