### PR TITLE
testing: run nbft-test.sh only if jq is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,8 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 AC_PROG_LIBTOOL
+AC_PATH_PROG(JQ, jq)
+AM_CONDITIONAL([nbft_test], [test "x$enable_nbft" = "xyes" -a "x$JQ" != "x"])
 
 # Checks for libraries.
 AC_CHECK_LIB([dl], [dlopen], [LIBDL_LIBS="-ldl"],[

--- a/testing/Makefile.am
+++ b/testing/Makefile.am
@@ -52,8 +52,11 @@ EXTRA_DIST			= ibft xpath		\
 TESTS				= socket-mock-test	\
 				  bitmask-test		\
 				  bitmap-test		\
-				  nbft-test.sh		\
 				  json-test		\
 				  ptr_array-test
+
+if nbft_test
+TESTS				+= nbft-test.sh
+endif
 
 # vim: ai


### PR DESCRIPTION
Execute nbft-test.sh in make check only when nbft
is enabled and also the jq utility is available.