### PR TITLE
wicked-nbft: conditionally disable on SLE < 15-SP5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,13 @@ if test "x$enable_lldp" = "xyes" ; then
 	AC_DEFINE([NI_ENABLE_LLDP], [], [Enable lldp support])
 fi
 
+# Whether to enable nbft support (>= SLE-15-SP5)
+AC_ARG_ENABLE([nbft],
+	[AS_HELP_STRING([--disable-nbft],
+		[disable to not install nbft firmware extension])],,
+	[enable_nbft=yes])
+AM_CONDITIONAL([nbft], [test "x$enable_nbft" = "xyes"])
+
 # Whether to request NIS option in dhcp6 by default
 AC_ARG_ENABLE([dhcp6-nis],
 	      [AS_HELP_STRING([--disable-dhcp6-nis],

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -13,12 +13,19 @@ BUILT_SOURCES			= \
 	$(systemv_init_SCRIPTS)	\
 	$(wicked_scripts_SCRIPTS)
 
+noinst_DATA			=
+
 wicked_config_DATA		= \
 	common.xml		\
 	client.xml		\
-	client-nbft.xml		\
 	server.xml		\
 	nanny.xml
+
+if nbft
+wicked_config_DATA		+= client-nbft.xml
+else
+noinst_DATA			+= client-nbft.xml
+endif
 
 wicked_scripts_SCRIPTS		= \
 	scripts/redfish-update
@@ -72,6 +79,7 @@ endif
 endif
 
 templates			= \
+	$(noinst_DATA:=.in)		\
 	$(wicked_config_DATA:=.in)	\
 	$(systemd_dbus_files:=.in)	\
 	$(systemd_unit_files:=.in)	\

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -1,17 +1,22 @@
 
 CLEANFILES			= *~
 MAINTAINERCLEANFILES		= Makefile.in
+EXTRA_DIST			= $(wicked_extensions_SCRIPTS)
 
 wicked_extensions_SCRIPTS	= \
 	dispatch	\
 	firewall	\
 	hostname	\
 	ibft		\
-	nbft		\
 	netconfig	\
 	redfish-config
 
-EXTRA_DIST			= $(wicked_extensions_SCRIPTS)
+if nbft
+wicked_extensions_SCRIPTS	+= nbft
+else
+EXTRA_DIST			+= nbft
+endif
+
 
 check-local:
 	@for i in $(wicked_extensions_SCRIPTS) ; \

--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -48,6 +48,11 @@ Provides:       libwicked@LIBWICKED_PACKAGE_SUFFIX@ = %{version}-%{release}
 Provides:       libwicked-0-6 = %{version}
 Obsoletes:      libwicked-0-6 < %{version}
 
+%if 0%{?suse_version} > 1500 || 0%{?sle_version} >= 150500
+%bcond_without  nbft
+%else
+%bcond_with     nbft
+%endif
 %if 0%{?suse_version} >= 1500
 %bcond_without  rfc4361_cid
 %else
@@ -123,6 +128,8 @@ Wicked is a network configuration infrastructure incorporating a number
 of existing frameworks into a unified architecture, providing a DBUS
 interface to network configuration.
 
+%if %{with nbft}
+
 %package nbft
 Summary:        Network configuration infrastructure - nbft support
 Group:          System/Management
@@ -134,6 +141,8 @@ Requires:       jq >= 1.6
 This package provides an extension to retrieve the NBFT firmware
 network interface configuration according to the NVM Express Boot
 Specification 1.0 and convert it to wicked configuration.
+
+%endif
 
 %if %{with systemd}
 
@@ -210,6 +219,9 @@ export CFLAGS="-std=gnu89 $RPM_OPT_FLAGS -fPIC" LDFLAGS="-pie"
 %endif
 %if %{without use_teamd}
 	--disable-teamd			\
+%endif
+%if %{without nbft}
+	--disable-nbft			\
 %endif
 %if %{with systemd}
 	--enable-systemd		\
@@ -336,11 +348,15 @@ if [ ${FIRST_ARG:-$1} -eq 0 ]; then
 	/usr/bin/systemctl reload dbus.service 2>/dev/null || :
 fi
 
+%if %{with nbft}
+
 %postun nbft
 # revert nbft override in client-firmware.xml config
 if [ ${FIRST_ARG:-$1} -eq 0 ]; then
 	%_sbindir/wicked firmware revert nbft 2>/dev/null || :
 fi
+
+%endif
 
 %files
 %defattr (-,root,root)
@@ -419,9 +435,13 @@ fi
 %_fillupdir/sysconfig.dhcp-wicked
 %attr(0750,root,root) %dir        %wicked_storedir
 
+%if %{with nbft}
+
 %files nbft
 %config(noreplace) %_sysconfdir/wicked/client-nbft.xml
 %config(noreplace) %_sysconfdir/wicked/extensions/nbft
+
+%endif
 
 %if %{with systemd}
 


### PR DESCRIPTION
Add rpmbuild --with[out] nbft conditional along with the configure --disable-nbft option
to not build the wicked-nbft firmware extension rpm sub-package on SLE/LEAP < 15.5.