### PR TITLE
route: fix family and destination processing (bsc#1231060) 

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -1932,12 +1932,18 @@ __ni_compat_generate_static_route(xml_node_t *aconf, const ni_route_t *rp, const
 	char *tmp = NULL;
 	const char *ptr;
 
+	/*
+	 * Each route must have a destination family,
+	 * even address and prefixlen are unspecified
+	 * (default destination 0.0.0.0/0 or ::/0).
+	 */
+	if (rp->destination.ss_family == AF_UNSPEC)
+		return;
+
 	rnode = xml_node_new("route", aconf);
 
-	if (rp->destination.ss_family != AF_UNSPEC && rp->prefixlen != 0) {
-		xml_node_new_element("destination", rnode,
-			ni_sockaddr_prefix_print(&rp->destination, rp->prefixlen));
-	}
+	xml_node_new_element("destination", rnode,
+		ni_sockaddr_prefix_print(&rp->destination, rp->prefixlen));
 
 	__ni_compat_generate_static_route_hops(rnode, &rp->nh, ifname);
 

--- a/src/dbus-objects/addrconf.c
+++ b/src/dbus-objects/addrconf.c
@@ -424,7 +424,7 @@ ni_objectmodel_addrconf_static_request(ni_dbus_object_t *object, unsigned int ad
 	ni_uuid_generate(&lease->uuid);
 
 	if (!__ni_objectmodel_set_address_dict(&lease->addrs, dict, error)
-	 || !__ni_objectmodel_set_route_dict(&lease->routes, dict, error)
+	 || !__ni_objectmodel_set_route_dict(&lease->routes, addrfamily, dict, error)
 	 || !__ni_objectmodel_set_rule_dict(&lease->rules, addrfamily, dict, error)
 	 || !__ni_objectmodel_set_resolver_dict(&lease->resolver, dict, error)) {
 		ni_addrconf_lease_drop(&lease);

--- a/src/dbus-objects/interface.c
+++ b/src/dbus-objects/interface.c
@@ -1424,7 +1424,7 @@ __ni_objectmodel_netif_get_routes(const ni_dbus_object_t *object,
 	ni_netdev_t *ifp = ni_dbus_object_get_handle(object);
 
 	ni_dbus_dict_array_init(result);
-	return __ni_objectmodel_get_route_list(ifp->routes, result, error);
+	return __ni_objectmodel_get_route_list(ifp->routes, AF_UNSPEC, result, error);
 }
 
 static dbus_bool_t
@@ -1435,7 +1435,7 @@ __ni_objectmodel_netif_set_routes(ni_dbus_object_t *object,
 {
 	ni_netdev_t *ifp = ni_dbus_object_get_handle(object);
 
-	return __ni_objectmodel_set_route_list(&ifp->routes, argument, error);
+	return __ni_objectmodel_set_route_list(&ifp->routes, AF_UNSPEC, argument, error);
 }
 
 /*

--- a/src/dbus-objects/model.h
+++ b/src/dbus-objects/model.h
@@ -140,9 +140,11 @@ extern dbus_bool_t		__ni_objectmodel_set_address_list(ni_address_t **list,
 						const ni_dbus_variant_t *argument,
 						DBusError *error);
 extern dbus_bool_t		__ni_objectmodel_get_route_list(ni_route_table_t *list,
+						unsigned int family,
 						ni_dbus_variant_t *result,
 						DBusError *error);
 extern dbus_bool_t		__ni_objectmodel_set_route_list(ni_route_table_t **list,
+						unsigned int family,
 						const ni_dbus_variant_t *result,
 						DBusError *error);
 extern dbus_bool_t		__ni_objectmodel_get_addrconf_lease(const ni_addrconf_lease_t *lease,
@@ -173,12 +175,10 @@ extern dbus_bool_t		__ni_objectmodel_set_address_dict(ni_address_t **list, const
 extern dbus_bool_t		__ni_objectmodel_address_to_dict(const ni_address_t *, ni_dbus_variant_t *);
 extern ni_address_t *		__ni_objectmodel_address_from_dict(ni_address_t **, const ni_dbus_variant_t *);
 
-extern dbus_bool_t		__ni_objectmodel_get_route_dict(ni_route_table_t *list,
-						ni_dbus_variant_t *result,
-						DBusError *error);
-extern dbus_bool_t		__ni_objectmodel_set_route_dict(ni_route_table_t **list,
-						const ni_dbus_variant_t *dict,
-						DBusError *error);
+extern dbus_bool_t		__ni_objectmodel_get_route_dict(ni_route_table_t *list, unsigned int family,
+						ni_dbus_variant_t *result, DBusError *error);
+extern dbus_bool_t		__ni_objectmodel_set_route_dict(ni_route_table_t **list, unsigned int family,
+						const ni_dbus_variant_t *dict, DBusError *error);
 extern dbus_bool_t		__ni_objectmodel_get_rule_dict(ni_rule_array_t *rules, unsigned int family,
 						ni_dbus_variant_t *result, DBusError *error);
 extern dbus_bool_t		__ni_objectmodel_set_rule_dict(ni_rule_array_t **rules, unsigned int family,


### PR DESCRIPTION
- Fix to not omit generation of route destination xml node when prefix length is 0 (default route).
- Fix to use lease family as hint for routes with missing destination in dbus dict (backward compatibility).