### PR TITLE
__ni_rtnl_parse_newaddr: Use peer-to-peer condition from comment instead of relying on interface's p2p flag

### DIFF
--- a/src/iflist.c
+++ b/src/iflist.c
@@ -2863,16 +2863,10 @@ __ni_rtnl_parse_newaddr(unsigned ifflags, struct nlmsghdr *h, struct ifaddrmsg *
 	 * but for point-to-point IFA_ADDRESS is DESTINATION address,
 	 * local address is supplied in IFA_LOCAL attribute.
 	 */
-	if (ifflags & NI_IFF_POINT_TO_POINT) {
-		if (tb[IFA_LOCAL]) {
-			/* local peer remote */
-			__ni_nla_get_addr(ifa->ifa_family, &ap->local_addr, tb[IFA_LOCAL]);
-			__ni_nla_get_addr(ifa->ifa_family, &ap->peer_addr, tb[IFA_ADDRESS]);
-		} else
-		if (tb[IFA_ADDRESS]) {
-			/* local only, e.g. tunnel ipv6 link layer address */
-			__ni_nla_get_addr(ifa->ifa_family, &ap->local_addr, tb[IFA_ADDRESS]);
-		}
+	if (!tb[IFA_BROADCAST] && tb[IFA_LOCAL] && tb[IFA_ADDRESS]) {
+		/* local peer remote */
+		__ni_nla_get_addr(ifa->ifa_family, &ap->local_addr, tb[IFA_LOCAL]);
+		__ni_nla_get_addr(ifa->ifa_family, &ap->peer_addr, tb[IFA_ADDRESS]);
 		/* Note iproute2 code obtains peer_addr from IFA_BROADCAST */
 		/* When I read and remember it correctly, iproute2 is using:
 		 *   !tb[IFA_BROADCAST] && tb[IFA_LOCAL] && tb[IFA_ADDRESS]


### PR DESCRIPTION
An ethernet interface is not a peer-to-peer interface. However, we may bind peer to peer addresses on it, which won't get removed with the current code (ni_nl_talk() in __ni_rtnl_send_deladdr() returns an error because ap->peer_addr stays empty for that p2p-address).

Instead, use the peer-to-peer condition from the comment below to check whether the interface address is P2P.