### PR TITLE
array: add macro to define qsort cmp function

### DIFF
--- a/src/array_priv.h
+++ b/src/array_priv.h
@@ -173,22 +173,23 @@
 		return -1U;								\
 	}
 
+#define			ni_define_ptr_array_qsort_cmp_fn(prefix)			\
+	int										\
+	prefix##_array_qsort_cmp_fn(const void *pa, const void *pb, void *arg)		\
+	{										\
+		const prefix##_t **a = (const prefix##_t **)pa;				\
+		const prefix##_t **b = (const prefix##_t **)pb;				\
+											\
+		prefix##_array_cmp_fn cmpfn = (prefix##_array_cmp_fn)arg;		\
+		return cmpfn(*a, *b);							\
+	}
+
 #define			ni_define_ptr_array_qsort(prefix)				\
 	void										\
 	prefix##_array_qsort(prefix##_array_t *arr, prefix##_array_cmp_fn cmpfn)	\
 	{										\
-		int prefix##_array_cmpfn_wrapper(const void *pa, const void *pb,	\
-				void *arg)						\
-		{									\
-			const prefix##_t **a = (const prefix##_t **)pa;			\
-			const prefix##_t **b = (const prefix##_t **)pb;			\
-											\
-			prefix##_array_cmp_fn cmpfn = (prefix##_array_cmp_fn)arg;	\
-			return cmpfn(*a, *b);						\
-		}									\
-											\
 		qsort_r(arr->data, arr->count, sizeof(arr->data[0]),			\
-				prefix##_array_cmpfn_wrapper, cmpfn);			\
+				prefix##_array_qsort_cmp_fn, cmpfn);			\
 	}
 
 #endif /* NI_WICKED_ARRAY_PRIV_H */

--- a/src/route.c
+++ b/src/route.c
@@ -1467,7 +1467,7 @@ ni_route_array_free(ni_route_array_t *nra)
 }
 extern				ni_define_ptr_array_init(ni_route);
 extern				ni_define_ptr_array_destroy(ni_route);
-extern				ni_define_ptr_array_realloc(ni_route, NI_ROUTE_ARRAY_CHUNK);
+static				ni_define_ptr_array_realloc(ni_route, NI_ROUTE_ARRAY_CHUNK);
 extern				ni_define_ptr_array_append(ni_route);
 extern				ni_define_ptr_array_delete_at(ni_route);
 extern				ni_define_ptr_array_remove_at(ni_route);

--- a/src/route.c
+++ b/src/route.c
@@ -1472,6 +1472,7 @@ extern				ni_define_ptr_array_append(ni_route);
 extern				ni_define_ptr_array_delete_at(ni_route);
 extern				ni_define_ptr_array_remove_at(ni_route);
 extern				ni_define_ptr_array_at(ni_route);
+static				ni_define_ptr_array_qsort_cmp_fn(ni_route);
 extern				ni_define_ptr_array_qsort(ni_route);
 
 ni_route_t *

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -2041,7 +2041,7 @@ ni_wireless_wep_key_array_destroy(char **array)
  * Wireless network arrays
  */
 extern ni_define_ptr_array_init(ni_wireless_network);
-extern ni_define_ptr_array_realloc(ni_wireless_network, 1);
+static ni_define_ptr_array_realloc(ni_wireless_network, 1);
 extern ni_define_ptr_array_append(ni_wireless_network);
 extern ni_define_ptr_array_destroy(ni_wireless_network);
 

--- a/testing/ptr_array-test.c
+++ b/testing/ptr_array-test.c
@@ -66,6 +66,7 @@ static ni_define_ptr_array_remove_at(ni_data);
 static ni_define_ptr_array_delete_at(ni_data);
 static ni_define_ptr_array_at(ni_data);
 static ni_define_ptr_array_index(ni_data);
+static ni_define_ptr_array_qsort_cmp_fn(ni_data);
 static ni_define_ptr_array_qsort(ni_data);
 
 


### PR DESCRIPTION
Add macro to define qsort element compare wrapper in favour
of a nested wrapper inside the array qsort function to avoid
executable stack requirements.