### PR TITLE
wireless: add frequency-list in station mode (jsc#PED-8715)

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1420,6 +1420,12 @@ __ni_compat_generate_wireless_network(xml_node_t *parent, ni_wireless_network_t 
 		ni_string_free(&tmp);
 	}
 
+	if (net->frequency_list.count > 0) {
+		xml_node_new_element("frequency-list", network,
+				ni_stringbuf_join(&buf, &net->frequency_list, " "));
+		ni_stringbuf_destroy(&buf);
+	}
+
 	if (net->fragment_size > 0 &&
 			ni_string_printf(&tmp, "%u", net->fragment_size)) {
 		xml_node_new_element("fragment-size", network, tmp);

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -513,9 +513,10 @@ ni_ifstatus_show_wireless(const ni_netdev_t *dev, ni_bool_t verbose)
 		else
 			duration = 0;
 
-		if_printf("", "wireless:", "bssid %s, signal %d, duration %us\n",
+		if_printf("", "wireless:", "bssid %s, signal %d, channel %u (%uMHz), duration %us\n",
 			ni_link_address_print(&wlan->assoc.bssid),
-			wlan->assoc.signal, duration);
+			wlan->assoc.signal, ni_wireless_frequency_to_channel(wlan->assoc.frequency),
+			wlan->assoc.frequency, duration);
 
 	}
 }

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -4058,6 +4058,22 @@ try_add_wireless_net(const ni_sysconfig_t *sc, ni_netdev_t *dev, const char *suf
 		}
 	}
 
+	if (net->mode == NI_WIRELESS_MODE_MANAGED &&
+	    (var = __find_indexed_variable(sc, "WIRELESS_FREQUENCY_LIST", suffix))) {
+
+		ni_string_array_t errors = NI_STRING_ARRAY_INIT;
+		ni_stringbuf_t tmp = NI_STRINGBUF_INIT_DYNAMIC;
+
+		if (!ni_wireless_frequency_list_parse_string(var->value, &net->frequency_list, &errors)) {
+			ni_warn("ifcfg-%s: invalid WIRELESS_FREQUENCY_LIST%s: '%s'",
+					dev->name, suffix,
+					ni_stringbuf_join(&tmp, &errors, " "));
+
+			ni_string_array_destroy(&errors);
+			ni_stringbuf_destroy(&tmp);
+		}
+	}
+
 	/* Default is unset */
 	if ((var = __find_indexed_variable(sc, "WIRELESS_FRAG", suffix))) {
 		if (ni_string_eq_nocase(var->value, "auto") ||

--- a/include/wicked/util.h
+++ b/include/wicked/util.h
@@ -221,6 +221,7 @@ extern void		ni_stringbuf_trim_tail(ni_stringbuf_t *, const char *);
 extern void		ni_stringbuf_trim_empty_lines(ni_stringbuf_t *);
 extern ni_bool_t	ni_stringbuf_empty(const ni_stringbuf_t *);
 extern const char *	ni_stringbuf_join(ni_stringbuf_t *, const ni_string_array_t *, const char *);
+extern const char *	ni_stringbuf_join_uint(ni_stringbuf_t *, const ni_uint_array_t *, const char *);
 
 extern ni_bool_t	ni_file_exists(const char *);
 extern ni_bool_t	ni_file_executable(const char *);

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -154,6 +154,13 @@ typedef enum ni_wireless_pmf {
     NI_WIRELESS_PMF_REQUIRED,
 } ni_wireless_pmf_t;
 
+typedef enum ni_wireless_frequency_set {
+	NI_WIRELESS_FREQUENCY_SET_NONE = 0U,
+	NI_WIRELESS_FREQUENCY_SET_2_4GHz,
+	NI_WIRELESS_FREQUENCY_SET_5GHz,
+	NI_WIRELESS_FREQUENCY_SET_6GHz,
+} ni_wireless_frequency_set_t;
+
 #define NI_WIRELESS_PAIRWISE_CIPHERS_MAX	4
 
 typedef struct ni_wireless_auth_info {
@@ -455,5 +462,8 @@ extern const char *			ni_rfkill_type_string(ni_rfkill_type_t type);
 extern					ni_declare_refcounted_new(ni_wireless_network);
 extern					ni_declare_refcounted_drop(ni_wireless_network);
 extern					ni_declare_refcounted_ref(ni_wireless_network);
+
+extern const char *			ni_wireless_frequency_set_name(ni_wireless_frequency_set_t);
+extern ni_bool_t			ni_wireless_frequency_set_type(const char *, ni_wireless_frequency_set_t *);
 
 #endif /* NI_WICKED_WIRELESS_H */

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -161,6 +161,11 @@ typedef enum ni_wireless_frequency_set {
 	NI_WIRELESS_FREQUENCY_SET_6GHz,
 } ni_wireless_frequency_set_t;
 
+
+/* The frequency must be equal or greater then NI_WIRELESS_FREQUENCY_MIN, otherwise
+ * it is very likely to be a channel number.*/
+#define NI_WIRELESS_FREQUENCY_MIN		250
+
 #define NI_WIRELESS_PAIRWISE_CIPHERS_MAX	4
 
 typedef struct ni_wireless_auth_info {
@@ -218,6 +223,7 @@ struct ni_wireless_network {
 	ni_hwaddr_t			access_point;
 	ni_wireless_mode_t		mode;
 	unsigned int			channel;
+	ni_string_array_t		frequency_list;
 	unsigned int			fragment_size;		/* used with EAP */
 
 	unsigned int			auth_proto;
@@ -465,5 +471,10 @@ extern					ni_declare_refcounted_ref(ni_wireless_network);
 
 extern const char *			ni_wireless_frequency_set_name(ni_wireless_frequency_set_t);
 extern ni_bool_t			ni_wireless_frequency_set_type(const char *, ni_wireless_frequency_set_t *);
+
+extern ni_bool_t			ni_wireless_frequency_list_parse_string(const char *, ni_string_array_t *,
+										ni_string_array_t *);
+extern ni_bool_t			ni_wireless_frequency_list_expand(ni_uint_array_t *,
+									const ni_string_array_t *, ni_string_array_t *);
 
 #endif /* NI_WICKED_WIRELESS_H */

--- a/include/wicked/wireless.h
+++ b/include/wicked/wireless.h
@@ -291,6 +291,7 @@ struct ni_wireless_bss {
 	ni_bool_t		privacy;
 	ni_wireless_mode_t	wireless_mode;
 	uint32_t		channel;
+	uint32_t		frequency;
 	uint32_t		rate_max;
 	int16_t			signal;
 	uint32_t		age;
@@ -349,6 +350,7 @@ struct ni_wireless {
 		ni_hwaddr_t			bssid;
 		int16_t				signal;
 		char *				auth_mode;
+		uint32_t			frequency;
 	} assoc;
 };
 
@@ -468,6 +470,8 @@ extern const char *			ni_rfkill_type_string(ni_rfkill_type_t type);
 extern					ni_declare_refcounted_new(ni_wireless_network);
 extern					ni_declare_refcounted_drop(ni_wireless_network);
 extern					ni_declare_refcounted_ref(ni_wireless_network);
+
+extern unsigned int			ni_wireless_frequency_to_channel(unsigned int);
 
 extern const char *			ni_wireless_frequency_set_name(ni_wireless_frequency_set_t);
 extern ni_bool_t			ni_wireless_frequency_set_type(const char *, ni_wireless_frequency_set_t *);

--- a/man/ifcfg-wireless.5.in
+++ b/man/ifcfg-wireless.5.in
@@ -219,6 +219,26 @@ to get the total number of channels and list the available frequencies.
 Depending on regulations, some frequencies/channels may not be
 available.
 .TP
+\f[CR]WIRELESS_FREQUENCY_LIST <num|frequency\-set>\f[R]
+In station mode, this space\-separated list restricts the frequencies
+(in MHz) to search for the BSS (Access\-Point with ESSID).
+Additionally, the following predefined frequency set names can be used
+to specify frequency ranges:
+.RS
+.IP \[bu] 2
+\f[B]2.4Ghz\f[R]: 2412\-2484 Mhz
+.PD 0
+.P
+.PD
+.IP \[bu] 2
+\f[B]5Ghz\f[R]: 4920\-5885 Mhz
+.PD 0
+.P
+.PD
+.IP \[bu] 2
+\f[B]6Ghz\f[R]: 5935\-7115 Mhz
+.RE
+.TP
 \f[CR]WIRELESS_KEY_[0123] <string|hex>\f[R]
 You can define up to 4 WEP encryption keys.
 You can use WEP with open and sharedkey authentication.

--- a/man/src/ifcfg-wireless.5.md
+++ b/man/src/ifcfg-wireless.5.md
@@ -112,6 +112,16 @@ global to the interface. The description of the variable points this out.
     channels and list the available frequencies. Depending on regulations, some
     frequencies/channels may not be available.
 
+`WIRELESS_FREQUENCY_LIST <num|frequency-set>`
+:   In station mode, this space-separated list restricts the frequencies (in MHz) to
+    search for the BSS (Access-Point with ESSID).
+    Additionally, the following predefined frequency set names can be used to specify
+    frequency ranges:
+
+       - **2.4Ghz**: 2412-2484 Mhz\
+       - **5Ghz**: 4920-5885 Mhz\
+       - **6Ghz**: 5935-7115 Mhz
+
 `WIRELESS_KEY_[0123] <string|hex>`
 :   You can define up to 4 WEP encryption keys. You can use WEP with open and
     sharedkey authentication. The key can be entered in as ASCII string, where

--- a/schema/wireless.xml
+++ b/schema/wireless.xml
@@ -16,6 +16,7 @@
     <mode type="builtin-wireless-mode"/>
     <access-point type="ethernet-address" description="Address of AP to connect to"/>
     <channel type="uint32"/>
+    <frequency-list type="string"/>
     <fragment-size type="uint32"/>
     <frequency type="double"/>
     <key-management type="builtin-wireless-key-mgmt-mask"/>

--- a/schema/wireless.xml
+++ b/schema/wireless.xml
@@ -105,6 +105,7 @@
     <privacy type="boolean"/>
     <mode type="builtin-wireless-mode"/>
     <channel type="uint32"/>
+    <frequency type="uint32"/>
     <rate-max type="uint32"/>
     <signal type="int16"/>
     <age type="uint32"/>
@@ -127,6 +128,7 @@
       <ssid type="string"/>
       <bssid type="ethernet-address"/>
       <signal type="int16"/>
+      <frequency type="uint32"/>
       <duration type="uint32"/>
       <authmode type="string"/>
     </current-connection>

--- a/schema/wireless.xml
+++ b/schema/wireless.xml
@@ -18,7 +18,6 @@
     <channel type="uint32"/>
     <frequency-list type="string"/>
     <fragment-size type="uint32"/>
-    <frequency type="double"/>
     <key-management type="builtin-wireless-key-mgmt-mask"/>
 
     <wep class="dict">

--- a/src/dbus-objects/wireless.c
+++ b/src/dbus-objects/wireless.c
@@ -637,6 +637,8 @@ ni_objectmodel_bss_to_dict(ni_wireless_bss_t *bss, ni_dbus_variant_t *dict, time
 		return FALSE;
 	if (!ni_dbus_dict_add_uint32(dict, "channel", bss->channel))
 		return FALSE;
+	if (!ni_dbus_dict_add_uint32(dict, "frequency", bss->frequency))
+		return FALSE;
 	if (!ni_dbus_dict_add_uint32(dict, "rate-max", bss->rate_max))
 		return FALSE;
 	if (!ni_dbus_dict_add_int16(dict, "signal", bss->signal))
@@ -752,6 +754,8 @@ ni_objectmodel_bss_from_dict(ni_wireless_bss_t *bss, const ni_dbus_variant_t *di
 		return FALSE;
 	if (!ni_dbus_dict_get_uint32(dict, "channel", &bss->channel))
 		return FALSE;
+	if (!ni_dbus_dict_get_uint32(dict, "frequency", &bss->frequency))
+		return FALSE;
 	if (!ni_dbus_dict_get_uint32(dict, "rate-max", &bss->rate_max))
 		return FALSE;
 	if (!ni_dbus_dict_get_int16(dict, "signal", &bss->signal))
@@ -824,6 +828,9 @@ ni_objectmodel_wireless_get_current_connection(const ni_dbus_object_t *object,
 		if (!ni_dbus_dict_add_int16(result, "signal", wlan->assoc.signal))
 			return FALSE;
 
+		if (!ni_dbus_dict_add_uint32(result, "frequency", wlan->assoc.frequency))
+			return FALSE;
+
 		if (ni_timer_get_time(&now) == 0)
 			if (!ni_dbus_dict_add_uint32(result, "duration", now.tv_sec - wlan->assoc.established_time.tv_sec))
 				return FALSE;
@@ -867,6 +874,9 @@ ni_objectmodel_wireless_set_current_connection(ni_dbus_object_t *object,
 				return FALSE;
 
 		if (!ni_dbus_dict_get_int16(argument, "signal", &wlan->assoc.signal))
+			return FALSE;
+
+		if (!ni_dbus_dict_get_uint32(argument, "frequency", &wlan->assoc.frequency))
 			return FALSE;
 
 		if (ni_dbus_dict_get_uint32(argument, "duration", &duration) &&

--- a/src/dbus-objects/wireless.c
+++ b/src/dbus-objects/wireless.c
@@ -343,7 +343,7 @@ ni_objectmodel_get_wireless_request_net(const char *ifname, ni_wireless_network_
 				const ni_dbus_variant_t *var, DBusError *error)
 {
 	const ni_dbus_variant_t *child;
-	const char *string;
+	const char *string = NULL;
 	uint32_t value;
 	dbus_bool_t boolean;
 
@@ -390,6 +390,23 @@ ni_objectmodel_get_wireless_request_net(const char *ifname, ni_wireless_network_
 
 	if (ni_dbus_dict_get_uint32(var, "channel", &value))
 		net->channel = value;
+
+	if (ni_dbus_dict_get_string(var, "frequency-list", &string)) {
+		ni_string_array_t errors = NI_STRING_ARRAY_INIT;
+		ni_stringbuf_t tmp = NI_STRINGBUF_INIT_DYNAMIC;
+
+		if (!ni_wireless_frequency_list_parse_string(string, &net->frequency_list, &errors)) {
+			if (!dbus_error_is_set(error))
+				dbus_set_error(error, DBUS_ERROR_INVALID_ARGS,
+						"%s: invalid frequency-list: '%s'",
+						ifname,
+						ni_stringbuf_join(&tmp, &errors, " ")),
+
+			ni_string_array_destroy(&errors);
+			ni_stringbuf_destroy(&tmp);
+			return FALSE;
+		}
+	}
 
 	if (ni_dbus_dict_get_uint32(var, "fragment-size", &value))
 		net->fragment_size = value;

--- a/src/util.c
+++ b/src/util.c
@@ -2565,6 +2565,24 @@ ni_stringbuf_join(ni_stringbuf_t *buf, const ni_string_array_t *nsa, const char 
 	return buf->string ? buf->string + len : NULL;
 }
 
+const char *
+ni_stringbuf_join_uint(ni_stringbuf_t *buf, const ni_uint_array_t *nsa, const char *sep)
+{
+	unsigned int i;
+	size_t len;
+
+	if (!buf || !nsa)
+		return NULL;
+
+	len = buf->len;
+	for (i = 0; i < nsa->count; ++i) {
+		if (sep && buf->len)
+			ni_stringbuf_puts(buf, sep);
+		ni_stringbuf_printf(buf, "%u", nsa->data[i]);
+	}
+	return buf->string ? buf->string + len : NULL;
+}
+
 inline static size_t
 __ni_stringbuf_size(ni_stringbuf_t *sb, size_t len)
 {

--- a/src/wireless.c
+++ b/src/wireless.c
@@ -1722,6 +1722,27 @@ ni_wireless_name_to_pmf(const char *val, ni_wireless_pmf_t *out)
 	return ni_parse_uint_mapped(val, __ni_wireless_pmf_names, out) == 0;
 }
 
+static const ni_intmap_t	ni_wireless_frequency_set_names[] = {
+	{ "2.4GHz",		NI_WIRELESS_FREQUENCY_SET_2_4GHz	},
+	{ "2,4GHz",		NI_WIRELESS_FREQUENCY_SET_2_4GHz	},
+	{ "5GHz",		NI_WIRELESS_FREQUENCY_SET_5GHz		},
+	{ "6GHz",		NI_WIRELESS_FREQUENCY_SET_6GHz		},
+
+	{ NULL,			NI_WIRELESS_FREQUENCY_SET_NONE		}
+};
+
+const char *
+ni_wireless_frequency_set_name(ni_wireless_frequency_set_t set)
+{
+	return ni_format_uint_mapped(set, ni_wireless_frequency_set_names);
+}
+
+ni_bool_t
+ni_wireless_frequency_set_type(const char *name, ni_wireless_frequency_set_t *set)
+{
+	return ni_parse_uint_mapped(name, ni_wireless_frequency_set_names, set) == 0;
+}
+
 /*
  * Wireless interface config
  */

--- a/src/wpa-supplicant.c
+++ b/src/wpa-supplicant.c
@@ -1265,7 +1265,7 @@ ni_debug_wpa_print_network_properties(const char *devname, const ni_wpa_net_prop
 		else if (ni_debug_escape_net_property(e->key))
 			value = escape_string;
 		else
-			value = ni_dbus_variant_sprint(&e->datum);
+			value = ni_dbus_variant_print(&sbuf, &e->datum);
 
 		ni_debug_wpa("%s:     %-10s: %s", devname, e->key, value);
 		ni_stringbuf_destroy(&sbuf);


### PR DESCRIPTION
* introduce new `WIRELESS_FREQUENCY_LIST` and `<frequency-list>`
  * It is possible to specify a frequency directly or use one of the following aliases `2.5GHz`, `5GHz`, `6GHz`.
* add `channel/frequency` info into `wicked ifstatus --verbose wlanX`
* add `frequency` to scan results

### Example wicked ifstatus output:
```bash
tw-1:~ # wicked ifstatus --verbose  wlan1
wlan1           up
      link:     #6, state up, mtu 1500
      type:     wireless, state established, ssid MySSID Muha, WPA2-PSK+WPA-PSK
      wireless: bssid 02:00:00:00:00:00, signal -30, channel 6 (2437MHz), duration 680s
      control:  none

...
```

### Manpage output:
![Screenshot from 2024-07-16 11-18-39](https://github.com/user-attachments/assets/15cba2b6-6240-4c29-96d6-ae0b71dc5fb0)

