### PR TITLE
duid: fix comment for v6time

### DIFF
--- a/src/duid.h
+++ b/src/duid.h
@@ -75,7 +75,7 @@
 typedef struct ni_duid_llt {
 	uint16_t		type;		/* type 1                     */
 	uint16_t		hwtype;         /* link layer address type    */
-	uint32_t		v6time;		/* second since 2001 % 2^32   */
+	uint32_t		v6time;		/* second since 2000 % 2^32   */
 	unsigned char		hwaddr[];	/* link layer address         */
 } NI_PACKED ni_duid_llt_t;
 


### PR DESCRIPTION
v6time is seconds since midnight (UTC), January 1, 2000, modulo 2^32. The value is generated correctly but the comment refers to 2001 instead of 2000.