### PR TITLE
autogen.sh: improve usability and enable silent rules

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,15 @@ esac
 
 export CFLAGS="${CFLAGS:- -std=gnu89 -O1 -g -D_FORTIFY_SOURCE=2 -fstack-protector -Wall -Wextra -Wno-unused-parameter}"
 prefix=/usr
-defaults=(--enable-silent-rules --sysconfdir=/etc --prefix=${prefix} --libdir=${prefix}/${_lib} --libexecdir=${prefix}/lib --datadir=${prefix}/share --localstatedir=/var)
+defaults=(
+	--enable-silent-rules
+	--sysconfdir=/etc
+	--prefix="${prefix}"
+	--libdir="${prefix}/${_lib}"
+	--libexecdir="${prefix}/lib"
+	--datadir="${prefix}/share"
+	--localstatedir=/var
+)
 
-"${srcdir}/configure" "${@:-${defaults[@]}}"
+"${srcdir}/configure" "${defaults[@]}" "${@}"
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,7 @@ esac
 
 export CFLAGS="${CFLAGS:- -std=gnu89 -O1 -g -D_FORTIFY_SOURCE=2 -fstack-protector -Wall -Wextra -Wno-unused-parameter}"
 prefix=/usr
-defaults=(--sysconfdir=/etc --prefix=${prefix} --libdir=${prefix}/${_lib} --libexecdir=${prefix}/lib --datadir=${prefix}/share --localstatedir=/var)
+defaults=(--enable-silent-rules --sysconfdir=/etc --prefix=${prefix} --libdir=${prefix}/${_lib} --libexecdir=${prefix}/lib --datadir=${prefix}/share --localstatedir=/var)
 
 "${srcdir}/configure" "${@:-${defaults[@]}}"
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,8 @@ pushd "${srcdir}" >/dev/null
 autoreconf --force --install     || exit 1
 popd >/dev/null
 
-_lib=`rpm -E '%_lib' 2>/dev/null`
+statedir=$(rpm -E '%{!_rundir:/var}' 2>/dev/null)
+_lib=$(rpm -E '%_lib' 2>/dev/null)
 test -n "$_lib" || case "$(uname -m)" in
 	x86_64|s390x|ppc64|powerpc64) _lib=lib64 ;;
 	*) _lib=lib ;;
@@ -23,7 +24,7 @@ defaults=(
 	--libdir="${prefix}/${_lib}"
 	--libexecdir="${prefix}/lib"
 	--datadir="${prefix}/share"
-	--localstatedir=/var
+	--localstatedir="${statedir}"
 )
 
 "${srcdir}/configure" "${defaults[@]}" "${@}"

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,6 +3,18 @@
 script=$0
 srcdir=$(dirname ${script})
 
+debug='-g -O1 -D_FORTIFY_SOURCE=2'
+werror=''
+args=()
+while test $# -gt 0 ; do
+	case $1 in
+	-debug0) debug='-g -O0'   ;;
+	-Werror) werror='-Werror' ;;
+	*)       args+=("$1")     ;;
+	esac
+	shift
+done
+
 test -f "${srcdir}/configure.ac" || exit 1
 pushd "${srcdir}" >/dev/null
 autoreconf --force --install     || exit 1
@@ -15,7 +27,8 @@ test -n "$_lib" || case "$(uname -m)" in
 	*) _lib=lib ;;
 esac
 
-export CFLAGS="${CFLAGS:- -std=gnu89 -O1 -g -D_FORTIFY_SOURCE=2 -fstack-protector -Wall -Wextra -Wno-unused-parameter}"
+export CFLAGS="${CFLAGS:--std=gnu89 ${debug} -fstack-protector -Wall -Wextra -Wno-unused-parameter ${werror}}"
+
 prefix=/usr
 defaults=(
 	--enable-silent-rules
@@ -27,5 +40,5 @@ defaults=(
 	--localstatedir="${statedir}"
 )
 
-"${srcdir}/configure" "${defaults[@]}" "${@}"
+"${srcdir}/configure" "${defaults[@]}" "${args[@]}"
 


### PR DESCRIPTION
- Add `-Werror` option to fail on compiler warnings and `-debug0` for non-optimized
  build (`-g -O0` plus) for an intended gdb use.
- Enable silent-rules to improve warnings/issues visibility in favor of full libtool output
  and pass all other options to configure additionally and not instead of our defaults,
  now considering also _rundir rpm config.