### PR TITLE
system-updater: Parse updater format from XML configuration to ensure install calls can run.

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -2025,6 +2025,7 @@ ni_config_parse_system_updater(ni_extension_t **list, xml_node_t *node)
 {
 	ni_extension_t *ex, *old;
 	const char *name;
+	const char *format;
 
 	ni_assert(list && node);
 
@@ -2045,6 +2046,17 @@ ni_config_parse_system_updater(ni_extension_t **list, xml_node_t *node)
 	if (!ex || !ni_config_parse_extension(ex, node)) {
 		ni_extension_free(ex);
 		return FALSE;
+	}
+
+	format = xml_node_get_attr(node, "format");
+	if (format) {
+		ex->format = strdup(format);
+
+		if (!ex->format) {
+			ni_warn("[%s] failed to allocate memory for format-string", node->name);
+			ni_extension_free(ex);
+			return FALSE;
+		}
 	}
 
 	if (ex->c_bindings) {

--- a/src/extension.c
+++ b/src/extension.c
@@ -199,6 +199,7 @@ ni_extension_free(ni_extension_t *ex)
 	if (ex) {
 		ni_string_free(&ex->name);
 		ni_string_free(&ex->interface);
+		ni_string_free(&ex->format);
 
 		ni_script_action_list_destroy(&ex->actions);
 		ni_c_binding_list_destroy(&ex->c_bindings);


### PR DESCRIPTION
In ni_system_updaters_init(), the updater's format is set by using ni_updater_format_type(ex->format). This in turn is used by ni_system_updater_generic_leaseinfo_create(), which is called by ni_system_updater_generic_install_call(). As ex->format is never actually set, ni_system_updater_generic_leaseinfo_create will always fail with an unknown format error and the install call is never executed.