### PR TITLE
client: fix to set and use origin in loaded config (bsc#1226125)

### DIFF
--- a/client/ifcheck.c
+++ b/client/ifcheck.c
@@ -340,7 +340,7 @@ ni_do_ifcheck(int argc, char **argv)
 		}
 	}
 
-	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE, TRUE)) {
+	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE)) {
 		status = NI_WICKED_RC_NOT_CONFIGURED;
 		goto cleanup;
 	}

--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -308,7 +308,7 @@ usage:
 		}
 	}
 
-	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE, TRUE)) {
+	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE)) {
 		status = NI_WICKED_RC_NOT_CONFIGURED;
 		goto cleanup;
 	}

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -844,7 +844,7 @@ ni_do_ifstatus(int argc, char **argv)
 			ni_string_array_copy(&opt_ifconfig, sources);
 	}
 
-	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE, TRUE)) {
+	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, TRUE)) {
 		status = NI_WICKED_ST_ERROR;
 		goto cleanup;
 	}

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -679,7 +679,7 @@ usage:
 		}
 	}
 
-	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, check_prio, TRUE)) {
+	if (!ni_ifconfig_load(fsm, opt_global_rootdir, &opt_ifconfig, check_prio)) {
 		status = NI_WICKED_RC_NOT_CONFIGURED;
 		goto cleanup;
 	}

--- a/client/wicked-client.h
+++ b/client/wicked-client.h
@@ -149,8 +149,7 @@ extern unsigned int		ni_compat_generate_interfaces(xml_document_array_t *, ni_co
 extern unsigned int		ni_compat_generate_policies(xml_document_array_t *, ni_compat_ifconfig_t *, ni_bool_t, ni_bool_t);
 extern void			ni_compat_netdev_set_origin(ni_compat_netdev_t *, const char *, const char *);
 
-extern ni_bool_t		ni_ifconfig_load(ni_fsm_t *, const char *, ni_string_array_t *,
-						ni_bool_t, ni_bool_t);
+extern ni_bool_t		ni_ifconfig_load(ni_fsm_t *, const char *, ni_string_array_t *, ni_bool_t);
 
 extern const ni_string_array_t *ni_config_sources(const char *);
 

--- a/src/client/policy.c
+++ b/src/client/policy.c
@@ -304,15 +304,15 @@ ni_convert_cfg_into_policy_doc(xml_document_t *doc)
 	xml_node_t *root, *match, *policy;
 	const char *origin;
 	const char *ifname;
+	char *name = NULL;
 
-	if (xml_document_is_empty(doc))
+	if (!(root = xml_document_root(doc)))
 		return NULL;
 
-	root = xml_document_root(doc);
-	if (ni_string_empty(root->name))
+	if (ni_string_empty(root->name) || !root->children)
 		return NULL;
 
-	origin = xml_node_location_filename(root);
+	origin = ni_ifconfig_get_origin(root);
 	if (ni_string_empty(origin))
 		return NULL;
 
@@ -329,8 +329,8 @@ ni_convert_cfg_into_policy_doc(xml_document_t *doc)
 	}
 
 	if (!ni_ifconfig_is_config(root)) {
-		ni_error("Invalid object found in file %s: neither an %s nor %s",
-			origin, NI_CLIENT_IFCONFIG, NI_NANNY_IFPOLICY);
+		ni_error("Unknown document node '%s' found in file %s: neither an %s nor %s",
+				root->name, origin, NI_CLIENT_IFCONFIG, NI_NANNY_IFPOLICY);
 		return NULL;
 	}
 
@@ -346,7 +346,9 @@ ni_convert_cfg_into_policy_doc(xml_document_t *doc)
 		return NULL;
 	}
 
-	policy = ni_convert_cfg_into_policy_node(root, match, ifname, origin);
+	name = ni_ifpolicy_name_from_ifname(ifname);
+	policy = ni_convert_cfg_into_policy_node(root, match, name, origin);
+	ni_string_free(&name);
 	if (policy) {
 		xml_node_location_relocate(policy, origin);
 		xml_document_set_root(doc, policy);

--- a/src/client/policy.c
+++ b/src/client/policy.c
@@ -283,9 +283,13 @@ ni_convert_cfg_into_policy_node(const xml_node_t *ifcfg, xml_node_t *match, cons
 	node = xml_node_clone(ifcfg, ifpolicy);
 	ni_string_dup(&node->name, NI_NANNY_IFPOLICY_MERGE);
 
+	/* apply name and origin to the policy node itself … */
 	ni_var_array_destroy(&ifpolicy->attrs);
 	xml_node_add_attr(ifpolicy, NI_NANNY_IFPOLICY_NAME, name);
 	xml_node_add_attr(ifpolicy, NI_NANNY_IFPOLICY_ORIGIN, origin);
+
+	/* … and remove origin, uuid, ... from policy action */
+	ni_var_array_destroy(&node->attrs);
 
 	/* calculate an UUIDv5 (sha1 checksum) of the policy content */
 	ni_ifconfig_generate_uuid(ifpolicy, &uuid);


### PR DESCRIPTION
When loading and migrating a master xml configuration with
obsolete port array and missed port interface configurations,
the migration hook were unable to inherit the origin from
master configuration cleared by a "read raw config" request,
failed to apply the port configurations caused a no-carrier
setup state on the (bond) master.