### PR TITLE
client: fix crash in hierarchy traversing (bsc#1226664)

### DIFF
--- a/autoip4/autoip.h
+++ b/autoip4/autoip.h
@@ -24,7 +24,9 @@ struct ni_autoip_device {
 	unsigned int		users;
 
 	char *			ifname;
-	ni_linkinfo_t		link;
+	struct ni_autoip_link {
+		unsigned int	ifindex;
+	} link;
 
 	ni_arp_socket_t *	arp_socket;
 	ni_capture_devinfo_t	devinfo;

--- a/autoip4/device.c
+++ b/autoip4/device.c
@@ -139,7 +139,8 @@ ni_autoip_device_free(ni_autoip_device_t *dev)
 	ni_autoip_device_drop_lease(dev);
 	ni_autoip_device_close(dev);
 
-	ni_string_free(&dev->devinfo.ifname);
+	ni_capture_devinfo_destroy(&dev->devinfo);
+
 	ni_string_free(&dev->ifname);
 
 	for (pos = &ni_autoip_active; *pos; pos = &(*pos)->next) {

--- a/client/ethtool.c
+++ b/client/ethtool.c
@@ -1230,7 +1230,7 @@ ni_do_ethtool(const char *caller, int argc, char **argv)
 	};
 	int c, n, status = NI_WICKED_RC_USAGE;
 	const struct ethtool_opt *opt;
-	ni_netdev_ref_t ref = { 0, NULL };
+	ni_netdev_ref_t ref = NI_NETDEV_REF_INIT;
 	ni_ethtool_t *ethtool = NULL;
 
 	optind = 1;
@@ -1267,7 +1267,7 @@ ni_do_ethtool(const char *caller, int argc, char **argv)
 	}
 
 	status = NI_WICKED_RC_ERROR;
-	ni_netdev_ref_init(&ref, argv[optind], ni_netdev_name_to_index(argv[optind]));
+	ni_netdev_ref_set(&ref, argv[optind], ni_netdev_name_to_index(argv[optind]));
 	if (!ref.index) {
 		fprintf(stderr, "%s: cannot find interface with name '%s'\n", argv[0], argv[optind]);
 		goto cleanup;

--- a/client/redfish.c
+++ b/client/redfish.c
@@ -2102,6 +2102,7 @@ ni_mchi_net_dev_new(ni_mchi_net_dev_type_t type)
 	if (dev) {
 		dev->refcount = 1;
 		dev->type = type;
+		ni_netdev_ref_init(&dev->device);
 		ni_mchi_net_dev_usb_init(&dev->usb);
 		ni_mchi_net_dev_pci_init(&dev->pci);
 	}

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -4607,6 +4607,8 @@ try_ppp(ni_suse_ifcfg_array_t *ifcfgs, ni_suse_ifcfg_t *ifcfg)
 		goto done;
 	}
 
+	ni_ppp_mode_init(&ppp->mode, ppp->mode.type);
+
 	if (ni_sysconfig_get_boolean(sc, "PPPDEBUG", &bval))
 		ppp->config.debug = bval;
 

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -186,6 +186,8 @@ extern ni_modem_t *	ni_netconfig_modem_list(ni_netconfig_t *);
 
 extern ni_netconfig_t *	ni_global_state_handle(int);
 
+extern ni_bool_t	ni_linkinfo_init(ni_linkinfo_t *);
+extern void		ni_linkinfo_destroy(ni_linkinfo_t *);
 
 extern ni_netdev_t *	ni_netdev_by_name(ni_netconfig_t *nic, const char *name);
 extern ni_netdev_t *	ni_netdev_by_index(ni_netconfig_t *nic, unsigned int index);

--- a/include/wicked/netinfo.h
+++ b/include/wicked/netinfo.h
@@ -263,10 +263,12 @@ extern void		ni_netdev_clear_event_filters(ni_netdev_t *);
 extern const ni_uuid_t *ni_netdev_add_event_filter(ni_netdev_t *, unsigned int mask);
 extern const ni_uuid_t *ni_netdev_get_event_uuid(ni_netdev_t *, ni_event_t);
 
-extern ni_bool_t	ni_netdev_ref_init(ni_netdev_ref_t *, const char *, unsigned int);
+extern ni_bool_t	ni_netdev_ref_init(ni_netdev_ref_t *);
+extern ni_bool_t	ni_netdev_ref_copy(ni_netdev_ref_t *, const ni_netdev_ref_t *);
 extern ni_bool_t	ni_netdev_ref_set(ni_netdev_ref_t *, const char *, unsigned int);
 extern ni_bool_t	ni_netdev_ref_set_ifname(ni_netdev_ref_t *, const char *);
 extern ni_bool_t	ni_netdev_ref_set_ifindex(ni_netdev_ref_t *, unsigned int);
+extern ni_bool_t	ni_netdev_ref_set_netnsid(ni_netdev_ref_t *, unsigned int);
 extern ni_netdev_t *	ni_netdev_ref_resolve(const ni_netdev_ref_t *, ni_netconfig_t *);
 extern ni_netdev_t *	ni_netdev_ref_bind_ifindex(ni_netdev_ref_t *, ni_netconfig_t *);
 extern ni_netdev_t *	ni_netdev_ref_bind_ifname (ni_netdev_ref_t *, ni_netconfig_t *);

--- a/include/wicked/types.h
+++ b/include/wicked/types.h
@@ -77,12 +77,15 @@ typedef struct ni_event_filter			ni_event_filter_t;
 typedef struct ni_modem				ni_modem_t;
 typedef struct ni_pci_dev			ni_pci_dev_t;
 
+#define NI_NETNSID_DEFAULT			-1U
+
 typedef struct ni_netdev_ref {
+	unsigned int				ns_id;	/* in netnsid */
 	unsigned int				index;	/* by ifindex */
 	char *					name;	/* by ifname  */
 } ni_netdev_ref_t;
 
-#define NI_NETDEV_REF_INIT			{ .index = 0, .name = NULL }
+#define NI_NETDEV_REF_INIT			{ .ns_id = NI_NETNSID_DEFAULT }
 
 typedef struct ni_netdev_ref_array {
 	unsigned int				count;

--- a/src/addrconf.c
+++ b/src/addrconf.c
@@ -477,6 +477,7 @@ ni_addrconf_updater_new(const ni_addrconf_action_static_t *table, const ni_netde
 		}
 		updater->event  = event;
 		ni_timer_get_time(&updater->started);
+		ni_netdev_ref_init(&updater->device);
 		if (dev)
 			ni_netdev_ref_set(&updater->device, dev->name, dev->link.ifindex);
 	}

--- a/src/auto6.c
+++ b/src/auto6.c
@@ -101,6 +101,7 @@ ni_auto6_new(const ni_netdev_t *dev)
 	if (auto6) {
 		auto6->enabled = TRUE;
 		auto6->update = NI_TRISTATE_DEFAULT;
+		ni_netdev_ref_init(&auto6->device);
 		ni_netdev_ref_set(&auto6->device, dev->name, dev->link.ifindex);
 	}
 	return auto6;

--- a/src/bonding.c
+++ b/src/bonding.c
@@ -194,6 +194,8 @@ __ni_bonding_init(ni_bonding_t *bonding)
 	bonding->lp_interval = 1;
 	bonding->ad_actor_sys_prio = 65535;
 	ni_link_address_init(&bonding->ad_actor_system);
+	ni_netdev_ref_init(&bonding->primary_slave);
+	ni_netdev_ref_init(&bonding->active_slave);
 }
 
 /*

--- a/src/capture.c
+++ b/src/capture.c
@@ -613,6 +613,7 @@ ni_capture_devinfo_destroy(ni_capture_devinfo_t *devinfo)
 	if (devinfo) {
 		ni_string_free(&devinfo->ifname);
 		memset(devinfo, 0, sizeof(*devinfo));
+		ni_link_address_init(&devinfo->hwaddr);
 	}
 }
 

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -87,7 +87,9 @@ ni_dhcp4_device_free(ni_dhcp4_device_t *dev)
 	ni_dhcp4_device_drop_lease(dev);
 	ni_dhcp4_device_drop_best_offer(dev);
 	ni_dhcp4_device_stop(dev);
-	ni_string_free(&dev->system.ifname);
+
+	ni_capture_devinfo_destroy(&dev->system);
+
 	ni_string_free(&dev->ifname);
 
 	for (pos = &ni_dhcp4_active; *pos; pos = &(*pos)->next) {

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -58,7 +58,7 @@ __ni_system_ethernet_refresh(ni_netdev_t *dev)
 	ethernet = ni_ethernet_new();
 	ethernet->permanent_address.type = dev->link.hwaddr.type;
 	if ((ethtool = ni_netdev_get_ethtool(dev))) {
-		ni_netdev_ref_t ref;
+		ni_netdev_ref_t ref = NI_NETDEV_REF_INIT;
 
 		ref.name = dev->name;
 		ref.index = dev->link.ifindex;

--- a/src/ethtool.c
+++ b/src/ethtool.c
@@ -3731,7 +3731,7 @@ static ni_bool_t
 ni_ethtool_refresh(ni_netdev_t *dev)
 {
 	ni_ethtool_t *ethtool;
-	ni_netdev_ref_t ref;
+	ni_netdev_ref_t ref = NI_NETDEV_REF_INIT;
 
 	if (!dev || !(ethtool = ni_netdev_get_ethtool(dev)))
 		return FALSE;
@@ -3766,7 +3766,7 @@ ni_system_ethtool_refresh(ni_netdev_t *dev)
 int
 ni_system_ethtool_setup(ni_netconfig_t *nc, ni_netdev_t *dev, const ni_netdev_t *cfg)
 {
-	ni_netdev_ref_t ref;
+	ni_netdev_ref_t ref = NI_NETDEV_REF_INIT;
 
 	if (!ni_netdev_device_is_ready(dev) || !dev->link.ifindex)
 		return -1;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -4525,13 +4525,13 @@ ni_fsm_print_config_device_worker_hierarchy(const ni_fsm_t *fsm,
 
 		if (w->lowerdev == c) {
 			ni_fsm_print_config_device_worker_hierarchy(fsm, c,
-					guard, depth, "+-- ", marked, logfn);
+					guard, depth, "--> ", marked, logfn);
 			continue;
 		}
 
 		if (c->masterdev == w) {
 			ni_fsm_print_config_device_worker_hierarchy(fsm, c,
-					guard, depth, "*-- ", marked, logfn);
+					guard, depth, "^-- ", marked, logfn);
 			continue;
 		}
 	}
@@ -4621,13 +4621,13 @@ ni_fsm_print_system_device_worker_hierarchy(const ni_fsm_t *fsm,
 
 		if (ni_string_eq(w->device->link.lowerdev.name, c->name)) {
 			ni_fsm_print_system_device_worker_hierarchy(fsm, c,
-					guard, depth, "+-- ", marked, logfn);
+					guard, depth, "--> ", marked, logfn);
 			continue;
 		}
 
 		if (ni_string_eq(c->device->link.masterdev.name, w->name)) {
 			ni_fsm_print_system_device_worker_hierarchy(fsm, c,
-					guard, depth, "*-- ", marked,  logfn);
+					guard, depth, "^-- ", marked,  logfn);
 			continue;
 		}
 	}

--- a/src/icmpv6.c
+++ b/src/icmpv6.c
@@ -111,7 +111,8 @@ ni_icmpv6_ra_socket_new(const ni_netdev_ref_t *ref, const ni_hwaddr_t *hwa)
 	if (!(ras = calloc(1, sizeof(*ras))))
 		return NULL;
 
-	ni_netdev_ref_init(&ras->dev, ref->name, ref->index);
+	ni_netdev_ref_init(&ras->dev);
+	ni_netdev_ref_set(&ras->dev, ref->name, ref->index);
 
 	ni_link_address_init(&ras->hwa);
 	if (hwa && hwa->len) {

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -55,12 +55,15 @@ ni_netdev_new(const char *name, unsigned int index)
 
 	dev->users = 1;
 	dev->link.type = NI_IFTYPE_UNKNOWN;
-	dev->link.hwaddr.type = ARPHRD_VOID;
-	dev->link.hwpeer.type = ARPHRD_VOID;
-	dev->link.ifindex = index;
 
-	if (name)
-		dev->name = xstrdup(name);
+	dev->link.ifindex = index;
+	ni_string_dup(&dev->name, name);
+
+	ni_link_address_init(&dev->link.hwaddr);
+	ni_link_address_init(&dev->link.hwpeer);
+
+	ni_netdev_ref_init(&dev->link.lowerdev);
+	ni_netdev_ref_init(&dev->link.masterdev);
 
 	return dev;
 }

--- a/src/ovs.c
+++ b/src/ovs.c
@@ -37,7 +37,8 @@ ni_ovs_bridge_new(void)
 	ni_ovs_bridge_t *ovsbr;
 
 	ovsbr = xcalloc(1, sizeof(*ovsbr));
-	/* ni_ovs_bridge_config_init(&ovsbr->conf); */
+	if (ovsbr)
+		ni_ovs_bridge_config_init(&ovsbr->config);
 	return ovsbr;
 }
 
@@ -53,7 +54,10 @@ ni_ovs_bridge_free(ni_ovs_bridge_t *ovsbr)
 void
 ni_ovs_bridge_config_init(ni_ovs_bridge_config_t *conf)
 {
-	memset(conf, 0, sizeof(*conf));
+	if (conf) {
+		memset(conf, 0, sizeof(*conf));
+		ni_netdev_ref_init(&conf->vlan.parent);
+	}
 }
 
 void
@@ -635,6 +639,8 @@ ni_ovs_bridge_port_info_new(void)
 	ni_ovs_bridge_port_info_t *info;
 
 	info = calloc(1, sizeof(*info));
+	if (info)
+		ni_netdev_ref_init(&info->bridge);
 	return info;
 }
 

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -169,6 +169,13 @@ ni_ppp_mode_init(ni_ppp_mode_t *mode, ni_ppp_mode_type_t type)
 {
 	memset(mode, 0, sizeof(*mode));
 	mode->type = type;
+	switch (mode->type) {
+	case NI_PPP_MODE_PPPOE:
+		ni_netdev_ref_init(&mode->pppoe.device);
+		break;
+	default:
+		break;
+	}
 }
 
 
@@ -177,7 +184,6 @@ ni_ppp_mode_copy(ni_ppp_mode_t *new_mode, ni_ppp_mode_t *old_mode)
 {
 	ni_ppp_mode_pppoe_t *new_pppoe;
 	ni_ppp_mode_pppoe_t *old_pppoe;
-	ni_netdev_ref_t *old_device;
 
 	if (!new_mode || !old_mode)
 		return;
@@ -187,8 +193,7 @@ ni_ppp_mode_copy(ni_ppp_mode_t *new_mode, ni_ppp_mode_t *old_mode)
 	case NI_PPP_MODE_PPPOE:
 		new_pppoe = &new_mode->pppoe;
 		old_pppoe = &old_mode->pppoe;
-		old_device = &old_pppoe->device;
-		ni_netdev_ref_init(&new_pppoe->device, old_device->name, old_device->index);
+		ni_netdev_ref_copy(&new_pppoe->device, &old_pppoe->device);
 		break;
 	default:
 		break;

--- a/src/pppd.c
+++ b/src/pppd.c
@@ -572,7 +572,7 @@ ni_pppd_config_file_read(const char *instance, ni_ppp_t *ppp)
 				goto done;
 
 			if (nc && (dev = ni_netdev_by_name(nc, var->name)))
-				ni_netdev_ref_init(&ppp->mode.pppoe.device,
+				ni_netdev_ref_set(&ppp->mode.pppoe.device,
 						dev->name, dev->link.ifindex);
 		}
 	}

--- a/src/update.c
+++ b/src/update.c
@@ -161,6 +161,7 @@ ni_updater_source_new(void)
 	src = xcalloc(1, sizeof(*src));
 	if (src) {
 		src->refcount = 1;
+		ni_netdev_ref_init(&src->device);
 	}
 	return src;
 }
@@ -387,6 +388,7 @@ ni_updater_job_new(ni_updater_job_t **list, const ni_addrconf_lease_t *lease,
 
 	job->nr = job_nr++; /* for debugging purposes only */
 	job->refcount = 1;
+	ni_netdev_ref_init(&job->device);
 	if (!ni_netdev_ref_set(&job->device, ifname, ifindex)) {
 		free(job);
 		return NULL;

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -765,6 +765,8 @@ static ni_bool_t
 ni_wpa_nif_init(ni_wpa_nif_t *wif, const char *ifname, unsigned int ifindex)
 {
 	memset(wif, 0, sizeof(*wif));
+
+	ni_netdev_ref_init(&wif->device);
 	ni_netdev_ref_set(&wif->device, ifname, ifindex);
 
 	ni_debug_verbose(NI_LOG_DEBUG3, NI_TRACE_WPA,


### PR DESCRIPTION
Added a loop guard to system and config interface worker hierarchy traversing
logged as debug or in a --dry-run and fixed resolving of link reference names
pointing to another netnsid and causing such a loop and wicked ifup crash in
systemd-nspawn containers using macvlans.