### PR TITLE
Replace "nvme show-nbft" with "nvme nbft show"

### DIFF
--- a/extensions/nbft
+++ b/extensions/nbft
@@ -252,7 +252,7 @@ nvme_show_nbft() {
 	if test "X$OPT_ROOTDIR" != "X" -a -f "$OPT_ROOTDIR/nbft.json" ; then
 		cat "$OPT_ROOTDIR/nbft.json"
 	else
-		nvme show-nbft -H -o json
+		nvme nbft show -H -o json
 	fi
 }
 
@@ -261,7 +261,7 @@ nbft_parse() {
 	local j=0 i
 
 	nbft_json=$(nvme_show_nbft 2>/dev/null) || {
-		warn "failed to read NBFT table, is \"nvme show-nbft\" supported?"
+		warn "failed to read NBFT table, is \"nvme nbft show\" supported?"
 		return $RC_ERROR
 	}
 	n_nbft=$(nbft_run_jq ". | length" "$nbft_json") || return 0

--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -121,7 +121,8 @@ interface to network configuration.
 Summary:        Network configuration infrastructure - nbft support
 Group:          System/Management
 Requires:       %name = %{version}
-Requires:       nvme-cli >= 2.2.1
+# Support for the "nvme nbft show" command
+Requires:       nvme-cli >= 2.4+17.gf4cfca93998a
 Requires:       jq >= 1.6
 
 %description nbft


### PR DESCRIPTION
Upstream nvme-cli has moved the nbft support into a plugin.
The syntax is now "nvme nbft show" rather than "nvme show-nbft".

See https://bugzilla.suse.com/show_bug.cgi?id=1221358