### PR TITLE
systemd: ensure wicked launches after dbus service

### DIFF
--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -1,10 +1,9 @@
 [Unit]
 Description=wicked AutoIPv4 supplicant service
-Requisite=dbus.service
+BindTo=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
-BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-auto4.service.in
+++ b/etc/systemd/wickedd-auto4.service.in
@@ -4,6 +4,7 @@ Requisite=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
+BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -1,10 +1,9 @@
 [Unit]
 Description=wicked DHCPv4 supplicant service
-Requisite=dbus.service
+BindTo=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
-BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-dhcp4.service.in
+++ b/etc/systemd/wickedd-dhcp4.service.in
@@ -4,6 +4,7 @@ Requisite=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
+BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -1,10 +1,9 @@
 [Unit]
 Description=wicked DHCPv6 supplicant service
-Requisite=dbus.service
+BindTo=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
-BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-dhcp6.service.in
+++ b/etc/systemd/wickedd-dhcp6.service.in
@@ -4,6 +4,7 @@ Requisite=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service
 Before=wickedd.service wicked.service network.target
 PartOf=wickedd.service
+BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd-nanny.service.in
+++ b/etc/systemd/wickedd-nanny.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=wicked network nanny service
-Requisite=dbus.service
+BindTo=dbus.service
 After=local-fs.target dbus.service network-pre.target SuSEfirewall2_init.service wickedd.service
 Before=wicked.service network.target
 PartOf=wickedd.service

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -1,10 +1,9 @@
 [Unit]
 Description=wicked network management service daemon
-Requisite=dbus.service
+BindTo=dbus.service
 Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service 
 After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service openvswitch.service
 Before=wickedd-nanny.service wicked.service network.target
-BindsTo=dbus.service
 
 [Service]
 Type=notify

--- a/etc/systemd/wickedd.service.in
+++ b/etc/systemd/wickedd.service.in
@@ -4,6 +4,7 @@ Requisite=dbus.service
 Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service wickedd-auto4.service 
 After=local-fs.target dbus.service isdn.service rdma.service network-pre.target SuSEfirewall2_init.service openvswitch.service
 Before=wickedd-nanny.service wicked.service network.target
+BindsTo=dbus.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
After the change to dbus-broker it was possible for wicked to start before the dbus-broker service was running. Adding `BindsTo: dbus.socket` fixes this.

https://bugzilla.suse.com/show_bug.cgi?id=1229745
https://bugzilla.suse.com/show_bug.cgi?id=1229799
https://bugzilla.suse.com/show_bug.cgi?id=1229800