### PR TITLE
dhcp4: add ignore-rfc3927-1-6 wicked-config(5) option (jsc#PED-10855)

### DIFF
--- a/man/wicked-config.5.in
+++ b/man/wicked-config.5.in
@@ -392,6 +392,19 @@ lease time to one hour:
 .PP
 
 .TP
+.B ignore-rfc3927-1-6
+The 169.254.0.0/16 prefix is reserved for dynamic configuration of IPv4 link-local
+addresses, prohibited for other purposes by RFC3927 Section 1.6 and wickedd-dhcp4
+supplicant rejects to request them in offers provided by DHCP servers.
+Administrators should use the RFC1918 prefixes (192.168.0.0/16, 172.16.0.0/12,
+10.0.0.0/8) in their DHCP servers instead.
+
+Enabling this option causes to ignore the RFC3927 Section 1.6 Alternate Use Prohibition:
+.IP
+.B "  <ignore-rfc3927-1-6>true</ignore-rfc3927-1-6>
+.PP
+
+.TP
 .B ignore-server
 Using the \fBip\fB attribute of this element, you can specify the
 IP or HW address (currently ethernet devices only) of a faulty DHCP

--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -133,6 +133,7 @@ ni_config_dhcp4_clone(const ni_config_dhcp4_t *src, const char *device)
 	dst->arp = src->arp;
 	ni_string_dup(&dst->vendor_class, src->vendor_class);
 	dst->lease_time = src->lease_time;
+	dst->ignore_rfc3927_1_6 = src->ignore_rfc3927_1_6;
 	ni_string_array_copy(&dst->ignore_servers, &src->ignore_servers);
 	memcpy(&dst->preferred_server, &src->preferred_server, sizeof(dst->preferred_server));
 	ni_dhcp_option_decl_list_copy(&dst->custom_options, src->custom_options);
@@ -566,6 +567,9 @@ ni_config_parse_addrconf_dhcp4_nodes(ni_config_dhcp4_t *dhcp4, xml_node_t *node)
 		else
 		if (!strcmp(child->name, "lease-time") && child->cdata)
 			ni_parse_uint(child->cdata, &dhcp4->lease_time, 0);
+		else
+		if (!strcmp(child->name, "ignore-rfc3927-1-6") && child->cdata)
+			ni_parse_boolean(child->cdata, &dhcp4->ignore_rfc3927_1_6);
 		else
 		if (!strcmp(child->name, "ignore-server")) {
 			if ((attrval = xml_node_get_attr(child, "ip")) != NULL)

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -138,6 +138,7 @@ typedef struct ni_config_dhcp4 {
 	unsigned int		routes_opts;
 	char *			vendor_class;
 	unsigned int		lease_time;
+	ni_bool_t		ignore_rfc3927_1_6;
 	ni_string_array_t	ignore_servers;
 	ni_config_arp_t		arp;
 

--- a/src/dhcp4/device.c
+++ b/src/dhcp4/device.c
@@ -1069,6 +1069,14 @@ ni_dhcp4_config_max_lease_time(const char *ifname)
 	return dhconf && dhconf->lease_time ? dhconf->lease_time : NI_SECONDS_INFINITE;
 }
 
+ni_bool_t
+ni_dhcp4_config_ignore_rfc3927_1_6(const char *ifname)
+{
+	const ni_config_dhcp4_t *dhconf = ni_config_dhcp4_find_device(ifname);
+
+	return dhconf && dhconf->ignore_rfc3927_1_6;
+}
+
 static void
 ni_dhcp4_config_set_request_options(const char *ifname, ni_uint_array_t *cfg, const ni_string_array_t *req)
 {

--- a/src/dhcp4/dhcp4.h
+++ b/src/dhcp4/dhcp4.h
@@ -309,6 +309,7 @@ extern int		ni_dhcp4_config_ignore_server(const char *);
 extern int		ni_dhcp4_config_have_server_preference(void);
 extern int		ni_dhcp4_config_server_preference_ipaddr(struct in_addr);
 extern int		ni_dhcp4_config_server_preference_hwaddr(const ni_hwaddr_t *);
+extern ni_bool_t	ni_dhcp4_config_ignore_rfc3927_1_6(const char *);
 extern unsigned int	ni_dhcp4_config_max_lease_time(const char *);
 extern void		ni_dhcp4_config_free(ni_dhcp4_config_t *);
 

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -1256,8 +1256,12 @@ ni_dhcp4_build_message(const ni_dhcp4_device_t *dev, unsigned int msg_code,
 		return -1;
 	}
 
-	if (IN_LINKLOCAL(ntohl(lease->dhcp4.address.s_addr))) {
-		ni_error("%s: cannot request a link local address", dev->ifname);
+	if (IN_LINKLOCAL(ntohl(lease->dhcp4.address.s_addr)) &&
+			!ni_dhcp4_config_ignore_rfc3927_1_6(dev->ifname)) {
+		ni_error("%s: Rejecting to request link local address offer prohibited by RFC3927 Section 1.6",
+				dev->ifname);
+		ni_error("%s: Fix the dhcp-server config or set `ignore-rfc3927-1-6` see `man 5 wicked-config`",
+				dev->ifname);
 		goto failed;
 	}
 


### PR DESCRIPTION
The RFC3927 Section 1.6: Alternate Use Prohibition prohibits the use of link-local
IPv4 (zeroconf) address range for other purposes, such as for DHCP.
Enabling this option in wicked-config(5) permits to use the addresses in DHCP.