### PR TITLE
 team: set arp link watcher interval default to 1s 

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -819,14 +819,22 @@ __ni_compat_generate_team_link_watch(xml_node_t *tnode, const ni_team_link_watch
 			if (!ni_string_empty(arp->target_host))
 				xml_node_new_element("target_host", watch, arp->target_host);
 
-			xml_node_new_element("interval", watch, ni_sprint_uint(arp->interval));
-			xml_node_new_element("init_wait", watch, ni_sprint_uint(arp->init_wait));
+			if (arp->interval)
+				xml_node_new_element("interval", watch, ni_sprint_uint(arp->interval));
+			if (arp->init_wait)
+				xml_node_new_element("init_wait", watch, ni_sprint_uint(arp->init_wait));
 
-			xml_node_new_element("validate_active", watch, ni_format_boolean(arp->validate_active));
-			xml_node_new_element("validate_inactive", watch, ni_format_boolean(arp->validate_inactive));
-			xml_node_new_element("send_always", watch, ni_format_boolean(arp->send_always));
+			if (arp->validate_active)
+				xml_node_new_element("validate_active", watch,
+							ni_format_boolean(arp->validate_active));
+			if (arp->validate_inactive)
+				xml_node_new_element("validate_inactive", watch,
+							ni_format_boolean(arp->validate_inactive));
+			if (arp->send_always)
+				xml_node_new_element("send_always", watch, ni_format_boolean(arp->send_always));
 
-			xml_node_new_element("missed_max", watch, ni_sprint_uint(arp->missed_max));
+			if (arp->missed_max)
+				xml_node_new_element("missed_max", watch, ni_sprint_uint(arp->missed_max));
 
 			if (arp->vlanid != UINT16_MAX)
 				xml_node_new_element("vlanid", watch, ni_sprint_uint(arp->vlanid));
@@ -839,9 +847,12 @@ __ni_compat_generate_team_link_watch(xml_node_t *tnode, const ni_team_link_watch
 			if (!ni_string_empty(nsna->target_host))
 				xml_node_new_element("target_host", watch, nsna->target_host);
 
-			xml_node_new_element("interval", watch, ni_sprint_uint(nsna->interval));
-			xml_node_new_element("init_wait", watch, ni_sprint_uint(nsna->init_wait));
-			xml_node_new_element("missed_max", watch, ni_sprint_uint(nsna->missed_max));
+			if (nsna->interval)
+				xml_node_new_element("interval", watch, ni_sprint_uint(nsna->interval));
+			if (nsna->init_wait)
+				xml_node_new_element("init_wait", watch, ni_sprint_uint(nsna->init_wait));
+			if (nsna->missed_max)
+				xml_node_new_element("missed_max", watch, ni_sprint_uint(nsna->missed_max));
 		}
 		break;
 

--- a/man/ifcfg-team.5.in
+++ b/man/ifcfg-team.5.in
@@ -262,6 +262,10 @@ Hostname or IP address used in ARP request as destination address.
 .TP
 \f[CR]TEAM_LW_ARP_PING_INTERVAL[SUFFIX]\f[R]
 Interval between ARP requests being sent (in milliseconds).
+.RS
+.PP
+Default: \f[B]1000\f[R]
+.RE
 .TP
 \f[CR]TEAM_LW_ARP_PING_INIT_WAIT[SUFFIX]\f[R]
 Delay between link watch initialization and the first ARP request being
@@ -313,6 +317,10 @@ Hostname or IPv6 address used in NS packet as target address.
 .TP
 \f[CR]TEAM_LW_NSNA_PING_INTERVAL[SUFFIX]\f[R]
 Interval between sending NS packets (in milliseconds).
+.RS
+.PP
+Default: \f[B]1000\f[R]
+.RE
 .TP
 \f[CR]TEAM_LW_NSNA_PING_INIT_WAIT[SUFFIX]\f[R]
 Delay between link watch initialization and the first NS packet being

--- a/man/src/ifcfg-team.5.md
+++ b/man/src/ifcfg-team.5.md
@@ -226,6 +226,8 @@ the usual network settings. But you must add additional variables
 `TEAM_LW_ARP_PING_INTERVAL[SUFFIX]`
 :   Interval between ARP requests being sent (in milliseconds).
 
+    Default: **1000**
+
 `TEAM_LW_ARP_PING_INIT_WAIT[SUFFIX]`
 :   Delay between link watch initialization and the first ARP request being
     sent (in milliseconds).
@@ -267,6 +269,8 @@ the usual network settings. But you must add additional variables
 
 `TEAM_LW_NSNA_PING_INTERVAL[SUFFIX]`
 :   Interval between sending NS packets (in milliseconds).
+
+    Default: **1000**
 
 `TEAM_LW_NSNA_PING_INIT_WAIT[SUFFIX]`
 :   Delay between link watch initialization and the first NS packet being sent

--- a/src/team.c
+++ b/src/team.c
@@ -1,7 +1,7 @@
 /*
  *	Team network interface support
  *
- *	Copyright (C) 2015-2023 SUSE LLC
+ *	Copyright (C) 2015-2024 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@
 #include "util_priv.h"
 #include "array_priv.h"
 
+#define NI_TEAM_LW_PING_INTERVAL_DEFAULT	1000
 #define NI_TEAM_LINK_WATCH_ARRAY_CHUNK		4
 
 /*
@@ -280,8 +281,10 @@ ni_team_link_watch_init(ni_team_link_watch_t *lw)
 		break;
 	case NI_TEAM_LINK_WATCH_ARP_PING:
 		lw->arp.vlanid = UINT16_MAX;
+		lw->arp.interval = NI_TEAM_LW_PING_INTERVAL_DEFAULT;
 		break;
 	case NI_TEAM_LINK_WATCH_NSNA_PING:
+		lw->nsna.interval = NI_TEAM_LW_PING_INTERVAL_DEFAULT;
 		break;
 	case NI_TEAM_LINK_WATCH_TIPC:
 		break;


### PR DESCRIPTION
`teamd` version `< 1.32` do not have a default value for link watch
interval. And if the configuration option is missed, the team
interface will never have any active port.