### PR TITLE
cleanup: fix enum-int-mismatch warnings

### DIFF
--- a/client/ifcheck.h
+++ b/client/ifcheck.h
@@ -43,5 +43,5 @@ extern ni_bool_t	ni_ifcheck_worker_device_is_persistent(ni_ifworker_t *);
 extern ni_bool_t	ni_ifcheck_worker_config_exists(ni_ifworker_t *);
 extern ni_bool_t	ni_ifcheck_worker_config_matches(ni_ifworker_t *);
 
-extern ni_bool_t	ni_ifcheck_worker_not_in_state(ni_ifworker_t *, unsigned int);
+extern ni_bool_t	ni_ifcheck_worker_not_in_state(ni_ifworker_t *, ni_fsm_state_t);
 #endif /* __WICKED_CLIENT_IFCHECK_H__ */

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -145,7 +145,7 @@ ni_do_ifdown(int argc, char **argv)
 
 	memset(&ifmarker, 0, sizeof(ifmarker));
 	ifmarker.target_range.min = NI_FSM_STATE_DEVICE_DOWN;
-	ifmarker.target_range.max = __NI_FSM_STATE_MAX - 2;
+	ifmarker.target_range.max = NI_FSM_STATE_MAX - 2;
 
 	optind = 1;
 	while ((c = getopt_long(argc, argv, "", ifdown_options, NULL)) != EOF) {

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -177,7 +177,7 @@ ni_client_get_state_strings(ni_stringbuf_t *sb, const ni_uint_range_t *range)
 		ni_fsm_state_t state;
 
 		for (state = (range ? range->min : NI_FSM_STATE_NONE);
-		     state <= (range ? range->max : __NI_FSM_STATE_MAX - 1);
+		     state <= (range ? range->max : NI_FSM_STATE_MAX - 1);
 		     state++) {
 			ni_stringbuf_printf(sb, "%s ", ni_ifworker_state_name(state));
 		}

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -34,7 +34,7 @@ typedef enum ni_fsm_state {
 	NI_FSM_STATE_ADDRCONF_UP,
 	NI_FSM_STATE_NETWORK_UP,
 
-	__NI_FSM_STATE_MAX
+	NI_FSM_STATE_MAX
 } ni_fsm_state_t;
 
 typedef enum ni_config_origin_prio {
@@ -512,7 +512,7 @@ static inline ni_bool_t
 ni_ifworker_is_valid_state(ni_fsm_state_t state)
 {
 	return  state > NI_FSM_STATE_NONE &&
-		state < __NI_FSM_STATE_MAX;
+		state < NI_FSM_STATE_MAX;
 }
 
 static inline ni_bool_t

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -367,7 +367,7 @@ extern void			ni_fsm_wait_tentative_addrs(ni_fsm_t *);
 extern ni_ifworker_type_t	ni_ifworker_type_from_string(const char *);
 extern const char *		ni_ifworker_type_to_string(ni_ifworker_type_t);
 extern ni_ifworker_type_t	ni_ifworker_type_from_object_path(const char *, const char **);
-extern ni_bool_t		ni_ifworker_state_in_range(const ni_uint_range_t *, const unsigned int);
+extern ni_bool_t		ni_ifworker_state_in_range(const ni_uint_range_t *, const ni_fsm_state_t);
 extern const char *		ni_ifworker_state_name(ni_fsm_state_t state);
 extern ni_bool_t		ni_ifworker_state_from_name(const char *, unsigned int *);
 extern ni_fsm_require_t *	ni_ifworker_reachability_check_new(xml_node_t *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -422,7 +422,7 @@ extern const char *			ni_wireless_mode_to_name(ni_wireless_mode_t);
 extern ni_bool_t			ni_wireless_name_to_mode(const char *, unsigned int *);
 extern const ni_intmap_t *		ni_wireless_auth_proto_map(void);
 extern const char *			ni_wireless_auth_proto_to_name(ni_wireless_auth_proto_t);
-extern ni_bool_t			ni_wireless_name_to_auth_proto(const char *, unsigned int *);
+extern ni_bool_t			ni_wireless_name_to_auth_proto(const char *, ni_wireless_auth_proto_t *);
 extern const ni_intmap_t *		ni_wireless_auth_algo_map(void);
 extern const char *			ni_wireless_auth_algo_to_name(ni_wireless_auth_algo_t);
 extern ni_bool_t			ni_wireless_name_to_auth_algo(const char *, unsigned int *);

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -166,8 +166,8 @@ ni_factory_device_up(ni_fsm_t *fsm, ni_ifworker_t *w)
 	ni_assert(fsm && w);
 	memset(&ifmarker, 0, sizeof(ifmarker));
 
-	ifmarker.target_range.min = __NI_FSM_STATE_MAX - 1;
-	ifmarker.target_range.max = __NI_FSM_STATE_MAX;
+	ifmarker.target_range.min = NI_FSM_STATE_MAX - 1;
+	ifmarker.target_range.max = NI_FSM_STATE_MAX;
 	ifmarker.persistent = w->control.persistent;
 
 	ni_ifworker_array_append(&ifmarked, w);
@@ -350,7 +350,7 @@ ni_managed_device_up(ni_managed_device_t *mdev, const char *origin)
 				ni_security_id_set_attr(&security_id, "essid", essid);
 		}
 
-		target_state = __NI_FSM_STATE_MAX - 1;
+		target_state = NI_FSM_STATE_MAX - 1;
 		break;
 
 	case NI_IFWORKER_TYPE_MODEM:
@@ -375,7 +375,7 @@ ni_managed_device_up(ni_managed_device_t *mdev, const char *origin)
 	ni_ifworker_set_config(w, mdev->selected_config, origin);
 
 	ifmarker.target_range.min = target_state;
-	ifmarker.target_range.max = __NI_FSM_STATE_MAX;
+	ifmarker.target_range.max = NI_FSM_STATE_MAX;
 	ifmarker.persistent = w->control.persistent;
 
 	ni_ifworker_array_append(&ifmarked, w);

--- a/src/client/client_state.c
+++ b/src/client/client_state.c
@@ -289,7 +289,7 @@ ni_client_state_is_valid(const ni_client_state_t *client_state)
  * Exported functions
  */
 ni_client_state_t *
-ni_client_state_new(ni_fsm_state_t state)
+ni_client_state_new(void)
 {
 	ni_client_state_t *client_state;
 

--- a/src/client/client_state.h
+++ b/src/client/client_state.h
@@ -51,7 +51,7 @@ typedef struct ni_client_state {
 	ni_client_state_scripts_t	scripts;
 } ni_client_state_t;
 
-extern ni_client_state_t *	ni_client_state_new(unsigned int);
+extern ni_client_state_t *	ni_client_state_new(void);
 extern ni_client_state_t *	ni_client_state_clone(ni_client_state_t *);
 extern void		ni_client_state_init(ni_client_state_t *);
 extern void		ni_client_state_reset(ni_client_state_t *);

--- a/src/client/ifconfig.h
+++ b/src/client/ifconfig.h
@@ -63,7 +63,7 @@
 #define NI_NANNY_IFPOLICY_WEIGHT		"weight"
 #define NI_NANNY_IFPOLICY_NAME			"name"
 
-extern ni_bool_t		ni_ifpolicy_match_add_min_state(xml_node_t *, unsigned int);
+extern ni_bool_t		ni_ifpolicy_match_add_min_state(xml_node_t *, ni_fsm_state_t);
 extern ni_bool_t		ni_ifpolicy_match_add_link_type(xml_node_t *, unsigned int);
 extern xml_node_t *		ni_ifpolicy_generate_match(const ni_string_array_t *, const char *);
 extern ni_bool_t		ni_ifpolicy_name_is_valid(const char *);

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -231,7 +231,7 @@ __ni_ifworker_new(ni_ifworker_type_t type, const char *name)
 	w->refcount = 1;
 
 	w->target_range.min = NI_FSM_STATE_NONE;
-	w->target_range.max = __NI_FSM_STATE_MAX;
+	w->target_range.max = NI_FSM_STATE_MAX;
 	w->readonly = FALSE;
 	w->args.release = NI_TRISTATE_DEFAULT;
 
@@ -413,7 +413,7 @@ ni_ifworker_reset(ni_ifworker_t *w)
 	w->pending = FALSE;
 
 	w->target_range.min = NI_FSM_STATE_NONE;
-	w->target_range.max = __NI_FSM_STATE_MAX;
+	w->target_range.max = NI_FSM_STATE_MAX;
 }
 
 void
@@ -443,7 +443,7 @@ ni_ifworker_free(ni_ifworker_t *w)
 	w->pending = FALSE;
 
 	w->target_range.min = NI_FSM_STATE_NONE;
-	w->target_range.max = __NI_FSM_STATE_MAX;
+	w->target_range.max = NI_FSM_STATE_MAX;
 
 	ni_string_free(&w->object_path);
 	if (w->device)
@@ -785,7 +785,7 @@ static ni_intmap_t __state_names[] = {
 	{ "lldp-up",		NI_FSM_STATE_LLDP_UP		},
 	{ "addrconf-up",	NI_FSM_STATE_ADDRCONF_UP	},
 	{ "network-up",		NI_FSM_STATE_NETWORK_UP		},
-	{ "max",		__NI_FSM_STATE_MAX		},
+	{ "max",		NI_FSM_STATE_MAX		},
 
 	{ NULL }
 };
@@ -3776,7 +3776,7 @@ ni_fsm_reset_matching_workers(ni_fsm_t *fsm, ni_ifworker_array_t *marked,
 			w->target_range = *target_range;
 		} else {
 			w->target_range.min = NI_FSM_STATE_NONE;
-			w->target_range.max = __NI_FSM_STATE_MAX;
+			w->target_range.max = NI_FSM_STATE_MAX;
 		}
 	}
 }
@@ -3835,7 +3835,7 @@ ni_ifworker_device_delete(ni_ifworker_t *w)
 		ni_ifworker_fail(w, "device has been deleted");
 
 	w->target_range.min = NI_FSM_STATE_NONE;
-	w->target_range.max = __NI_FSM_STATE_MAX;
+	w->target_range.max = NI_FSM_STATE_MAX;
 
 	ni_ifworker_destroy_action_table(w);
 	ni_ifworker_destroy_device_api(w);
@@ -3900,7 +3900,7 @@ ni_ifworker_start(ni_fsm_t *fsm, ni_ifworker_t *w, unsigned long timeout)
 				ni_ifworker_state_name(min_state),
 				ni_ifworker_state_name(max_state));
 
-	if (max_state == __NI_FSM_STATE_MAX) {
+	if (max_state == NI_FSM_STATE_MAX) {
 		if (min_state == NI_FSM_STATE_NONE)
 			return 0;
 
@@ -3910,7 +3910,7 @@ ni_ifworker_start(ni_fsm_t *fsm, ni_ifworker_t *w, unsigned long timeout)
 			return rv;
 	} else if (min_state == NI_FSM_STATE_NONE) {
 		/* No lower bound; bring it down to max level */
-		rv = ni_fsm_schedule_init(fsm, w, __NI_FSM_STATE_MAX - 1, max_state);
+		rv = ni_fsm_schedule_init(fsm, w, NI_FSM_STATE_MAX - 1, max_state);
 		if (rv < 0)
 			return rv;
 	} else {
@@ -4226,7 +4226,7 @@ static ni_bool_t
 ni_ifworker_meta_add_system_netif_check_state_require(ni_ifworker_t *w,
 		ni_ifworker_t *cw, xml_node_t *meta)
 {
-	ni_uint_range_t range = { NI_FSM_STATE_NONE, __NI_FSM_STATE_MAX };
+	ni_uint_range_t range = { NI_FSM_STATE_NONE, NI_FSM_STATE_MAX };
 	const ni_fsm_transition_t *action;
 	const char *attr;
 
@@ -4732,7 +4732,7 @@ ni_ifworker_netif_resolve_cb(xml_node_t *node, const ni_xs_type_t *type, const x
 		} else
 #endif
 		if (ni_string_eq(mchild->name, "require")) {
-			unsigned int min_state = NI_FSM_STATE_NONE, max_state = __NI_FSM_STATE_MAX;
+			unsigned int min_state = NI_FSM_STATE_NONE, max_state = NI_FSM_STATE_MAX;
 			const char *method;
 
 			/* Ignore if there is no check attribute */
@@ -4858,7 +4858,7 @@ ni_fsm_refresh_state(ni_fsm_t *fsm)
 
 		/* Set initial state of existing devices */
 		if (w->object != NULL)
-			ni_ifworker_update_state(w, NI_FSM_STATE_DEVICE_EXISTS, __NI_FSM_STATE_MAX);
+			ni_ifworker_update_state(w, NI_FSM_STATE_DEVICE_EXISTS, NI_FSM_STATE_MAX);
 	}
 	ni_fsm_events_unblock(fsm);
 
@@ -5067,7 +5067,7 @@ ni_fsm_recv_new_modem(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh
 
 	/* Don't touch devices we're done with */
 	if (!found->done)
-		ni_ifworker_update_state(found, NI_FSM_STATE_DEVICE_EXISTS, __NI_FSM_STATE_MAX);
+		ni_ifworker_update_state(found, NI_FSM_STATE_DEVICE_EXISTS, NI_FSM_STATE_MAX);
 
 	return found;
 }

--- a/src/modem-manager.c
+++ b/src/modem-manager.c
@@ -533,7 +533,7 @@ ni_modem_get_client_state(ni_modem_t *dev)
 		return NULL;
 
 	if (!dev->client_state)
-		dev->client_state = ni_client_state_new(0);
+		dev->client_state = ni_client_state_new();
 
 	return dev->client_state;
 }
@@ -721,7 +721,7 @@ ni_modem_manager_signal(ni_dbus_connection_t *conn, ni_dbus_message_t *msg, void
 		if (!dbus_message_get_args(msg, &error, DBUS_TYPE_UINT32, &quality, DBUS_TYPE_INVALID))
 			goto bad_vibes;
 
-		ni_debug_modem("%s: quality changed %u -> %u", object_path, 
+		ni_debug_modem("%s: quality changed %u -> %u", object_path,
 				modem->gsm.signal_quality, quality);
 		modem->gsm.signal_quality = quality;
 	} else

--- a/src/names.c
+++ b/src/names.c
@@ -816,7 +816,7 @@ ni_lldp_system_capability_name_to_type(const char *name)
 }
 
 const char *
-ni_lldp_system_capability_type_to_name(unsigned int type)
+ni_lldp_system_capability_type_to_name(ni_lldp_destination_t type)
 {
 	return ni_format_uint_maybe_mapped(type, __ni_lldp_systemcap_names);
 }

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -679,7 +679,7 @@ ni_netdev_get_client_state(ni_netdev_t *dev)
 		return NULL;
 
 	if (!dev->client_state)
-		dev->client_state = ni_client_state_new(0);
+		dev->client_state = ni_client_state_new();
 
 	return dev->client_state;
 }
@@ -704,21 +704,12 @@ ni_netdev_load_client_state(ni_netdev_t *dev)
 void
 ni_netdev_discover_client_state(ni_netdev_t *dev)
 {
-	ni_fsm_state_t state = NI_FSM_STATE_DEVICE_EXISTS;
 	ni_client_state_t *cs;
 
 	if (!dev)
 		return;
 
-	if (ni_netdev_device_is_up(dev))
-		state = NI_FSM_STATE_DEVICE_UP;
-	if (ni_netdev_link_is_up(dev))
-		state = NI_FSM_STATE_LINK_UP;
-	if (ni_netdev_network_is_up(dev))
-		state = NI_FSM_STATE_LINK_UP;
-
-	cs = ni_client_state_new(state);
-
+	cs = ni_client_state_new();
 	ni_netdev_set_client_state(dev, cs);
 }
 

--- a/src/xml-writer.c
+++ b/src/xml-writer.c
@@ -15,10 +15,8 @@
  *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *	GNU General Public License for more details.
  *
- *	You should have received a copy of the GNU General Public License along
- *	with this program; if not, see <http://www.gnu.org/licenses/> or write 
- *	to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
- *	Boston, MA 02110-1301 USA.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
 #ifdef HAVE_CONFIG_H
@@ -182,7 +180,7 @@ xml_node_sprint(const xml_node_t *node)
 }
 
 int
-xml_node_hash(const xml_node_t *node, unsigned int algo,
+xml_node_hash(const xml_node_t *node, ni_hashctx_algo_t algo,
 		void *md_buffer, size_t md_size)
 {
 	xml_writer_t writer;

--- a/testing/cstate-test.c
+++ b/testing/cstate-test.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
 	ni_global.config = ni_config_new();
 	ni_enable_debug("all");
 
-	if (!(cs = ni_client_state_new(NI_FSM_STATE_DEVICE_UP)))
+	if (!(cs = ni_client_state_new()))
 		return 1;
 
 	ni_client_state_debug("Test0", cs, "print");


### PR DESCRIPTION
- Fix inconsistent function declarations with unsinged int instead of ni_fsm_state_t
- Remove unused ni_fsm_state_t state argument artefact from ni_client_state_new
- Remove __ prefix from NI_FSM_STATE_MAX enum constant.