### PR TITLE
client: fix to not convert sec to msec twice (bsc#1222105)

### DIFF
--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -123,7 +123,7 @@ ni_do_ifdown(int argc, char **argv)
 	ni_ifworker_array_t ifmarked = NI_IFWORKER_ARRAY_INIT;
 	ni_string_array_t ifnames = NI_STRING_ARRAY_INIT;
 	unsigned int nmarked, max_state = NI_FSM_STATE_DEVICE_DOWN;
-	unsigned int seconds = NI_IFWORKER_DEFAULT_TIMEOUT;
+	unsigned int seconds = 0;
 	ni_stringbuf_t sb = NI_STRINGBUF_INIT_DYNAMIC;
 	ni_tristate_t opt_release = NI_TRISTATE_DEFAULT;
 	ni_fsm_t *fsm;
@@ -223,9 +223,10 @@ usage:
 	ifmarker.target_range.min = NI_FSM_STATE_NONE;
 	ifmarker.target_range.max = max_state;
 
-	fsm->worker_timeout = ni_fsm_find_max_timeout(fsm,
-					NI_TIMEOUT_FROM_SEC(seconds));
-
+	if (seconds)
+		fsm->worker_timeout = NI_TIMEOUT_FROM_SEC(seconds);
+	else
+		fsm->worker_timeout = NI_IFWORKER_DEFAULT_TIMEOUT;
 	if (fsm->worker_timeout == NI_IFWORKER_INFINITE_TIMEOUT)
 		ni_debug_application("wait for interfaces infinitely");
 	else

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -6119,6 +6119,7 @@ done:
 ni_timeout_t
 ni_fsm_find_max_timeout(ni_fsm_t *fsm, ni_timeout_t timeout)
 {
+	ni_timeout_t max = timeout;
 	unsigned int i;
 
 	if (!fsm || timeout >= NI_IFWORKER_INFINITE_TIMEOUT)
@@ -6126,19 +6127,13 @@ ni_fsm_find_max_timeout(ni_fsm_t *fsm, ni_timeout_t timeout)
 
 	for (i = 0; i < fsm->workers.count; i++) {
 		ni_ifworker_t *w = fsm->workers.data[i];
-		ni_timeout_t max, add;
+		ni_timeout_t add;
 
-		add = min_t(ni_timeout_t,
-				NI_TIMEOUT_FROM_SEC(w->extra_waittime),
-				NI_IFWORKER_INFINITE_TIMEOUT);
-		max = max_t(ni_timeout_t, timeout,
-				fsm->worker_timeout + add);
-
-		timeout = min_t(ni_timeout_t, max,
-				NI_IFWORKER_INFINITE_TIMEOUT);
+		add = NI_TIMEOUT_FROM_SEC(w->extra_waittime);
+		max = max_t(ni_timeout_t, max, timeout + add);
 	}
 
-	return timeout;
+	return min_t(ni_timeout_t, max, NI_IFWORKER_INFINITE_TIMEOUT);
 }
 
 void

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2058,7 +2058,7 @@ ni_ifworker_set_config_origin(ni_ifworker_t *w, const char *new_origin)
 static void
 ni_ifworker_extra_waittime_from_xml(ni_ifworker_t *w)
 {
-	unsigned int extra_timeout = 0;
+	unsigned int extra_waittime = 0;
 	const xml_node_t *brnode;
 
 	if (!w || xml_node_is_empty(w->config.node))
@@ -2066,9 +2066,9 @@ ni_ifworker_extra_waittime_from_xml(ni_ifworker_t *w)
 
 	/* Adding bridge dependent values (STP, Forwarding times) */
 	if ((brnode = xml_node_get_child(w->config.node, "bridge")))
-		extra_timeout += ni_bridge_waittime_from_xml(brnode);
+		extra_waittime += ni_bridge_waittime_from_xml(brnode);
 
-	w->extra_waittime = (extra_timeout*1000);
+	w->extra_waittime = extra_waittime;
 }
 
 ni_iftype_t


### PR DESCRIPTION
Fix to not convert user-timeout in seconds into to timer timeout in millisecond twice.
It caused to wait 1000 times longer when a bridge with stp=on starts and all it's ports
are disconnected and unable to find carrier.