### PR TITLE
rtnl: parse peer address on non-ptp interfaces

### DIFF
--- a/src/ifevent.c
+++ b/src/ifevent.c
@@ -512,7 +512,7 @@ __ni_rtevent_deladdr(ni_netconfig_t *nc, const struct sockaddr_nl *nladdr, struc
 	if (dev == NULL)
 		return 0;
 
-	if (__ni_rtnl_parse_newaddr(dev->link.ifflags, h, ifa, &tmp) < 0) {
+	if (__ni_rtnl_parse_newaddr(dev->name, dev->link.ifflags, h, ifa, &tmp) < 0) {
 		ni_error("Problem parsing %s message for %s", dev->name,
 				ni_rtnl_msg_type_to_name(h->nlmsg_type, NULL));
 		return -1;

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -120,7 +120,8 @@ extern ni_bool_t	ni_rtnl_route_filter_msg(struct rtmsg *);
 extern int	ni_rtnl_route_parse_msg(struct nlmsghdr *, struct rtmsg *, ni_route_t *);
 extern int	ni_rtnl_rule_parse_msg(struct nlmsghdr *, struct fib_rule_hdr *, ni_rule_t *);
 
-extern int	__ni_rtnl_parse_newaddr(unsigned, struct nlmsghdr *, struct ifaddrmsg *, ni_address_t *);
+extern int	__ni_rtnl_parse_newaddr(const char *, unsigned int, struct nlmsghdr *,
+				struct ifaddrmsg *, ni_address_t *);
 extern int	__ni_rtnl_parse_newprefix(const char *, struct nlmsghdr *, struct prefixmsg *, ni_ipv6_ra_pinfo_t *);
 
 extern int	__ni_netdev_process_newlink(ni_netdev_t *, struct nlmsghdr *, struct ifinfomsg *, ni_netconfig_t *);


### PR DESCRIPTION
Due to the incomplete parsing the peer address were empty
and caused an error in attempts to delete it while ifdown.