### PR TITLE
hide secrets in debug log (bsc#1221194) 

### DIFF
--- a/include/wicked/logging.h
+++ b/include/wicked/logging.h
@@ -18,6 +18,9 @@ extern void		ni_error(const char *, ...) ni__printf(1, 2);
 extern void		ni_error_extra(const char *, ...) ni__printf(1, 2);
 extern void		ni_trace(const char *, ...) ni__printf(1, 2);
 extern void		ni_fatal(const char *, ...) ni__printf(1, 2) ni__noreturn;
+extern void		ni_debug_verbose_config_xml(const xml_node_t *,
+					unsigned int, unsigned int,
+					const char *, ...) ni__printf(4, 5);
 
 extern int		ni_enable_debug(const char *);
 extern int		ni_debug_set_default(const char *);
@@ -116,6 +119,9 @@ extern unsigned int	ni_log_level;
 			xml_node_print_debug(xml_node, NI_TRACE_WICKED_XML); \
 		} \
 	} while (0)
+
+#define ni_debug_config_xml(xml_node, level, fmt, args...) \
+	ni_debug_verbose_config_xml(xml_node, level, NI_TRACE_WICKED_XML, fmt, ##args)
 
 #define ni_debug_none(fmt, args...)		do { } while (0)
 

--- a/include/wicked/xml.h
+++ b/include/wicked/xml.h
@@ -3,7 +3,8 @@
  *	This basically parses tags, attributes and CDATA, and that's
  *	just about it.
  *
- *	Copyright (C) 2009-2012  Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2009-2012 Olaf Kirch <okir@suse.de>
+ *	Copyright (C) 2009-2024 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -15,15 +16,11 @@
  *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *	GNU General Public License for more details.
  *
- *	You should have received a copy of the GNU General Public License along
- *	with this program; if not, see <http://www.gnu.org/licenses/> or write 
- *	to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
- *	Boston, MA 02110-1301 USA.
- *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __WICKED_XML_H__
-#define __WICKED_XML_H__
+#ifndef NI_WICKED_XML_H
+#define NI_WICKED_XML_H
 
 #include <stdio.h>
 #include <wicked/util.h>
@@ -109,6 +106,7 @@ extern int		xml_node_uuid(const xml_node_t *, unsigned int, const ni_uuid_t *, n
 extern int		xml_node_content_uuid(const xml_node_t *, unsigned int, const ni_uuid_t *, ni_uuid_t *);
 extern int		xml_node_print_fn(const xml_node_t *, void (*)(const char *, void *), void *);
 extern int		xml_node_print_debug(const xml_node_t *, unsigned int facility);
+extern void		xml_node_hide_cdata(xml_node_t *, const char * const [], const char *);
 extern xml_node_t *	xml_node_scan(FILE *fp, const char *location);
 extern void		xml_node_set_cdata(xml_node_t *, const char *);
 extern void		xml_node_set_int(xml_node_t *, int);
@@ -185,4 +183,4 @@ xml_document_is_empty(const xml_document_t *doc)
 	return (!doc || xml_node_is_empty(doc->root));
 }
 
-#endif /* __WICKED_XML_H__ */
+#endif /* NI_WICKED_XML_H */

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -205,8 +205,8 @@ ni_factory_device_apply_policy(ni_fsm_t *fsm, ni_ifworker_t *w, ni_managed_polic
 			w->name, type_name);
 		return -1;
 	}
-	ni_debug_nanny("%s: using device config", w->name);
-	xml_node_print_debug(config, 0);
+
+	ni_debug_config_xml(config, NI_LOG_DEBUG, "%s: using device config", w->name);
 
 	ni_ifworker_set_config(w, config, ni_fsm_policy_origin(policy));
 	xml_node_free(config);
@@ -269,8 +269,7 @@ ni_managed_device_apply_policy(ni_managed_device_t *mdev, ni_managed_policy_t *m
 		ni_error("%s: error when applying policy to %s document", w->name, type_name);
 		return -1;
 	}
-	ni_debug_nanny("%s: using device config", w->name);
-	xml_node_print_debug(config, 0);
+	ni_debug_config_xml(config, NI_LOG_DEBUG, "%s: using device config", w->name);
 
 	ni_managed_device_set_policy(mdev, mpolicy, config);
 	xml_node_free(config);

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -158,8 +158,8 @@ ni_netif_firmware_discovery_script_ifconfig(xml_document_t **doc,
 			xml_document_free(*doc);
 			*doc = NULL;
 		} else if (ni_log_level_at(NI_LOG_DEBUG2)) {
-			ni_debug_ifconfig("%s discovery script xml output:", type);
-			xml_node_print_debug(xml_document_root(*doc), NI_TRACE_IFCONFIG);
+			ni_debug_verbose_config_xml(xml_document_root(*doc), NI_LOG_DEBUG2,
+					NI_TRACE_IFCONFIG, "%s discovery script xml output:", type);
 		}
 	}
 	ni_buffer_destroy(&buf);

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1224,7 +1224,9 @@ ni_debug_escape_net_property(const char *prop_name)
 		NI_WPA_NET_PROPERTY_WEP_KEY1,
 		NI_WPA_NET_PROPERTY_WEP_KEY2,
 		NI_WPA_NET_PROPERTY_WEP_KEY3,
-		NI_WPA_NET_PROPERTY_PASSWORD
+		NI_WPA_NET_PROPERTY_PASSWORD,
+		NI_WPA_NET_PROPERTY_PRIVATE_KEY,
+		NI_WPA_NET_PROPERTY_PRIVATE_KEY_PASSWD
 	};
 
 	if (!ni_wpa_net_property_type(prop_name, &type))


### PR DESCRIPTION
Replaces cdata in a copy of a config node and it's children that contain passwords before logging it.

Please merge https://github.com/openSUSE/wicked/pull/1005 first.