### PR TITLE
client: fix exit code for no-carrier status (bsc#1219265)

### DIFF
--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -884,6 +884,7 @@ ni_do_ifstatus(int argc, char **argv)
 			case NI_WICKED_ST_UNCONFIGURED:
 			case NI_WICKED_ST_NOT_RUNNING:
 			case NI_WICKED_ST_IN_PROGRESS:
+			case NI_WICKED_ST_NO_CARRIER:
 				break;
 			default:
 				status = NI_WICKED_ST_OK;
@@ -1000,6 +1001,7 @@ ni_ifstatus_display_result(ni_fsm_t *fsm, ni_string_array_t *names, ni_ifworker_
 			case NI_WICKED_ST_UNCONFIGURED:
 			case NI_WICKED_ST_NOT_RUNNING:
 			case NI_WICKED_ST_IN_PROGRESS:
+			case NI_WICKED_ST_NO_CARRIER:
 				break;
 			default:
 				status = NI_WICKED_ST_OK;

--- a/client/suse/scripts/ifup.in
+++ b/client/suse/scripts/ifup.in
@@ -226,6 +226,9 @@ rc_map_status()
 	166)	# NI_WICKED_ST_PERSISTENT_ON
 		return $R_NOTALLOWED
 	;;
+	168)	# NI_WICKED_ST_NO_CARRIER
+		return $R_DHCP_BG
+	;;
 	*)	# any other
 		return ${1:-1}
 	;;


### PR DESCRIPTION
The 'no-carrier' status was separated from the 'setup-in-progress' status. Even though the interface appears active during this status, the setup process is not complete and the NIC is not ready. Therefore, the `ifstatus <nic>` command should not return 0 for this status.