### PR TITLE
dhcp6: omit the SO_REUSEPORT option (bsc#1215692)

### DIFF
--- a/src/dhcp6/protocol.c
+++ b/src/dhcp6/protocol.c
@@ -89,7 +89,7 @@ static int	ni_dhcp6_option_get_duid(ni_buffer_t *bp, ni_opaque_t *duid);
  *
  */
 static int
-__ni_dhcp6_mcast_socket_open(const struct ni_dhcp6_link *link, const char *ifname)
+ni_dhcp6_link_mcast_socket_open(const struct ni_dhcp6_link *link, const char *ifname)
 {
 	ni_sockaddr_t saddr;
 	int fd, on;
@@ -119,10 +119,7 @@ __ni_dhcp6_mcast_socket_open(const struct ni_dhcp6_link *link, const char *ifnam
 	on = 1;
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1)
 		ni_error("%s: Cannot set setsockopt(SO_REUSEADDR): %m", ifname);
-#if defined(SO_REUSEPORT)
-	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) == -1)
-		ni_error("%s: Cannot set setsockopt(SO_REUSEPORT): %m", ifname);
-#endif
+
 	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &on, sizeof(on)) == -1)
 		ni_error("%s: Cannot set setsockopt(SO_RCVBUF): %m", ifname);
 
@@ -199,7 +196,7 @@ ni_dhcp6_mcast_socket_open(ni_dhcp6_device_t *dev)
 	dev->mcast.dest.six.sin6_scope_id = dev->link.ifindex;
 
 	/* open the socket an bind to the link-local address */
-	if ((fd = __ni_dhcp6_mcast_socket_open(&dev->link, dev->ifname)) == -1)
+	if ((fd = ni_dhcp6_link_mcast_socket_open(&dev->link, dev->ifname)) == -1)
 		return -1;
 
 	/* finally wrap it and allocate receive buffer */


### PR DESCRIPTION
Setting the SO_REUSEPORT socket option causes that replies are
delivered to the first process/socket bound to an `[ip%dev]:port`
with the effect that `wicked test dhcp6 ...` does not receive it's
replies, but the wickedd-dhcp6 (service) active on the
same interface.