### PR TITLE
 arp: Improve error handling and default settings 

### DIFF
--- a/autoip4/autoip.h
+++ b/autoip4/autoip.h
@@ -39,8 +39,7 @@ struct ni_autoip_device {
 
 	struct {
 	    struct in_addr	candidate;
-	    unsigned int	nprobes;
-	    unsigned int	nclaims;
+	    ni_arp_verify_t	verify;
 	    unsigned int	nconflicts;
 	    struct timeval	last_defense;
 	} autoip;

--- a/client/arputil.c
+++ b/client/arputil.c
@@ -48,10 +48,20 @@ struct arp_ops;
 
 #define NI_ARPUTIL_MAX_SEND_ERR  3
 
+#define ARP_VERIFY_COUNT	3
+#define	ARP_VERIFY_INTERVAL_MIN	1000
+#define	ARP_VERIFY_INTERVAL_MAX	2000
+#define ARP_NOTIFY_COUNT	2
+#define ARP_NOTIFY_INTERVAL_MIN	2000
+#define ARP_NOTIFY_INTERVAL_MAX	2000
+#define ARP_PING_COUNT		-1U
+#define ARP_PING_INTERVAL_MIN	1000
+#define ARP_PING_INTERVAL_MAX	1000
+
 struct arp_handle {
 	ni_bool_t		verbose;
 	unsigned int		count;
-	unsigned int		interval;
+	ni_uint_range_t		interval;
 	unsigned int		deadline;
 	unsigned int		replies;
 
@@ -82,6 +92,31 @@ struct arp_ops {
 
 static void		do_arp_handle_close(struct arp_handle *);
 
+static ni_bool_t
+do_parse_interval(ni_uint_range_t *range, const char *arg)
+{
+	const char *needle = "..";
+	ni_bool_t ret = FALSE;
+	char *smin = NULL;
+	char *smax = NULL;
+
+	if (!range || ni_string_empty(arg) || !ni_string_dup(&smin, arg))
+		return ret;
+
+	range->min = range->max = 0;
+	if ((smax = strstr(smin, needle))) {
+		*smax = '\0';
+		smax += ni_string_len(needle);
+		ret = !ni_parse_uint(smin, &range->min, 10) &&
+			!ni_parse_uint(smax, &range->max, 10) &&
+			range->min >= 100 && range->max >= range->min;
+	} else {
+		ret = !ni_parse_uint(smin, &range->min, 10) &&
+			(range->max = range->min) >= 100;
+	}
+	ni_string_free(&smin);
+	return ret;
+}
 
 static int
 do_arp_init(struct arp_handle *handle, ni_capture_devinfo_t *dev_info)
@@ -261,11 +296,14 @@ do_arp_arm_deadline_timer(struct arp_handle *handle)
 static void
 do_arp_arm_interval_timer(struct arp_handle *handle)
 {
+	ni_timeout_t rt;
+
+	rt = ni_timeout_random_range(handle->interval.min, handle->interval.max);
 	if (handle->timer.interval) {
-		ni_timer_rearm(handle->timer.interval, handle->interval);
+		ni_timer_rearm(handle->timer.interval, rt);
 	} else {
 		handle->timer.interval = ni_timer_register(
-			handle->interval, do_arp_interval_timeout, handle
+			rt, do_arp_interval_timeout, handle
 		);
 	}
 }
@@ -325,11 +363,13 @@ do_arp_verify_run(struct arp_handle *handle, const char *caller, int argc, char 
 				"\n"
 				"  --count <count>\n"
 				"      Send <count> duplicate address detection probes\n"
-				"      (default: 3). Returns 4 when address is in use.\n"
-				"  --interval <msec>\n"
+				"      (default: %u). Returns 4 when address is in use.\n"
+				"  --interval <msec[..msec]>\n"
 				"      DAD probing packet sending interval in msec\n"
-				"      (default: 1000..2000).\n"
+				"      (default: %u..%u).\n"
 				, argv[0]
+				, ARP_VERIFY_COUNT
+				, ARP_VERIFY_INTERVAL_MIN, ARP_VERIFY_INTERVAL_MAX
 			);
 			goto cleanup;
 
@@ -351,8 +391,7 @@ do_arp_verify_run(struct arp_handle *handle, const char *caller, int argc, char 
 			break;
 
 		case OPT_INTERVAL:
-			if (ni_parse_uint(optarg, &handle->interval, 10) ||
-					!handle->interval) {
+			if (!do_parse_interval(&handle->interval, optarg)) {
 				ni_error("%s: Cannot parse verify interval '%s'",
 						argv[0], optarg);
 				goto cleanup;
@@ -386,19 +425,19 @@ cleanup:
 static int
 do_arp_verify_init(struct arp_handle *handle, ni_netdev_t *dev, ni_netconfig_t *nc)
 {
-	/* a uniform random jitter of (PROBE_MAX - PROBE_MIN) */
-	const ni_int_range_t jitter = { .min = 0, .max = 1000 };
+	static const ni_uint_range_t range = {
+		.min = ARP_VERIFY_INTERVAL_MIN,
+		.max = ARP_VERIFY_INTERVAL_MAX,
+	};
 
 	(void)nc;
 	(void)dev;
 
-	/* rfc5227 PROBE_NUM                      */
 	if (!handle->count)
-		handle->count	 = 3;
+		handle->count	 = ARP_VERIFY_COUNT;
 
-	/* rfc5227 random(PROBE_MIN .. PROBE_MAX) */
-	if (!handle->interval)
-		handle->interval = ni_timeout_randomize(1000, &jitter);
+	if (!handle->interval.min)
+		handle->interval = range;
 
 	return 0;
 }
@@ -596,11 +635,13 @@ do_arp_notify_run(struct arp_handle *handle, const char *caller, int argc, char 
 				"\n"
 				"  --count <count>\n"
 				"      Announce IP address use (gratuitous ARP) <count> times\n"
-				"      (default: 2).\n"
-				"  --interval <msec>\n"
+				"      (default: %u).\n"
+				"  --interval <msec[..msec]>\n"
 				"      Announcement packet sending interval in msec\n"
-				"      (default: 2000).\n"
+				"      (default: %u).\n"
 				, argv[0]
+				, ARP_NOTIFY_COUNT
+				, ARP_NOTIFY_INTERVAL_MIN
 			);
 			goto cleanup;
 
@@ -622,8 +663,7 @@ do_arp_notify_run(struct arp_handle *handle, const char *caller, int argc, char 
 			break;
 
 		case OPT_INTERVAL:
-			if (ni_parse_uint(optarg, &handle->interval, 10) ||
-					!handle->interval) {
+			if (!do_parse_interval(&handle->interval, optarg)) {
 				ni_error("%s: Cannot parse notify interval '%s'",
 						argv[0], optarg);
 				goto cleanup;
@@ -657,16 +697,19 @@ cleanup:
 static int
 do_arp_notify_init(struct arp_handle *handle, ni_netdev_t *dev, ni_netconfig_t *nc)
 {
+	static const ni_uint_range_t range = {
+		.min = ARP_NOTIFY_INTERVAL_MIN,
+		.max = ARP_NOTIFY_INTERVAL_MAX,
+	};
+
 	(void)nc;
 	(void)dev;
 
-	/* rfc5227 ANNOUNCE_NUM      */
 	if (!handle->count)
-		handle->count	 = 2;
+		handle->count	 = ARP_NOTIFY_COUNT;
 
-	/* rfc5227 ANNOUNCE_INTERVAL */
-	if (!handle->interval)
-		handle->interval = 2000;
+	if (!handle->interval.min)
+		handle->interval = range;
 
 	return 0;
 }
@@ -794,9 +837,9 @@ do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **
 				"  --count <count> | inf\n"
 				"      Ping specified IP address <count> times\n"
 				"      (default: infinite).\n"
-				"  --interval <msec>\n"
+				"  --interval <msec[..msec]>\n"
 				"      Packet sending interval in msec\n"
-				"      (default: 1000).\n"
+				"      (default: %u).\n"
 				"  --replies <count>\n"
 				"      Wait unitil specified number of ping replies\n"
 				"  --timeout <msec>\n"
@@ -804,6 +847,7 @@ do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **
 				"  --from-ip <source ip>\n"
 				"      Use specified IP address as the ping source\n"
 				, argv[0]
+				, ARP_PING_INTERVAL_MIN
 			);
 			goto cleanup;
 
@@ -828,8 +872,7 @@ do_arp_ping_run(struct arp_handle *handle, const char *caller, int argc, char **
 			break;
 
 		case OPT_INTERVAL:
-			if (ni_parse_uint(optarg, &handle->interval, 10) ||
-					!handle->interval) {
+			if (!do_parse_interval(&handle->interval, optarg)) {
 				ni_error("%s: Cannot parse ping interval '%s'",
 						argv[0], optarg);
 				goto cleanup;
@@ -887,15 +930,19 @@ cleanup:
 static int
 do_arp_ping_init(struct arp_handle *handle, ni_netdev_t *dev, ni_netconfig_t *nc)
 {
+	static const ni_uint_range_t range = {
+		.min = ARP_PING_INTERVAL_MIN,
+		.max = ARP_PING_INTERVAL_MAX,
+	};
 	ni_address_t *ap;
 
 	ni_assert(handle && nc && dev);
 
 	if (!handle->count)
-		handle->count	 = -1U;
+		handle->count	 = ARP_PING_COUNT;
 
-	if (!handle->interval)
-		handle->interval = 1000;
+	if (!handle->interval.min)
+		handle->interval = range;
 
 	if (handle->deadline) {
 		if (!handle->replies)
@@ -1165,7 +1212,7 @@ ni_do_arp(const char *caller, int argc, char **argv)
 				"      Returns 4, when duplicate IP address exists.\n"
 				"  --notify <count>\n"
 				"      Notify about IP address use (gratuitous ARP)\n"
-				"  --interval <msec>\n"
+				"  --interval <msec[..msec]>\n"
 				"      Packet sending interval in msec\n"
 				"\n"
 				"Actions:\n"
@@ -1207,7 +1254,7 @@ ni_do_arp(const char *caller, int argc, char **argv)
 			break;
 
 		case OPT_INTERVAL:
-			if (ni_parse_uint(optarg, &handle.interval, 10) || !handle.interval) {
+			if (!do_parse_interval(&handle.interval, optarg)) {
 				ni_error("%s: Cannot parse valid interval timeout: '%s'",
 						argv[0], optarg);
 				goto cleanup;

--- a/client/arputil.c
+++ b/client/arputil.c
@@ -924,9 +924,9 @@ do_arp_ping_init(struct arp_handle *handle, ni_netdev_t *dev, ni_netconfig_t *nc
 				&ap->local_addr, &handle->ipaddr))
 			continue;
 
+		ni_sockaddr_set_ipv4(&handle->fromip, ap->local_addr.sin.sin_addr, 0);
 		ni_info("%s: Using source IP address %s from matching network",
 				handle->ifname, ni_sockaddr_print(&handle->fromip));
-		ni_sockaddr_set_ipv4(&handle->fromip, ap->local_addr.sin.sin_addr, 0);
 		return NI_WICKED_RC_SUCCESS;
 	}
 

--- a/include/wicked/time.h
+++ b/include/wicked/time.h
@@ -100,4 +100,6 @@ extern ni_timeout_t		ni_timeout_left(const struct timeval *, const struct timeva
 
 extern ni_bool_t		ni_timeval_add_timeout(struct timeval *, ni_timeout_t);
 
+extern ni_timeout_t		ni_timeout_random_range(ni_timeout_t min, ni_timeout_t max);
+
 #endif /* WICKED_TIME_H */

--- a/man/wicked-config.5.in
+++ b/man/wicked-config.5.in
@@ -260,6 +260,48 @@ supplicant. See below for a list of options.
 .TP
 .B auto6
 This element can be used to control the behavior of AUTO6 processing.
+.TP
+.B arp
+This element can be used to control ARP verify and ARP notify settings.
+See \fBARP CONFIGURATION OPTIONS\fR for more info.
+
+.PP
+.\" --------------------------------------------------------
+.SH ARP CONFIGURATION OPTIONS
+The ARP configuration specify the verify and notify settings used by wicked
+for duplicate address detection. If specified in \fB<addrconf>\fR the
+settings apply to static only. To change the ARP settings for AUTO4 or
+DHCP4, add the \fB<arp>\fR node as child of the corresponding \fB<auto4>\fR
+or \fB<dhcp4>\fR node.
+.PP
+.nf
+.B "  <arp>
+.B "    <verify>
+.B "      <count></count>
+.B "      <retries></retries>
+.B "      <interval>
+.B "        <min></min>
+.B "        <max></max>
+.B "      </interval>
+.B "    </verify>
+.B "    <notify>
+.B "      <count></count>
+.B "      <interval></interval>
+.B "      <retries></retries>
+.B "    </notify>
+.B "  </arp>
+.fi
+.PP
+.TP
+.B count
+This element can specify the number of ARP packets send.
+.TP
+.B retries
+This element specify the number of retries while sending ARP packages.
+.TP
+.B interval
+This element specify the delay between each ARP package. For \fB<verify>\fR it
+can be a range specified via \fB<min>\fR and \fB<max>\fR.
 
 .PP
 .\" --------------------------------------------------------

--- a/src/addrconf.h
+++ b/src/addrconf.h
@@ -51,7 +51,7 @@ struct ni_addrconf_updater {
 
 	const ni_timer_t *		timer;
 	ni_int_range_t			jitter;
-	unsigned int			timeout;
+	ni_timeout_t			timeout;
 	struct timeval			started;	/* updater */
 	unsigned int			deadline;
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -111,6 +111,23 @@ typedef enum {
 	NI_CONFIG_DHCP4_CID_TYPE_DISABLE,
 } ni_config_dhcp4_cid_type_t;
 
+typedef struct ni_config_arp_verify {
+	unsigned int	count;
+	unsigned int	retries;
+	ni_uint_range_t	interval;
+} ni_config_arp_verify_t;
+
+typedef struct ni_config_arp_notify {
+	unsigned int	count;
+	unsigned int	retries;
+	unsigned int	interval;
+} ni_config_arp_notify_t;
+
+typedef struct ni_config_arp {
+	ni_config_arp_verify_t	verify;
+	ni_config_arp_notify_t	notify;
+} ni_config_arp_t;
+
 typedef struct ni_config_dhcp4 {
 	struct ni_config_dhcp4 *next;
 	char *			device;
@@ -122,6 +139,7 @@ typedef struct ni_config_dhcp4 {
 	char *			vendor_class;
 	unsigned int		lease_time;
 	ni_string_array_t	ignore_servers;
+	ni_config_arp_t		arp;
 
 	unsigned int		num_preferred_servers;
 	ni_server_preference_t	preferred_server[NI_DHCP_SERVER_PREFERENCES_MAX];
@@ -159,7 +177,8 @@ typedef struct ni_config_dhcp6 {
 } ni_config_dhcp6_t;
 
 typedef struct ni_config_auto4 {
-	unsigned int	allow_update;
+	unsigned int		allow_update;
+	ni_config_arp_t		arp;
 } ni_config_auto4_t;
 
 typedef struct ni_config_auto6 {
@@ -174,6 +193,7 @@ typedef struct ni_config {
 
 	struct {
 	    unsigned int	default_allow_update;
+	    ni_config_arp_t	arp;
 
 	    ni_config_dhcp4_t	dhcp4;
 	    ni_config_dhcp6_t	dhcp6;
@@ -209,6 +229,7 @@ extern ni_extension_t *		ni_config_find_extension(ni_config_t *, const char *);
 extern ni_extension_t *		ni_config_find_system_updater(ni_config_t *, const char *);
 extern unsigned int		ni_config_addrconf_update_mask(ni_addrconf_mode_t, unsigned int);
 extern unsigned int		ni_config_addrconf_update(const char *, ni_addrconf_mode_t, unsigned int);
+extern const ni_config_arp_t *	ni_config_addrconf_arp(ni_addrconf_mode_t, const char *);
 
 extern const ni_config_dhcp4_t *ni_config_dhcp4_find_device(const char *);
 extern const char *		ni_config_dhcp4_cid_type_format(ni_config_dhcp4_cid_type_t);

--- a/src/arp.c
+++ b/src/arp.c
@@ -352,7 +352,7 @@ ni_arp_verify_process(ni_arp_socket_t *sock, const ni_arp_packet_t *pkt, void *u
 }
 
 ni_bool_t
-ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, unsigned int *timeout)
+ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, ni_timeout_t *timeout)
 {
 	static struct in_addr null = { 0 };
 	const struct in_addr *ip;
@@ -487,7 +487,7 @@ ni_arp_notify_add_address(ni_arp_notify_t *nfy,  ni_address_t *ap)
 }
 
 ni_bool_t
-ni_arp_notify_send(ni_arp_socket_t *sock, ni_arp_notify_t *nfy, unsigned int *timeout)
+ni_arp_notify_send(ni_arp_socket_t *sock, ni_arp_notify_t *nfy, ni_timeout_t *timeout)
 {
 	const struct in_addr *ip;
 	unsigned int i, count;

--- a/src/arp.c
+++ b/src/arp.c
@@ -383,6 +383,7 @@ ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, unsigned int *ti
 	}
 
 	need_wait = FALSE;
+	vfy->started = now;
 	for (i = 0; i < vfy->ipaddrs.count; ++i) {
 		vap = &vfy->ipaddrs.data[i];
 		ap  = vap->address;

--- a/src/arp.c
+++ b/src/arp.c
@@ -498,6 +498,7 @@ ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, ni_timeout_t *ti
 	return NI_ARP_SEND_FAILURE;
 }
 
+
 void
 ni_arp_notify_init(ni_arp_notify_t *nfy, const ni_config_arp_notify_t *cfg)
 {

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -83,9 +83,8 @@ struct ni_dhcp4_device {
 	ni_buffer_t		message;
 
 	struct {
+	   ni_arp_verify_t	verify;
 	   ni_arp_socket_t *	handle;
-	   unsigned int		nprobes;
-	   unsigned int		nclaims;
 
 	   void (*dad_success)(ni_dhcp4_device_t *);
 	   void (*dad_failure)(ni_dhcp4_device_t *);
@@ -107,7 +106,6 @@ struct ni_dhcp4_device {
 #define NI_DHCP4_REBOOT_TIMEOUT		NI_DHCP4_REQUEST_TIMEOUT
 #define NI_DHCP4_DECLINE_BACKOFF	10	/* seconds */
 #define NI_DHCP4_NAK_BACKOFF_MAX	60	/* seconds */
-#define NI_DHCP4_ARP_TIMEOUT		200	/* msec */
 
 /*
  * common NI_ADDRCONF_UPDATE_* + dhcp4 specific options

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -5036,7 +5036,7 @@ ni_address_updater_init(ni_addrconf_updater_t *updater, ni_netdev_t *dev, unsign
 static ni_bool_t
 ni_address_updater_arp_send(ni_addrconf_updater_t *updater, ni_netdev_t *dev, ni_addrconf_mode_t owner)
 {
-	unsigned int wait_verify = 0, wait_notify = 0;
+	ni_timeout_t wait_verify = 0, wait_notify = 0;
 	ni_address_updater_t *au;
 	const ni_config_arp_t *arpcfg = ni_config_addrconf_arp(owner, dev->name);
 

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -18,6 +18,7 @@
 #include <wicked/logging.h>
 #include <wicked/team.h>
 #include <wicked/ovs.h>
+#include "appconfig.h"
 
 typedef struct ni_capture	ni_capture_t;
 typedef struct __ni_netlink	ni_netlink_t;
@@ -218,7 +219,9 @@ typedef struct ni_arp_verify {
 	unsigned int			nprobes;
 	unsigned int			nretry;
 
-	unsigned int			wait_ms;
+	ni_timeout_t			probe_min_ms;
+	ni_timeout_t			probe_max_ms;
+	ni_timeout_t			last_timeout;
 	struct timeval			started;
 
 	ni_arp_verify_address_array_t	ipaddrs;
@@ -232,8 +235,8 @@ extern ni_arp_verify_address_t *	ni_arp_verify_address_array_find_match(ni_arp_v
 							ni_address_t *, unsigned int *,
 							ni_bool_t (*)(const ni_address_t *, const ni_address_t *));
 
-extern void				ni_arp_verify_init(ni_arp_verify_t *, unsigned int, unsigned int);
-extern void				ni_arp_verify_reset(ni_arp_verify_t *, unsigned int, unsigned int);
+extern void				ni_arp_verify_init(ni_arp_verify_t *, const ni_config_arp_verify_t *);
+extern void				ni_arp_verify_reset(ni_arp_verify_t *, const ni_config_arp_verify_t *);
 extern void				ni_arp_verify_destroy(ni_arp_verify_t *);
 extern unsigned int			ni_arp_verify_add_address(ni_arp_verify_t *,  ni_address_t *);
 extern void				ni_arp_verify_process(ni_arp_socket_t *, const ni_arp_packet_t *, void *);
@@ -241,6 +244,7 @@ extern ni_bool_t			ni_arp_verify_send(ni_arp_socket_t *, ni_arp_verify_t *, unsi
 
 typedef struct ni_arp_notify {
 	unsigned int			nclaims;
+	unsigned int			nretry;
 
 	unsigned int			wait_ms;
 	struct timeval			started;
@@ -248,8 +252,8 @@ typedef struct ni_arp_notify {
 	ni_address_array_t		ipaddrs;
 } ni_arp_notify_t;
 
-extern void				ni_arp_notify_init(ni_arp_notify_t *, unsigned int, unsigned int);
-extern void				ni_arp_notify_reset(ni_arp_notify_t *, unsigned int, unsigned int);
+extern void				ni_arp_notify_init(ni_arp_notify_t *, const ni_config_arp_notify_t *);
+extern void				ni_arp_notify_reset(ni_arp_notify_t *, const ni_config_arp_notify_t *);
 extern void				ni_arp_notify_destroy(ni_arp_notify_t *);
 extern unsigned int			ni_arp_notify_add_address(ni_arp_notify_t *,  ni_address_t *);
 extern ni_bool_t			ni_arp_notify_send(ni_arp_socket_t *, ni_arp_notify_t *, unsigned int *);

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -240,7 +240,7 @@ extern void				ni_arp_verify_reset(ni_arp_verify_t *, const ni_config_arp_verify
 extern void				ni_arp_verify_destroy(ni_arp_verify_t *);
 extern unsigned int			ni_arp_verify_add_address(ni_arp_verify_t *,  ni_address_t *);
 extern void				ni_arp_verify_process(ni_arp_socket_t *, const ni_arp_packet_t *, void *);
-extern ni_bool_t			ni_arp_verify_send(ni_arp_socket_t *, ni_arp_verify_t *, unsigned int *);
+extern ni_bool_t			ni_arp_verify_send(ni_arp_socket_t *, ni_arp_verify_t *, ni_timeout_t *);
 
 typedef struct ni_arp_notify {
 	unsigned int			nclaims;
@@ -256,7 +256,7 @@ extern void				ni_arp_notify_init(ni_arp_notify_t *, const ni_config_arp_notify_
 extern void				ni_arp_notify_reset(ni_arp_notify_t *, const ni_config_arp_notify_t *);
 extern void				ni_arp_notify_destroy(ni_arp_notify_t *);
 extern unsigned int			ni_arp_notify_add_address(ni_arp_notify_t *,  ni_address_t *);
-extern ni_bool_t			ni_arp_notify_send(ni_arp_socket_t *, ni_arp_notify_t *, unsigned int *);
+extern ni_bool_t			ni_arp_notify_send(ni_arp_socket_t *, ni_arp_notify_t *, ni_timeout_t *);
 
 /* netdev reques port config */
 struct ni_netdev_port_req {

--- a/src/timer.c
+++ b/src/timer.c
@@ -430,6 +430,37 @@ ni_timeout_randomize(ni_timeout_t timeout, const ni_int_range_t *jitter)
 	return rtimeout;
 }
 
+ni_timeout_t
+ni_timeout_random_range(ni_timeout_t min, ni_timeout_t max)
+{
+	ni_timeout_t randval = 0;
+	ni_timeout_t range;
+
+	if (max <= min)
+		return min;
+
+	if (min >= NI_TIMEOUT_INFINITE || max >= NI_TIMEOUT_INFINITE)
+		return NI_TIMEOUT_INFINITE;
+
+	range = max - min + 1;
+
+	if (range > RAND_MAX) {
+		/*
+		 * Assume the largest number RAND_MAX is INT_MAX,
+		 * even random returns long int (64 or 32bit)...
+		 */
+		size_t count = sizeof(ni_timeout_t) / sizeof(int);
+		size_t i, bits = (sizeof(int) * 8) - 1;
+
+		for (i = 0; i < count; i++)
+			randval |= (ni_timeout_t)random() << (i * bits);
+	} else {
+		randval = (ni_timeout_t)random();
+	}
+
+	return min + (randval % range);
+}
+
 static ni_timeout_t
 ni_timeout_arm_randomized(struct timeval *deadline, ni_timeout_t timeout, const ni_int_range_t *jitter)
 {


### PR DESCRIPTION
* Read probe and notify settings from config file
* Retry arp verify/notify on ENOBUFS
* Unify arp verify/notify in autoip4, dhcp4 and static-ip
* client: allow interval as range for `wicked arp verify`
