### PR TITLE
route: use new array macros and fix on error leaks

### DIFF
--- a/autoip4/fsm.c
+++ b/autoip4/fsm.c
@@ -177,6 +177,7 @@ ni_autoip_fsm_build_lease(ni_autoip_device_t *dev)
 {
 	ni_addrconf_lease_t *lease;
 	ni_sockaddr_t addr;
+	ni_route_t *rp;
 
 	ni_debug_autoip("%s: building lease", dev->ifname);
 	lease = ni_addrconf_lease_new(NI_ADDRCONF_AUTOCONF, AF_INET);
@@ -187,7 +188,9 @@ ni_autoip_fsm_build_lease(ni_autoip_device_t *dev)
 	ni_address_create(AF_INET, 16, &addr, &lease->addrs);
 
 	ni_sockaddr_parse(&addr, "169.254.0.0", AF_INET);
-	ni_route_create(16, &addr, NULL, 0, &lease->routes);
+	rp = ni_route_create(16, &addr, NULL, 0);
+	ni_route_tables_add_route(&lease->routes, rp);
+	ni_route_free(rp);
 
 	lease->state = NI_ADDRCONF_STATE_GRANTED;
 	ni_timer_get_time(&lease->acquired);

--- a/client/dracut/cmdline.c
+++ b/client/dracut/cmdline.c
@@ -646,6 +646,7 @@ parse_ip3(ni_compat_netdev_array_t *nda, char *val, const char *client_ip)
 	unsigned int peer_prefixlen = ~0U;
 	unsigned int client_prefixlen = ~0U;
 	ni_hwaddr_t lladdr;
+	ni_route_t *rp;
 
 	if (ni_string_empty(val))
 		return FALSE;
@@ -715,9 +716,13 @@ parse_ip3(ni_compat_netdev_array_t *nda, char *val, const char *client_ip)
 	}
 	ni_address_create(client_addr.ss_family, client_prefixlen, &client_addr, &nd->dev->addrs);
 
-	// Add the default gw
-	if (!ni_route_create(0, NULL, &gateway_addr, RT_TABLE_MAIN, &nd->dev->routes))
+	// Add the default gw route
+	rp = ni_route_create(0, NULL, &gateway_addr, RT_TABLE_MAIN);
+	if (!ni_route_tables_add_route(&nd->dev->routes, rp)) {
+		ni_route_free(rp);
 		return FALSE;
+	}
+	ni_route_free(rp);
 
 	return TRUE;
 }

--- a/client/redhat/compat-redhat.c
+++ b/client/redhat/compat-redhat.c
@@ -466,11 +466,17 @@ __ni_redhat_addrconf_static(ni_sysconfig_t *sc, ni_compat_netdev_t *compat, cons
 
 	if ((value = ni_sysconfig_get_value(sc, "GATEWAY")) != NULL) {
 		ni_sockaddr_t gateway;
+		ni_route_t *rp;
 
 		if (ni_sockaddr_parse(&gateway, value, AF_INET) < 0)
 			return FALSE;
-		if (ni_route_create(0, NULL, &gateway, 0, &dev->routes) == NULL)
+
+		rp = ni_route_create(0, NULL, &gateway, 0);
+		if (!ni_route_tables_add_route(&dev->routes, rp)) {
+			ni_route_free(rp);
 			return FALSE;
+		}
+		ni_route_free(rp);
 	}
 
 	return TRUE;

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -1221,6 +1221,7 @@ __ni_suse_route_parse(ni_route_table_t **routes, char *buffer, const char *ifnam
 	if (ni_route_tables_find_match(*routes, rp, ni_route_equal_destination)) {
 		ni_debug_readwrite("Skipping route -- duplicate destination: %s/%u",
 				ni_sockaddr_print(&rp->destination), rp->prefixlen);
+		ni_route_free(rp);
 		return 1;
 	}
 

--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -1594,13 +1594,16 @@ ni_suse_parse_rule_line(ni_rule_array_t *rules, char *buffer, const char *ifname
 	if (!(rule = ni_rule_new())) {
 		ni_error("%s[%u]: Unable to allocate routing rule structure",
 				filename, line);
+		ni_string_array_destroy(&opts);
 		return -1;
 	}
 
 	if ((ret = ni_suse_parse_rule(rule, &opts, filename, line))) {
+		ni_string_array_destroy(&opts);
 		ni_rule_free(rule);
 		return ret;
 	}
+	ni_string_array_destroy(&opts);
 
 	if (!ni_rule_array_append_ref(rules, rule)) {
 		ni_rule_free(rule);

--- a/include/wicked/route.h
+++ b/include/wicked/route.h
@@ -163,8 +163,7 @@ extern				ni_declare_refcounted_move(ni_route);
 extern ni_route_t *		ni_route_create(unsigned int prefix_len,
 						const ni_sockaddr_t *dest,
 						const ni_sockaddr_t *gw,
-						unsigned int table,
-						ni_route_table_t **list);
+						unsigned int table);
 extern ni_route_t *		ni_route_clone(const ni_route_t *);
 extern ni_bool_t		ni_route_copy(ni_route_t *, const ni_route_t *);
 extern ni_bool_t		ni_route_equal(const ni_route_t *, const ni_route_t *);

--- a/include/wicked/route.h
+++ b/include/wicked/route.h
@@ -239,14 +239,14 @@ extern ni_route_array_t *	ni_route_array_new(void);
 extern void			ni_route_array_free(ni_route_array_t *);
 extern				ni_declare_ptr_array_init(ni_route);
 extern				ni_declare_ptr_array_destroy(ni_route);
-extern				ni_declare_ptr_array_append(ni_route);
+extern				ni_declare_ptr_array_append_ref(ni_route);
 extern				ni_declare_ptr_array_delete_at(ni_route);
 extern				ni_declare_ptr_array_remove_at(ni_route);
 extern				ni_declare_ptr_array_at(ni_route);
+extern				ni_declare_ptr_array_index(ni_route);
+extern				ni_declare_ptr_array_delete(ni_route);
+extern				ni_declare_ptr_array_remove(ni_route);
 extern				ni_declare_ptr_array_qsort(ni_route);
-extern ni_bool_t		ni_route_array_delete_ref(ni_route_array_t *, const ni_route_t *);
-extern ni_route_t *		ni_route_array_remove_ref(ni_route_array_t *, const ni_route_t *);
-extern ni_route_t *		ni_route_array_ref(ni_route_array_t *, unsigned int);
 extern ni_route_t *		ni_route_array_find_match(ni_route_array_t *, const ni_route_t *,
 					ni_bool_t (*match)(const ni_route_t *, const ni_route_t *));
 extern unsigned int		ni_route_array_find_matches(ni_route_array_t *, const ni_route_t *,
@@ -299,12 +299,12 @@ extern ni_rule_array_t *	ni_rule_array_clone(const ni_rule_array_t *);
 extern void			ni_rule_array_copy(ni_rule_array_t *, const ni_rule_array_t *);
 extern				ni_declare_ptr_array_init(ni_rule);
 extern				ni_declare_ptr_array_destroy(ni_rule);
-extern				ni_declare_ptr_array_index(ni_rule);
-extern				ni_declare_ptr_array_append(ni_rule);
-extern				ni_declare_ptr_array_insert(ni_rule);
+extern				ni_declare_ptr_array_append_ref(ni_rule);
+extern				ni_declare_ptr_array_insert_ref(ni_rule);
 extern				ni_declare_ptr_array_delete_at(ni_rule);
 extern				ni_declare_ptr_array_remove_at(ni_rule);
 extern				ni_declare_ptr_array_at(ni_rule);
+extern				ni_declare_ptr_array_index(ni_rule);
 extern ni_rule_t *		ni_rule_array_find_match(const ni_rule_array_t *, const ni_rule_t *,
 					ni_bool_t (*match)(const ni_rule_t *, const ni_rule_t *));
 extern unsigned int		ni_rule_array_find_matches(const ni_rule_array_t *, const ni_rule_t *,

--- a/src/dbus-objects/misc.c
+++ b/src/dbus-objects/misc.c
@@ -773,10 +773,9 @@ __ni_objectmodel_set_route_list(ni_route_table_t **list, unsigned int family,
 		}
 
 		route->family = family;
-		if (!ni_objectmodel_route_from_dict(route, dict))
-			ni_route_free(route);
-		else if (!ni_route_tables_add_route(list, route))
-			ni_route_free(route);
+		if (ni_objectmodel_route_from_dict(route, dict))
+			ni_route_tables_add_route(list, route);
+		ni_route_free(route);
 	}
 	return TRUE;
 }
@@ -811,11 +810,9 @@ __ni_objectmodel_set_rule_list(ni_rule_array_t **rules, unsigned int family,
 		}
 
 		rule->family = family;
-		if (!ni_objectmodel_rule_from_dict(rule, dict))
-			ni_rule_free(rule);
-		else
-		if (!ni_rule_array_append(*rules, rule))
-			ni_rule_free(rule);
+		if (ni_objectmodel_rule_from_dict(rule, dict))
+			ni_rule_array_append_ref(*rules, rule);
+		ni_rule_free(rule);
 	}
 	return TRUE;
 }
@@ -894,10 +891,9 @@ __ni_objectmodel_set_route_dict(ni_route_table_t **list, unsigned int family,
 		}
 
 		route->family = family;
-		if (!ni_objectmodel_route_from_dict(route, var))
-			ni_route_free(route);
-		else if (!ni_route_tables_add_route(list, route))
-			ni_route_free(route);
+		if (ni_objectmodel_route_from_dict(route, var))
+			ni_route_tables_add_route(list, route);
+		ni_route_free(route);
 	}
 	return TRUE;
 }
@@ -963,11 +959,9 @@ __ni_objectmodel_set_rule_dict(ni_rule_array_t **rules, unsigned int family,
 			return FALSE;
 
 		rule->family = family;
-		if (!ni_objectmodel_rule_from_dict(rule, var))
-			ni_rule_free(rule);
-		else
-		if (!ni_rule_array_append(*rules, rule))
-			ni_rule_free(rule);
+		if (ni_objectmodel_rule_from_dict(rule, var))
+			ni_rule_array_append_ref(*rules, rule);
+		ni_rule_free(rule);
 	}
 	return TRUE;
 }

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -1469,7 +1469,7 @@ ni_dhcp4_decode_csr(ni_buffer_t *bp, ni_route_array_t *routes)
 		if (ni_dhcp4_option_get_sockaddr(bp, &gateway) < 0)
 			return -1;
 
-		rp = ni_route_create(prefix_len, &destination, &gateway, 0, NULL);
+		rp = ni_route_create(prefix_len, &destination, &gateway, 0);
 		ni_route_array_append_ref(routes, rp);
 		ni_route_free(rp);
 	}
@@ -1612,7 +1612,7 @@ ni_dhcp4_decode_static_routes(ni_buffer_t *bp, ni_route_array_t *routes)
 		rp = ni_route_create(guess_prefix_len_sockaddr(&destination),
 				&destination,
 				&gateway,
-				0, NULL);
+				0);
 		ni_route_array_append_ref(routes, rp);
 		ni_route_free(rp);
 	}
@@ -1646,7 +1646,7 @@ ni_dhcp4_decode_routers(ni_buffer_t *bp, ni_route_array_t *routes)
 		if (!ni_sockaddr_is_specified(&gateway))
 			continue;
 
-		rp = ni_route_create(0, NULL, &gateway, 0, NULL);
+		rp = ni_route_create(0, NULL, &gateway, 0);
 		ni_route_array_append_ref(routes, rp);
 		ni_route_free(rp);
 	}
@@ -1896,7 +1896,7 @@ ni_dhcp4_apply_routes(ni_addrconf_lease_t *lease, ni_route_array_t *routes)
 			unsigned int plen = ni_af_address_prefixlen(rp->family);
 
 			if (plen) {
-				r = ni_route_create(plen, &rp->nh.gateway, NULL, 0, NULL);
+				r = ni_route_create(plen, &rp->nh.gateway, NULL, 0);
 				ni_route_array_append_ref(&temp, r);
 				ni_route_free(r);
 			}

--- a/src/dhcp4/protocol.c
+++ b/src/dhcp4/protocol.c
@@ -1470,7 +1470,8 @@ ni_dhcp4_decode_csr(ni_buffer_t *bp, ni_route_array_t *routes)
 			return -1;
 
 		rp = ni_route_create(prefix_len, &destination, &gateway, 0, NULL);
-		ni_route_array_append(routes, rp);
+		ni_route_array_append_ref(routes, rp);
+		ni_route_free(rp);
 	}
 
 	if (bp->underflow)
@@ -1612,7 +1613,8 @@ ni_dhcp4_decode_static_routes(ni_buffer_t *bp, ni_route_array_t *routes)
 				&destination,
 				&gateway,
 				0, NULL);
-		ni_route_array_append(routes, rp);
+		ni_route_array_append_ref(routes, rp);
+		ni_route_free(rp);
 	}
 
 	if (bp->underflow)
@@ -1644,8 +1646,9 @@ ni_dhcp4_decode_routers(ni_buffer_t *bp, ni_route_array_t *routes)
 		if (!ni_sockaddr_is_specified(&gateway))
 			continue;
 
-		if ((rp = ni_route_create(0, NULL, &gateway, 0, NULL)))
-			ni_route_array_append(routes, rp);
+		rp = ni_route_create(0, NULL, &gateway, 0, NULL);
+		ni_route_array_append_ref(routes, rp);
+		ni_route_free(rp);
 	}
 
 	if (bp->underflow)
@@ -1853,7 +1856,7 @@ ni_dhcp4_apply_routes(ni_addrconf_lease_t *lease, ni_route_array_t *routes)
 			continue;
 		if (ni_sockaddr_is_specified(&rp->nh.gateway))
 			continue;
-		ni_route_array_append(&temp, ni_route_ref(rp));
+		ni_route_array_append_ref(&temp, rp);
 	}
 
 	/* now the routes with a gateway - add a
@@ -1870,8 +1873,8 @@ ni_dhcp4_apply_routes(ni_addrconf_lease_t *lease, ni_route_array_t *routes)
 		for (ap = lease->addrs; !added && ap; ap = ap->next) {
 			if (!ni_address_can_reach(ap, &rp->nh.gateway))
 				continue;
-			ni_route_array_append(&temp, ni_route_ref(rp));
-			added = TRUE;
+			if (ni_route_array_append_ref(&temp, rp))
+				added = TRUE;
 		}
 		/* or there is a device route allowing to reach it */
 		for (j = 0; !added && j < temp.count; ++j) {
@@ -1884,16 +1887,20 @@ ni_dhcp4_apply_routes(ni_addrconf_lease_t *lease, ni_route_array_t *routes)
 						&r->destination,
 						&rp->nh.gateway))
 				continue;
-			ni_route_array_append(&temp, ni_route_ref(rp));
-			added = TRUE;
+			if (ni_route_array_append_ref(&temp, rp))
+				added = TRUE;
 		}
 
 		/* otherwise, automatically prepend a device route */
 		if (!added) {
-			unsigned int len = ni_af_address_length(rp->family);
-			r = ni_route_create(len * 8, &rp->nh.gateway, NULL, 0, NULL);
-			ni_route_array_append(&temp, r);
-			ni_route_array_append(&temp, ni_route_ref(rp));
+			unsigned int plen = ni_af_address_prefixlen(rp->family);
+
+			if (plen) {
+				r = ni_route_create(plen, &rp->nh.gateway, NULL, 0, NULL);
+				ni_route_array_append_ref(&temp, r);
+				ni_route_free(r);
+			}
+			ni_route_array_append_ref(&temp, rp);
 		}
 	}
 	ni_route_tables_add_routes(&lease->routes, &temp);

--- a/src/ifconfig.c
+++ b/src/ifconfig.c
@@ -5594,7 +5594,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 			ni_stringbuf_destroy(&out);
 
 			rule->seq = r ? __ni_global_seqno : 0;
-			ni_rule_array_append(&mod_rules, ni_rule_ref(rule));
+			ni_rule_array_append_ref(&mod_rules, rule);
 		}
 	} else {
 		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,
@@ -5623,7 +5623,7 @@ __ni_netdev_update_rules(ni_netconfig_t *nc, ni_netdev_t *dev,
 					dev->name, ni_rule_print(&out, rule));
 			ni_stringbuf_destroy(&out);
 
-			ni_rule_array_append(&del_rules, ni_rule_ref(rule));
+			ni_rule_array_append_ref(&del_rules, rule);
 		}
 	} else {
 		ni_debug_verbose(NI_LOG_DEBUG1, NI_TRACE_IFCONFIG|NI_TRACE_ROUTE,

--- a/src/leasefile.c
+++ b/src/leasefile.c
@@ -904,11 +904,13 @@ ni_addrconf_lease_routes_data_from_xml(ni_addrconf_lease_t *lease, const xml_nod
 			rp->destination.ss_family = lease->family;
 			if (__ni_addrconf_lease_route_from_xml(rp, child) != 0) {
 				ni_route_free(rp);
-			} else
+				continue;
+			}
 			if (!ni_route_tables_add_route(&lease->routes, rp)) {
 				ni_route_free(rp);
 				return -1;
 			}
+			ni_route_free(rp);
 		}
 	}
 	return 0;

--- a/src/netinfo.c
+++ b/src/netinfo.c
@@ -661,7 +661,7 @@ ni_netconfig_route_add(ni_netconfig_t *nc, ni_route_t *rp, ni_netdev_t *dev)
 			ret = -1;
 		} else
 		if (!ni_route_tables_find_match(dev->routes, rp, ni_route_equal_ref) &&
-		    !ni_route_tables_add_route(&dev->routes, ni_route_ref(rp))) {
+		    !ni_route_tables_add_route(&dev->routes, rp)) {
 			ni_warn("Unable to record route for device %s[%u]: %s",
 				dev->name, dev->link.ifindex, ni_route_print(&buf, rp));
 			ni_stringbuf_destroy(&buf);
@@ -748,7 +748,7 @@ ni_netconfig_rule_add(ni_netconfig_t *nc, ni_rule_t *rule)
 		last = i + 1;
 	}
 
-	if (!ni_rule_array_insert(rules, last, ni_rule_ref(rule))) {
+	if (!ni_rule_array_insert_ref(rules, last, rule)) {
 		ni_error("%s: unable to insert routing policy rule", __func__);
 		return -1;
 	}

--- a/src/route.c
+++ b/src/route.c
@@ -187,8 +187,7 @@ extern ni_define_refcounted_move(ni_route);
 
 ni_route_t *
 ni_route_create(unsigned int prefixlen, const ni_sockaddr_t *dest,
-		const ni_sockaddr_t *gw, unsigned int table,
-		ni_route_table_t **list)
+		const ni_sockaddr_t *gw, unsigned int table)
 {
 	static const ni_sockaddr_t null_addr;
 	ni_route_t *rp;
@@ -242,12 +241,6 @@ ni_route_create(unsigned int prefixlen, const ni_sockaddr_t *dest,
 	else
 		rp->table = ni_route_guess_table(rp);
 
-	if (list) {
-		if (ni_route_tables_add_route(list, rp))
-			ni_route_free(rp);
-		else
-			ni_route_drop(&rp);
-	}
 	return rp;
 }
 


### PR DESCRIPTION
- Avoid unsafe use of append(array, ref(entry)) function calls not allowing to release reference
  on append failure in favor of the new append_ref(array, obj) and insert_ref macros.
- Free discarded duplicate route and route rule option array and on parse errors.
- Remove table list argument from route create for consistent reference counting behavior.