### PR TITLE
extensions/nbft: add post-up script (bsc#1211647)

### DIFF
--- a/extensions/nbft
+++ b/extensions/nbft
@@ -239,6 +239,11 @@ nbft_parse_hfi() {
 		EOF
 	fi
 	cat <<-EOF
+	  <scripts>
+	    <post-up>
+	      <script>systemd:nvmf-connect-nbft.service</script>
+	    </post-up>
+	  </scripts>
 	</interface>
 	EOF
 }

--- a/testing/nbft/dhcp-routed/nbft.out
+++ b/testing/nbft/dhcp-routed/nbft.out
@@ -8,4 +8,9 @@
     <enabled>true</enabled>
     <!-- no host name -->
   </ipv4:dhcp>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/dhcp-simple/nbft.out
+++ b/testing/nbft/dhcp-simple/nbft.out
@@ -8,4 +8,9 @@
     <enabled>true</enabled>
     <!-- no host name -->
   </ipv4:dhcp>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/dhcp-vlan/nbft.out
+++ b/testing/nbft/dhcp-vlan/nbft.out
@@ -20,4 +20,9 @@
     <enabled>true</enabled>
     <hostname>nvmepoc-wicked</hostname>
   </ipv4:dhcp>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/static-bad-gateway/nbft.out
+++ b/testing/nbft/static-bad-gateway/nbft.out
@@ -11,4 +11,9 @@
     <hostname>nvmepoc-wicked</hostname>
     <enabled>true</enabled>
   </ipv4:static>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/static-no-prefix/nbft.out
+++ b/testing/nbft/static-no-prefix/nbft.out
@@ -11,4 +11,9 @@
     <hostname>nvmepoc-wicked</hostname>
     <enabled>true</enabled>
   </ipv4:static>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/static-routed-vlan/nbft.out
+++ b/testing/nbft/static-routed-vlan/nbft.out
@@ -23,4 +23,9 @@
     <hostname>nvmepoc-wicked</hostname>
     <enabled>true</enabled>
   </ipv4:static>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/static-routed/nbft.out
+++ b/testing/nbft/static-routed/nbft.out
@@ -11,4 +11,9 @@
     <hostname>nvmepoc-wicked</hostname>
     <enabled>true</enabled>
   </ipv4:static>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>

--- a/testing/nbft/static-vlan/nbft.out
+++ b/testing/nbft/static-vlan/nbft.out
@@ -23,4 +23,9 @@
     <hostname>nvmepoc-wicked</hostname>
     <enabled>true</enabled>
   </ipv4:static>
+  <scripts>
+    <post-up>
+      <script>systemd:nvmf-connect-nbft.service</script>
+    </post-up>
+  </scripts>
 </interface>


### PR DESCRIPTION
In multipath scenarios, not all NBFT interfaces and respective connections may have been brought up during initramfs processing. If wicked brings up some NBFT interfaces after switching to the root file system, run a post-up script to initiate the NVMe connections.