### PR TITLE
ifcheck: fix config changed check (bsc#1218926)

### DIFF
--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -305,6 +305,18 @@ ni_do_ifcheck(int argc, char **argv)
 		goto usage;
 	}
 
+	if (!ni_fsm_create_client(fsm)) {
+		/* Severe error we always explicitly return */
+		status = NI_WICKED_RC_ERROR;
+		goto cleanup;
+	}
+
+	if (!ni_fsm_refresh_state(fsm)) {
+		/* Severe error we always explicitly return */
+		status = NI_WICKED_RC_ERROR;
+		goto cleanup;
+	}
+
 	if (opt_ifconfig.count == 0) {
 		const ni_string_array_t *sources = ni_config_sources("ifconfig");
 
@@ -323,17 +335,6 @@ ni_do_ifcheck(int argc, char **argv)
 		goto cleanup;
 	}
 
-	if (!ni_fsm_create_client(fsm)) {
-		/* Severe error we always explicitly return */
-		status = NI_WICKED_RC_ERROR;
-		goto cleanup;
-	}
-
-	if (!ni_fsm_refresh_state(fsm)) {
-		/* Severe error we always explicitly return */
-		status = NI_WICKED_RC_ERROR;
-		goto cleanup;
-	}
 
 	status = NI_WICKED_ST_OK;
 


### PR DESCRIPTION
This fix the outcome of the following commands:
```bash
source /etc/sysconfig/network/ifcfg-en0
grep IPADDR /etc/sysconfig/network/ifcfg-en0
sed -i '/IPADDR/cIPADDR=10.1.2.5/24' /etc/sysconfig/network/ifcfg-en0
wicked ifcheck --changed en0 && echo "ERROR config changed not notified"
sed -i '/IPADDR/cIPADDR='$IPADDR /etc/sysconfig/network/ifcfg-en0
wicked ifcheck --changed en0 || echo "ERROR unexpected config changed"
```