### PR TITLE
bond: add ports when master is up (bsc#1219108)

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -401,7 +401,6 @@ extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
 extern void			ni_ifworker_array_append(ni_ifworker_array_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_ifworker_array_remove_index(ni_ifworker_array_t *, unsigned int);
 extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
-extern void			ni_ifworker_array_remove_with_children(ni_ifworker_array_t *, ni_ifworker_t *);
 extern int			ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
 extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);
 

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -155,7 +155,7 @@ ni_nanny_schedule_recheck(ni_ifworker_array_t *array, ni_ifworker_t *w)
 void
 ni_nanny_unschedule(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
-	ni_ifworker_array_remove_with_children(array, w);
+	ni_ifworker_array_remove(array, w);
 }
 
 /*

--- a/schema/interface.xml
+++ b/schema/interface.xml
@@ -234,7 +234,7 @@
    <alias type="string"/>
    <master type="string">
      <meta:netif-reference subordinate="true" />
-     <meta:require check="netif-config-state" op="linkUp" min-state="firewall-up" />
+     <meta:require check="netif-config-state" op="linkUp" min-state="device-up" />
    </master>
    <port class="union" switch="type">
      <bond       type="bond:port-config" />

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -949,19 +949,6 @@ ni_ifworker_array_remove(ni_ifworker_array_t *array, ni_ifworker_t *w)
 	return found;
 }
 
-void
-ni_ifworker_array_remove_with_children(ni_ifworker_array_t *array, ni_ifworker_t *w)
-{
-	if (ni_ifworker_array_index(array, w) != -1) {
-		unsigned int i;
-
-		for (i = 0; i < w->children.count; i++) {
-			ni_ifworker_array_remove_with_children(array, w->children.data[i]);
-		}
-		ni_ifworker_array_remove(array, w);
-	}
-}
-
 ni_ifworker_t *
 ni_fsm_ifworker_by_name(const ni_fsm_t *fsm, ni_ifworker_type_t type, const char *name)
 {


### PR DESCRIPTION
- Change schema to add ports to master in `device-up` state, so the
  (bond) master has an already configured MTU and propagates it
  to the ports.
- Fix to not stop monitoring non-hotplug ports or lower interfaces
  when a link (vlan) on  top finished before the lower itself.