### PR TITLE
arp: don't set target broadcast hardware address

### DIFF
--- a/src/arp.c
+++ b/src/arp.c
@@ -136,7 +136,6 @@ ni_arp_send_grat_request(ni_arp_socket_t *arph, struct in_addr sip)
 	packet.sip = sip;
 	packet.sha = arph->dev_info.hwaddr;
 	packet.tip = sip;
-	ni_link_address_get_broadcast(arph->dev_info.hwaddr.type, &packet.tha);
 	return ni_arp_send(arph, &packet);
 }
 


### PR DESCRIPTION
According to RFC5227 section 2.1.1, the "'target hardware address' field is ignored and SHOULD be set to all zeroes".
The section 2.3 defines that an announcement is identical, except of the announced IP in sender and target IP field.