### PR TITLE
ifconfig: fix arp notify loop (boo#1212806) and burst sending

### DIFF
--- a/src/arp.c
+++ b/src/arp.c
@@ -440,7 +440,6 @@ ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, ni_timeout_t *ti
 	}
 
 	need_wait = FALSE;
-	vfy->started = now;
 	for (i = 0; i < vfy->ipaddrs.count; ++i) {
 		vap = vfy->ipaddrs.data[i];
 		ap  = vap->address;
@@ -485,6 +484,7 @@ ni_arp_verify_send(ni_arp_socket_t *sock, ni_arp_verify_t *vfy, ni_timeout_t *ti
 		}
 	}
 	if (need_wait) {
+		ni_timer_get_time(&vfy->started);
 		vfy->last_timeout = ni_timeout_random_range(vfy->probe_min_ms, vfy->probe_max_ms);
 		*timeout = vfy->last_timeout;
 		return NI_ARP_SEND_PROGRESS;
@@ -561,7 +561,6 @@ ni_arp_notify_send(ni_arp_socket_t *sock, ni_arp_notify_t *nfy, ni_timeout_t *ti
 		return TRUE;
 
 	if (nfy->nclaims && nfy->ipaddrs.count) {
-		nfy->started = now;
 		need_wait = FALSE;
 
 		for (i = 0; i < nfy->ipaddrs.count; ++i) {
@@ -606,6 +605,7 @@ ni_arp_notify_send(ni_arp_socket_t *sock, ni_arp_notify_t *nfy, ni_timeout_t *ti
 			}
 		}
 		if (need_wait) {
+			ni_timer_get_time(&nfy->started);
 			*timeout = nfy->wait_ms;
 			return TRUE;
 		}

--- a/src/arp.c
+++ b/src/arp.c
@@ -232,6 +232,7 @@ static ni_define_ptr_array_init(ni_arp_address);
 static ni_define_ptr_array_destroy(ni_arp_address);
 static ni_define_ptr_array_realloc(ni_arp_address, NI_ARP_ADDRESS_ARRAY_CHUNK);
 static ni_define_ptr_array_append(ni_arp_address);
+static ni_define_ptr_array_delete_at(ni_arp_address);
 
 static ni_bool_t
 ni_arp_address_array_append_addr(ni_arp_address_array_t *arr, ni_address_t *addr)
@@ -318,6 +319,24 @@ ni_arp_verify_add_address(ni_arp_verify_t *vfy,  ni_address_t *ap)
 		return 0;
 
 	return vfy->ipaddrs.count;
+}
+
+ni_bool_t
+ni_arp_verify_remove_address(ni_arp_verify_t *vfy,  ni_address_t *ap)
+{
+	unsigned int index = 0;
+
+	if (!vfy || !ap)
+		return FALSE;
+
+	if (ap->family != AF_INET || !ni_sockaddr_is_ipv4_specified(&ap->local_addr))
+		return FALSE;
+
+	if (!ni_arp_address_array_find_match_addr(&vfy->ipaddrs, ap, &index,
+				ni_address_equal_local_addr))
+		return FALSE;
+
+	return ni_arp_address_array_delete_at(&vfy->ipaddrs, index);
 }
 
 unsigned int

--- a/src/arp.c
+++ b/src/arp.c
@@ -603,7 +603,8 @@ ni_arp_notify_send(ni_arp_socket_t *sock, ni_arp_notify_t *nfy, ni_timeout_t *ti
 			ip = &ap->local_addr.sin.sin_addr;
 			if (ni_arp_send_grat_request(sock, *ip) > 0) {
 				aa->nattempts++;
-				need_wait = TRUE;
+				if (nfy->nclaims > aa->nattempts)
+					need_wait = TRUE;
 			} else {
 				if (errno == ENOBUFS) {
 					aa->nerrors++;

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -4861,9 +4861,9 @@ ni_netdev_addr_needs_update(ni_netdev_t *dev, ni_address_t *o, ni_address_t *n)
  * Update the addresses and routes assigned to an interface
  * for a given addrconf method
  */
-#define NI_ADDRCONF_UPDATER_MAX_ADDR_CHANGES	256
+#define NI_ADDRCONF_UPDATER_MAX_ARP_MESSAGES	256
+#define NI_ADDRCONF_UPDATER_MAX_ADDR_CHANGES	(NI_ADDRCONF_UPDATER_MAX_ARP_MESSAGES / 2)
 #define NI_ADDRCONF_UPDATER_MAX_ADDR_TIMEOUT	100
-#define NI_ADDRCONF_UPDATER_MAX_ARP_MESSAGES	NI_ADDRCONF_UPDATER_MAX_ADDR_CHANGES
 
 typedef struct ni_address_updater {
 	ni_arp_verify_t		verify;

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -5066,25 +5066,18 @@ ni_address_updater_arp_send(ni_addrconf_updater_t *updater, ni_netdev_t *dev, ni
 {
 	ni_timeout_t wait_verify = 0, wait_notify = 0;
 	ni_address_updater_t *au;
-	const ni_config_arp_t *arpcfg = ni_config_addrconf_arp(owner, dev->name);
 
 	if (!dev || !(au = ni_addrconf_address_updater_get(updater)))
 		return FALSE;
 
-	if (au->notify.nclaims) {
-		if (ni_arp_notify_send(au->sock, &au->notify, &wait_notify)) {
-			updater->timeout = wait_notify;
-			return TRUE;
-		}
-		ni_arp_notify_reset(&au->notify, &arpcfg->notify);
+	if (ni_arp_notify_send(au->sock, &au->notify, &wait_notify)) {
+		updater->timeout = wait_notify;
+		return TRUE;
 	}
 
-	if (au->verify.nprobes) {
-		if (ni_arp_verify_send(au->sock, &au->verify, &wait_verify) == NI_ARP_SEND_PROGRESS) {
-			updater->timeout = wait_verify;
-			return TRUE;
-		}
-		ni_arp_verify_reset(&au->verify, &arpcfg->verify);
+	if (ni_arp_verify_send(au->sock, &au->verify, &wait_verify) == NI_ARP_SEND_PROGRESS) {
+		updater->timeout = wait_verify;
+		return TRUE;
 	}
 
 	return FALSE;

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -5236,7 +5236,14 @@ __ni_netdev_update_addrs(ni_netdev_t *dev,
 		if (ni_address_is_duplicate(ap))
 			continue;
 
-		if (ni_address_is_tentative(ap)) {
+		if (!ni_address_is_tentative(ap)) {
+			/*
+			 *  Remove address from verify array, as it isn't
+			 *  tentative anymore and we need space for the
+			 *  next burst (NI_ADDRCONF_UPDATE_MAX_ADDR_CHANGES)
+			 */
+			ni_arp_verify_remove_address(&au->verify, ap);
+		} else {
 			count = ni_arp_verify_add_address(&au->verify, ap);
 			if (count >= NI_ADDRCONF_UPDATER_MAX_ADDR_CHANGES)
 				break;

--- a/src/netinfo_priv.h
+++ b/src/netinfo_priv.h
@@ -234,6 +234,7 @@ extern void				ni_arp_verify_init(ni_arp_verify_t *, const ni_config_arp_verify_
 extern void				ni_arp_verify_reset(ni_arp_verify_t *, const ni_config_arp_verify_t *);
 extern void				ni_arp_verify_destroy(ni_arp_verify_t *);
 extern unsigned int			ni_arp_verify_add_address(ni_arp_verify_t *,  ni_address_t *);
+extern ni_bool_t			ni_arp_verify_remove_address(ni_arp_verify_t *,  ni_address_t *);
 extern unsigned int			ni_arp_verify_add_in_addr(ni_arp_verify_t *, struct in_addr);
 extern ni_arp_send_status_t			ni_arp_verify_send(ni_arp_socket_t *, ni_arp_verify_t *, ni_timeout_t *);
 extern ni_arp_address_t *		ni_arp_reply_match_address(ni_arp_socket_t *, ni_arp_address_array_t *,


### PR DESCRIPTION
 * fix the regression [boo#1212806](https://bugzilla.suse.com/show_bug.cgi?id=1212806) introduced with https://github.com/openSUSE/wicked/pull/979 
 * fix the burst sending of max 256 arp verify/notify messages
 * config value of `<arp><verify|notify><count>` need to be greater then `0`