### PR TITLE
compat-suse: repair dummy interfaces (boo#1229555)

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -3787,7 +3787,7 @@ try_dummy(ni_suse_ifcfg_array_t *ifcfgs, ni_suse_ifcfg_t *ifcfg)
 		if (iftype && !ni_string_eq_nocase(iftype, "dummy"))
 			return 1;
 
-		if (dev->link.type != NI_IFTYPE_UNKNOWN || !maybe_dummy(dev->name))
+		if (dev->link.type != NI_IFTYPE_UNKNOWN || (!iftype && !maybe_dummy(dev->name)))
 			return 1;
 	} else {
 		if (!ni_sysconfig_get_boolean(sc, "DUMMY", &enabled) || !enabled)


### PR DESCRIPTION
Commit 98b4fb3359ebf48e2466338df2b89e263e0aa609 introduced changes causing dummy interaces configured using "INTERFACETYPE=dummy" or "DUMMY=yes" to presumably inadvertently no longer be recognized. Restore functionality of these settings by only calling the new pattern matching logic if a prior iftype lookup did not yield success. This is needed to continue supporting configuration of dummy interfaces not matching the predefined naming scheme.

The following constellations have been tested:
- "ifcfg-foo" file with "INTERFACETYPE=dummy"
- "ifcfg-foo" file with "DUMMY=yes"
- "ifcfg-dummy1" file without "INTERFACETYPE" or "DUMMY"

Fixes: 98b4fb3359eb ("compat-suse: fix dummy type detection from ifname")
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>