### PR TITLE
fsm: use refcount and array macros in worker and policy

### DIFF
--- a/client/ifreload.c
+++ b/client/ifreload.c
@@ -395,7 +395,7 @@ usage:
 			if (ni_ifcheck_device_configured(w->device))
 				continue;
 
-			if (ni_ifworker_array_remove(&down_marked, w))
+			if (ni_ifworker_array_delete(&down_marked, w))
 				--i;
 		}
 

--- a/client/ifstatus.c
+++ b/client/ifstatus.c
@@ -972,7 +972,7 @@ ni_ifstatus_shutdown_result(ni_fsm_t *fsm, ni_string_array_t *names, ni_ifworker
 		if (!w->kickstarted)
 			continue;
 
-		if (marked && ni_ifworker_array_index(marked, w) < 0)
+		if (marked && ni_ifworker_array_index(marked, w) == -1U)
 			continue;
 
 		if (names && names->count != 0 &&
@@ -1022,7 +1022,7 @@ ni_ifstatus_display_result(ni_fsm_t *fsm, ni_string_array_t *names, ni_ifworker_
 		if (!w || ni_string_empty(w->name))
 			continue;
 
-		if (marked && ni_ifworker_array_index(marked, w) < 0)
+		if (marked && ni_ifworker_array_index(marked, w) == -1U)
 			continue;
 
 		if (names && names->count != 0 &&

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -337,7 +337,7 @@ ni_nanny_fsm_monitor_remove_port(ni_ifworker_array_t *workers, ni_ifworker_t *po
 	if (ni_nanny_fsm_monitor_wait_by_startmode(port))
 		return FALSE;
 
-	return ni_ifworker_array_remove(workers, port);
+	return ni_ifworker_array_delete(workers, port);
 }
 
 static void
@@ -360,7 +360,7 @@ static void
 ni_nanny_fsm_monitor_remove_finished(ni_ifworker_array_t *workers, ni_ifworker_t *worker)
 {
 	ni_nanny_fsm_monitor_remove_ports(workers, worker);
-	ni_ifworker_array_remove(workers, worker);
+	ni_ifworker_array_delete(workers, worker);
 }
 
 static void

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -393,7 +393,7 @@ extern ni_ifworker_array_t *	ni_ifworker_array_new(void);
 extern void			ni_ifworker_array_free(ni_ifworker_array_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
 extern ni_bool_t		ni_ifworker_array_append_ref(ni_ifworker_array_t *, ni_ifworker_t *);
-extern ni_bool_t		ni_ifworker_array_remove_index(ni_ifworker_array_t *, unsigned int);
+extern ni_bool_t		ni_ifworker_array_delete_at(ni_ifworker_array_t *, unsigned int);
 extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
 extern unsigned int		ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
 extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -392,7 +392,7 @@ extern void			ni_ifworker_control_free(ni_ifworker_control_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_new(void);
 extern void			ni_ifworker_array_free(ni_ifworker_array_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
-extern ni_bool_t		ni_ifworker_array_append(ni_ifworker_array_t *, ni_ifworker_t *);
+extern ni_bool_t		ni_ifworker_array_append_ref(ni_ifworker_array_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_ifworker_array_remove_index(ni_ifworker_array_t *, unsigned int);
 extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
 extern int			ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -394,7 +394,7 @@ extern void			ni_ifworker_array_free(ni_ifworker_array_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
 extern ni_bool_t		ni_ifworker_array_append_ref(ni_ifworker_array_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_ifworker_array_delete_at(ni_ifworker_array_t *, unsigned int);
-extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
+extern ni_bool_t		ni_ifworker_array_delete(ni_ifworker_array_t *, ni_ifworker_t *);
 extern unsigned int		ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
 extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);
 

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -63,12 +63,9 @@ typedef struct ni_fsm_policy_array {
 
 #define NI_FSM_POLICY_ARRAY_INIT	{ .count = 0, .data = NULL }
 
-typedef struct ni_ifworker_array {
-	unsigned int			count;
-	ni_ifworker_t **		data;
-} ni_ifworker_array_t;
+ni_declare_ptr_array_type(ni_ifworker);
 
-#define NI_IFWORKER_ARRAY_INIT		{ .count = 0, .data = NULL }
+#define NI_IFWORKER_ARRAY_INIT		NI_ARRAY_INIT
 
 typedef struct ni_fsm_timer_ctx	ni_fsm_timer_ctx_t;
 typedef void			ni_fsm_timer_fn_t(const ni_timer_t *, ni_fsm_timer_ctx_t *);
@@ -397,11 +394,14 @@ extern				ni_declare_refcounted_move(ni_ifworker);
 extern ni_ifworker_array_t *	ni_ifworker_array_new(void);
 extern void			ni_ifworker_array_free(ni_ifworker_array_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
-extern ni_bool_t		ni_ifworker_array_append_ref(ni_ifworker_array_t *, ni_ifworker_t *);
-extern ni_bool_t		ni_ifworker_array_delete_at(ni_ifworker_array_t *, unsigned int);
-extern ni_bool_t		ni_ifworker_array_delete(ni_ifworker_array_t *, ni_ifworker_t *);
-extern unsigned int		ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
-extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);
+
+extern				ni_declare_ptr_array_init(ni_ifworker);
+extern				ni_declare_ptr_array_destroy(ni_ifworker);
+extern				ni_declare_ptr_array_append_ref(ni_ifworker);
+extern				ni_declare_ptr_array_delete_at(ni_ifworker);
+extern				ni_declare_ptr_array_delete(ni_ifworker);
+extern				ni_declare_ptr_array_index(ni_ifworker);
+extern				ni_declare_ptr_array_at(ni_ifworker);
 
 extern ni_timeout_t		ni_fsm_find_max_timeout(ni_fsm_t *, ni_timeout_t);
 extern void			ni_fsm_require_register_type(const char *, ni_fsm_require_ctor_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -9,6 +9,7 @@
 #define __CLIENT_FSM_H__
 
 #include <wicked/time.h>
+#include <wicked/array.h>
 #include <wicked/secret.h>
 #include <wicked/refcount.h>
 #include <wicked/objectmodel.h>
@@ -54,14 +55,9 @@ typedef struct ni_ifworker		ni_ifworker_t;
 typedef struct ni_fsm_event		ni_fsm_event_t;
 typedef struct ni_fsm_require		ni_fsm_require_t;
 typedef struct ni_fsm_policy		ni_fsm_policy_t;
-typedef int				ni_fsm_policy_compare_fn_t(const ni_fsm_policy_t *, const ni_fsm_policy_t *);
 
-typedef struct ni_fsm_policy_array {
-	unsigned int			count;
-	ni_fsm_policy_t **		data;
-} ni_fsm_policy_array_t;
-
-#define NI_FSM_POLICY_ARRAY_INIT	{ .count = 0, .data = NULL }
+ni_declare_ptr_array_type(ni_fsm_policy);
+ni_declare_ptr_array_cmp_fn(ni_fsm_policy);
 
 ni_declare_ptr_array_type(ni_ifworker);
 
@@ -323,17 +319,15 @@ extern const char *		ni_fsm_policy_origin(const ni_fsm_policy_t *);
 extern unsigned int		ni_fsm_policy_weight(const ni_fsm_policy_t *);
 extern ni_bool_t		ni_fsm_policies_changed_since(const ni_fsm_t *, unsigned int *tstamp);
 
-extern void			ni_fsm_policy_array_init(ni_fsm_policy_array_t *);
-extern void			ni_fsm_policy_array_destroy(ni_fsm_policy_array_t *);
-extern void			ni_fsm_policy_array_sort(ni_fsm_policy_array_t *, ni_fsm_policy_compare_fn_t *);
-extern ni_bool_t		ni_fsm_policy_array_move(ni_fsm_policy_array_t *, ni_fsm_policy_array_t *);
-extern ni_bool_t		ni_fsm_policy_array_append(ni_fsm_policy_array_t *, ni_fsm_policy_t *);
-extern ni_bool_t		ni_fsm_policy_array_insert(ni_fsm_policy_array_t *, unsigned int, ni_fsm_policy_t *);
-extern ni_bool_t		ni_fsm_policy_array_delete(ni_fsm_policy_array_t *, unsigned int);
-extern ni_fsm_policy_t *	ni_fsm_policy_array_remove(ni_fsm_policy_array_t *, unsigned int);
-extern ni_fsm_policy_t *	ni_fsm_policy_array_get(ni_fsm_policy_array_t *, unsigned int);
-extern ni_fsm_policy_t *	ni_fsm_policy_array_ref(ni_fsm_policy_array_t *, unsigned int);
-extern unsigned int		ni_fsm_policy_array_index(const ni_fsm_policy_array_t *, const ni_fsm_policy_t *);
+extern				ni_declare_ptr_array_init(ni_fsm_policy);
+extern				ni_declare_ptr_array_destroy(ni_fsm_policy);
+extern				ni_declare_ptr_array_append_ref(ni_fsm_policy);
+extern				ni_declare_ptr_array_insert_ref(ni_fsm_policy);
+extern				ni_declare_ptr_array_remove_at(ni_fsm_policy);
+extern				ni_declare_ptr_array_delete_at(ni_fsm_policy);
+extern				ni_declare_ptr_array_index(ni_fsm_policy);
+extern				ni_declare_ptr_array_at(ni_fsm_policy);
+extern				ni_declare_ptr_array_qsort(ni_fsm_policy);
 
 extern ni_dbus_client_t *	ni_fsm_create_client(ni_fsm_t *);
 extern ni_bool_t		ni_fsm_refresh_state(ni_fsm_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -356,12 +356,6 @@ extern ni_ifworker_t *		ni_fsm_ifworker_by_ifindex(ni_fsm_t *, unsigned int);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_netdev(ni_fsm_t *, const ni_netdev_t *);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_name(const ni_fsm_t *, ni_ifworker_type_t, const char *);
 extern ni_ifworker_t *		ni_fsm_ifworker_by_policy_name(ni_fsm_t *, ni_ifworker_type_t, const char *);
-extern ni_ifworker_t *		ni_fsm_recv_new_netif(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh);
-extern ni_ifworker_t *		ni_fsm_recv_new_netif_path(ni_fsm_t *fsm, const char *path);
-extern ni_ifworker_t *		ni_fsm_recv_new_modem(ni_fsm_t *fsm, ni_dbus_object_t *object, ni_bool_t refresh);
-extern ni_ifworker_t *		ni_fsm_recv_new_modem_path(ni_fsm_t *fsm, const char *path);
-extern ni_ifworker_t *		ni_fsm_ifworker_new(ni_fsm_t *, ni_ifworker_type_t, const char *);
-extern void			ni_fsm_destroy_worker(ni_fsm_t *fsm, ni_ifworker_t *w);
 extern void			ni_fsm_wait_tentative_addrs(ni_fsm_t *);
 
 extern ni_ifworker_type_t	ni_ifworker_type_from_string(const char *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -392,7 +392,7 @@ extern void			ni_ifworker_control_free(ni_ifworker_control_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_new(void);
 extern void			ni_ifworker_array_free(ni_ifworker_array_t *);
 extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
-extern void			ni_ifworker_array_append(ni_ifworker_array_t *, ni_ifworker_t *);
+extern ni_bool_t		ni_ifworker_array_append(ni_ifworker_array_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_ifworker_array_remove_index(ni_ifworker_array_t *, unsigned int);
 extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
 extern int			ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -298,9 +298,14 @@ extern void			ni_fsm_events_block(ni_fsm_t *);
 extern void			ni_fsm_process_events(ni_fsm_t *);
 extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
-extern ni_fsm_policy_t *	ni_fsm_policy_new(ni_fsm_t *, const char *, xml_node_t *);
-extern ni_fsm_policy_t *	ni_fsm_policy_ref(ni_fsm_policy_t *);
-extern void			ni_fsm_policy_free(ni_fsm_policy_t *);
+extern				ni_declare_refcounted_new(ni_fsm_policy,
+						ni_fsm_t *, const char *, xml_node_t *);
+extern				ni_declare_refcounted_ref(ni_fsm_policy);
+extern				ni_declare_refcounted_free(ni_fsm_policy);
+extern				ni_declare_refcounted_hold(ni_fsm_policy);
+extern				ni_declare_refcounted_drop(ni_fsm_policy);
+extern				ni_declare_refcounted_move(ni_fsm_policy);
+
 extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
 extern ni_bool_t		ni_fsm_policy_remove(ni_fsm_t *, ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_policy_by_name(const ni_fsm_t *, const char *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -395,7 +395,7 @@ extern ni_ifworker_array_t *	ni_ifworker_array_clone(ni_ifworker_array_t *);
 extern ni_bool_t		ni_ifworker_array_append_ref(ni_ifworker_array_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_ifworker_array_remove_index(ni_ifworker_array_t *, unsigned int);
 extern ni_bool_t		ni_ifworker_array_remove(ni_ifworker_array_t *, ni_ifworker_t *);
-extern int			ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
+extern unsigned int		ni_ifworker_array_index(const ni_ifworker_array_t *, const ni_ifworker_t *);
 extern void			ni_ifworker_array_destroy(ni_ifworker_array_t *);
 
 extern ni_timeout_t		ni_fsm_find_max_timeout(ni_fsm_t *, ni_timeout_t);

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -170,7 +170,7 @@ ni_factory_device_up(ni_fsm_t *fsm, ni_ifworker_t *w)
 	ifmarker.target_range.max = NI_FSM_STATE_MAX;
 	ifmarker.persistent = w->control.persistent;
 
-	ni_ifworker_array_append(&ifmarked, w);
+	ni_ifworker_array_append_ref(&ifmarked, w);
 	ni_fsm_mark_matching_workers(fsm, &ifmarked, &ifmarker);
 	ni_ifworker_array_destroy(&ifmarked);
 
@@ -378,7 +378,7 @@ ni_managed_device_up(ni_managed_device_t *mdev, const char *origin)
 	ifmarker.target_range.max = NI_FSM_STATE_MAX;
 	ifmarker.persistent = w->control.persistent;
 
-	ni_ifworker_array_append(&ifmarked, w);
+	ni_ifworker_array_append_ref(&ifmarked, w);
 
 	/* Binding: this validates the XML configuration document,
 	 * resolves any references to other devices (if there are any),

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -792,7 +792,7 @@ ni_nanny_process_rename_event(ni_nanny_t *mgr, ni_ifworker_t *w)
 				ni_nanny_unregister_device(mgr, c);
 
 			rebuild = TRUE;
-			if (ni_ifworker_array_remove_index(&mgr->fsm->workers, i))
+			if (ni_ifworker_array_delete_at(&mgr->fsm->workers, i))
 				continue;
 		}
 		i++;

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -155,7 +155,7 @@ ni_nanny_schedule_recheck(ni_ifworker_array_t *array, ni_ifworker_t *w)
 void
 ni_nanny_unschedule(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
-	ni_ifworker_array_remove(array, w);
+	ni_ifworker_array_delete(array, w);
 }
 
 /*

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -148,7 +148,7 @@ ni_nanny_free(ni_nanny_t *mgr)
 void
 ni_nanny_schedule_recheck(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
-	if (ni_ifworker_array_index(array, w) < 0)
+	if (ni_ifworker_array_index(array, w) == -1U)
 		ni_ifworker_array_append_ref(array, w);
 }
 

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -149,7 +149,7 @@ void
 ni_nanny_schedule_recheck(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
 	if (ni_ifworker_array_index(array, w) < 0)
-		ni_ifworker_array_append(array, w);
+		ni_ifworker_array_append_ref(array, w);
 }
 
 void

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -17,6 +17,7 @@
 #include "client/ifconfig.h"
 #include "util_priv.h"
 #include "refcount_priv.h"
+#include "array_priv.h"
 
 #define NI_FSM_POLICY_ARRAY_CHUNK	2
 
@@ -2143,168 +2144,15 @@ ni_fsm_policy_conditions_from_xml(xml_node_t *node)
 	return ni_ifcondition_and(node);
 }
 
-void
-ni_fsm_policy_array_init(ni_fsm_policy_array_t *array)
-{
-	ni_assert(array);
-	memset(array, 0, sizeof(*array));
-}
+extern ni_define_ptr_array_init(ni_fsm_policy);
+extern ni_define_ptr_array_destroy(ni_fsm_policy);
+static ni_define_ptr_array_realloc(ni_fsm_policy, NI_FSM_POLICY_ARRAY_CHUNK);
+extern ni_define_ptr_array_append_ref(ni_fsm_policy);
+extern ni_define_ptr_array_insert_ref(ni_fsm_policy);
+extern ni_define_ptr_array_remove_at(ni_fsm_policy);
+extern ni_define_ptr_array_delete_at(ni_fsm_policy);
+extern ni_define_ptr_array_at(ni_fsm_policy);
+extern ni_define_ptr_array_index(ni_fsm_policy);
+static ni_define_ptr_array_qsort_cmp_fn(ni_fsm_policy);
+extern ni_define_ptr_array_qsort(ni_fsm_policy);
 
-void
-ni_fsm_policy_array_destroy(ni_fsm_policy_array_t *array)
-{
-	if (array) {
-		while (array->count) {
-			array->count--;
-			ni_fsm_policy_free(array->data[array->count]);
-			array->data[array->count] = NULL;
-		}
-		free(array->data);
-		array->data = NULL;
-	}
-}
-
-static int
-ni_fsm_policy_array_qsort_r_cmp(const void *p1, const void *p2, void *arg)
-{
-	/* cast + dereference the pointers to policy pointer arguments */
-	const ni_fsm_policy_t *policy1 = *(const ni_fsm_policy_t **)p1;
-	const ni_fsm_policy_t *policy2 = *(const ni_fsm_policy_t **)p2;
-	ni_fsm_policy_compare_fn_t *cmp_fn = (ni_fsm_policy_compare_fn_t *)arg;
-	return cmp_fn(policy1, policy2);
-}
-
-void
-ni_fsm_policy_array_sort(ni_fsm_policy_array_t *array, ni_fsm_policy_compare_fn_t *cmp_fn)
-{
-	if (!array || !array->count || !cmp_fn)
-		return;
-
-	qsort_r(&array->data[0], array->count, sizeof(array->data[0]),
-			ni_fsm_policy_array_qsort_r_cmp, cmp_fn);
-}
-
-ni_bool_t
-ni_fsm_policy_array_move(ni_fsm_policy_array_t *dst, ni_fsm_policy_array_t *src)
-{
-	if (dst && src && dst != src) {
-		ni_fsm_policy_array_destroy(dst);
-		*dst = *src;
-		memset(src, 0, sizeof(*src));
-		return TRUE;
-	}
-	return FALSE;
-}
-
-static ni_bool_t
-ni_fsm_policy_array_realloc(ni_fsm_policy_array_t *array, unsigned int newsize)
-{
-	ni_fsm_policy_t **newdata;
-	unsigned int i;
-
-	if (!array || (UINT_MAX - NI_FSM_POLICY_ARRAY_CHUNK) <= newsize)
-		return FALSE;
-
-	newsize = newsize + NI_FSM_POLICY_ARRAY_CHUNK;
-	newdata	= realloc(array->data, (size_t)newsize * sizeof(*newdata));
-	if (!newdata)
-		return FALSE;
-
-	array->data = newdata;
-	for (i = array->count; i < newsize; ++i)
-		array->data[i] = NULL;
-
-	return TRUE;
-}
-
-ni_bool_t
-ni_fsm_policy_array_append(ni_fsm_policy_array_t *array, ni_fsm_policy_t *policy)
-{
-	return ni_fsm_policy_array_insert(array, -1U, policy);
-}
-
-ni_bool_t
-ni_fsm_policy_array_insert(ni_fsm_policy_array_t *array, unsigned int index, ni_fsm_policy_t *policy)
-{
-	ni_fsm_policy_t *ref;
-
-	if (!array || !policy || !(ref = ni_fsm_policy_ref(policy)))
-		return FALSE;
-
-	if ((array->count % NI_FSM_POLICY_ARRAY_CHUNK) == 0 &&
-	    !ni_fsm_policy_array_realloc(array, array->count)) {
-		ni_fsm_policy_free(ref);
-		return FALSE;
-	}
-
-	if (index >= array->count) {
-		index = array->count;
-	} else {
-		memmove(&array->data[index + 1], &array->data[index],
-			(array->count - index) * sizeof(policy));
-	}
-	array->data[index] = ref;
-	array->count++;
-	return TRUE;
-}
-
-ni_bool_t
-ni_fsm_policy_array_delete(ni_fsm_policy_array_t *array, unsigned int index)
-{
-	ni_fsm_policy_t *policy;
-
-	policy = ni_fsm_policy_array_remove(array, index);
-	if (policy) {
-		ni_fsm_policy_free(policy);
-		return TRUE;
-	}
-	return FALSE;
-}
-
-ni_fsm_policy_t *
-ni_fsm_policy_array_remove(ni_fsm_policy_array_t *array, unsigned int index)
-{
-	ni_fsm_policy_t *policy;
-
-	if (!array || index >= array->count)
-		return NULL;
-
-	policy = array->data[index];
-	array->count--;
-	if (index < array->count) {
-		memmove(&array->data[index], &array->data[index + 1],
-			(array->count - index) * sizeof(policy));
-	}
-	array->data[array->count] = NULL;
-	return policy;
-}
-
-ni_fsm_policy_t *
-ni_fsm_policy_array_get(ni_fsm_policy_array_t *array, unsigned int index)
-{
-	if (!array || index >= array->count)
-		return NULL;
-
-	return array->data[index];
-}
-
-ni_fsm_policy_t *
-ni_fsm_policy_array_ref(ni_fsm_policy_array_t *array, unsigned int index)
-{
-	return ni_fsm_policy_ref(ni_fsm_policy_array_get(array, index));
-}
-
-unsigned int
-ni_fsm_policy_array_index(const ni_fsm_policy_array_t *array, const ni_fsm_policy_t *policy)
-{
-	unsigned int i;
-
-	if (!array || !policy)
-		return -1U;
-
-	for (i = 0; i < array->count; ++i) {
-		if (array->data[i] == policy)
-			return i;
-	}
-	return -1U;
-}

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -925,7 +925,7 @@ ni_ifworker_array_clone(ni_ifworker_array_t *array)
 }
 
 ni_bool_t
-ni_ifworker_array_remove_index(ni_ifworker_array_t *array, unsigned int index)
+ni_ifworker_array_delete_at(ni_ifworker_array_t *array, unsigned int index)
 {
 	unsigned int i;
 
@@ -951,7 +951,7 @@ ni_ifworker_array_remove(ni_ifworker_array_t *array, ni_ifworker_t *w)
 
 	for (i = 0; i < array->count; ) {
 		if (w == array->data[i]) {
-			found = ni_ifworker_array_remove_index(array, i);
+			found = ni_ifworker_array_delete_at(array, i);
 		} else {
 			++i;
 		}

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -844,7 +844,7 @@ ni_ifworker_array_append_ref(ni_ifworker_array_t *array, ni_ifworker_t *w)
 	return TRUE;
 }
 
-int
+unsigned int
 ni_ifworker_array_index(const ni_ifworker_array_t *array, const ni_ifworker_t *w)
 {
 	unsigned int i;
@@ -853,7 +853,7 @@ ni_ifworker_array_index(const ni_ifworker_array_t *array, const ni_ifworker_t *w
 		if (array->data[i] == w)
 			return i;
 	}
-	return -1;
+	return -1U;
 }
 
 void
@@ -3168,7 +3168,7 @@ ni_fsm_ifmatch_pull_up_lower(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		return FALSE;
 	}
 
-	if (match->ifreload && ni_ifworker_array_index(matching, w->lowerdev) != -1)
+	if (match->ifreload && ni_ifworker_array_index(matching, w->lowerdev) != -1U)
 		*changed = TRUE;
 
 	return TRUE;
@@ -3195,7 +3195,7 @@ ni_fsm_ifmatch_pull_up_master(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		return FALSE;
 	}
 
-	if (match->ifreload && ni_ifworker_array_index(matching, w->masterdev) != -1)
+	if (match->ifreload && ni_ifworker_array_index(matching, w->masterdev) != -1U)
 		*changed = TRUE;
 
 	return TRUE;
@@ -3231,7 +3231,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	ni_ifworker_array_t pulled = NI_IFWORKER_ARRAY_INIT;
 	unsigned int i;
 
-	if (ni_ifworker_array_index(matching, w) != -1)
+	if (ni_ifworker_array_index(matching, w) != -1U)
 		return TRUE;
 
 	/*
@@ -3293,7 +3293,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	for (i = 0; i < pulled.count; ++i) {
 		ni_ifworker_t *dep = pulled.data[i];
 
-		if (ni_ifworker_array_index(matching, dep) == -1)
+		if (ni_ifworker_array_index(matching, dep) == -1U)
 			ni_ifworker_array_append_ref(matching, dep);
 	}
 	ni_ifworker_array_destroy(&pulled);
@@ -3301,7 +3301,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	if (match->ifreload && !changed)
 		return TRUE; /* skip unchanged */
 
-	if (ni_ifworker_array_index(matching, w) == -1)
+	if (ni_ifworker_array_index(matching, w) == -1U)
 		ni_ifworker_array_append_ref(matching, w);
 
 	return TRUE;
@@ -3436,7 +3436,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	if (!(device = w->device))
 		return TRUE;
 
-	if (ni_ifworker_array_index(matching, w) != -1)
+	if (ni_ifworker_array_index(matching, w) != -1U)
 		return TRUE;
 
 	/*
@@ -3502,7 +3502,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	for (i = 0; i < pulled.count; ++i) {
 		ni_ifworker_t *dep = pulled.data[i];
 
-		if (ni_ifworker_array_index(matching, dep) == -1)
+		if (ni_ifworker_array_index(matching, dep) == -1U)
 			ni_ifworker_array_append_ref(matching, dep);
 	}
 	ni_ifworker_array_destroy(&pulled);
@@ -3510,7 +3510,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	if (match->ifreload && !changed)
 		return TRUE; /* skip unchanged */
 
-	if (ni_ifworker_array_index(matching, w) == -1)
+	if (ni_ifworker_array_index(matching, w) == -1U)
 		ni_ifworker_array_append_ref(matching, w);
 
 	return TRUE;
@@ -3636,7 +3636,7 @@ ni_ifworker_references_ok(const ni_ifworker_array_t *guard, ni_ifworker_t *w)
 		return FALSE;
 	}
 
-	if (ni_ifworker_array_index(guard, w) != -1) {
+	if (ni_ifworker_array_index(guard, w) != -1U) {
 		ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
 		ni_ifworker_guard_print(&buf, guard, " -> ");
@@ -4500,7 +4500,7 @@ static const char *
 ni_fsm_config_hierarchy_mark(const ni_ifworker_array_t *marked,
 	const ni_ifworker_t *w)
 {
-	if (w && marked && ni_ifworker_array_index(marked, w) != -1)
+	if (w && marked && ni_ifworker_array_index(marked, w) != -1U)
 		return "+ ";
 	else
 		return "  ";
@@ -4519,7 +4519,7 @@ ni_fsm_print_config_device_worker_hierarchy(const ni_fsm_t *fsm,
 	if (!w)
 		return;
 
-	if (ni_ifworker_array_index(guard, w) != -1) {
+	if (ni_ifworker_array_index(guard, w) != -1U) {
 		ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
 		ni_ifworker_guard_print(&buf, guard, " -> ");
@@ -4596,7 +4596,7 @@ static const char *
 ni_fsm_system_hierarchy_mark(const ni_ifworker_array_t *marked,
 		const ni_ifworker_t *w)
 {
-	if (w && marked && ni_ifworker_array_index(marked, w) != -1)
+	if (w && marked && ni_ifworker_array_index(marked, w) != -1U)
 		return "- ";
 	else
 		return "  ";
@@ -4615,7 +4615,7 @@ ni_fsm_print_system_device_worker_hierarchy(const ni_fsm_t *fsm,
 	if (!w || !w->device)
 		return;
 
-	if (ni_ifworker_array_index(guard, w) != -1) {
+	if (ni_ifworker_array_index(guard, w) != -1U) {
 		ni_stringbuf_t buf = NI_STRINGBUF_INIT_DYNAMIC;
 
 		ni_ifworker_guard_print(&buf, guard, " -> ");

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -824,14 +824,24 @@ ni_ifworker_array_new(void)
 	return array;
 }
 
-void
+ni_bool_t
 ni_ifworker_array_append(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
-	if (!array || !w)
-		return;
+	ni_ifworker_t **data;
+	ni_ifworker_t *ref;
 
-	array->data = realloc(array->data, (array->count + 1) * sizeof(array->data[0]));
-	array->data[array->count++] = ni_ifworker_get(w);
+	if (!array || !(ref = ni_ifworker_get(w)))
+		return FALSE;
+
+	data = realloc(array->data, (array->count + 1) * sizeof(array->data[0]));
+	if (!data) {
+		ni_ifworker_release(ref);
+		return FALSE;
+	}
+
+	array->data = data;
+	array->data[array->count++] = ref;
+	return TRUE;
 }
 
 int

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -257,7 +257,7 @@ ni_ifworker_new(ni_ifworker_array_t *array, ni_ifworker_type_t type, const char 
 	ni_ifworker_t *worker;
 
 	worker = __ni_ifworker_new(type, name);
-	ni_ifworker_array_append(array, worker);
+	ni_ifworker_array_append_ref(array, worker);
 	if (ni_ifworker_release(worker))
 		return worker;
 	else
@@ -825,7 +825,7 @@ ni_ifworker_array_new(void)
 }
 
 ni_bool_t
-ni_ifworker_array_append(ni_ifworker_array_t *array, ni_ifworker_t *w)
+ni_ifworker_array_append_ref(ni_ifworker_array_t *array, ni_ifworker_t *w)
 {
 	ni_ifworker_t **data;
 	ni_ifworker_t *ref;
@@ -919,7 +919,7 @@ ni_ifworker_array_clone(ni_ifworker_array_t *array)
 
 	clone = ni_ifworker_array_new();
 	for (i = 0; i < array->count; ++i)
-		ni_ifworker_array_append(clone, array->data[i]);
+		ni_ifworker_array_append_ref(clone, array->data[i]);
 
 	return clone;
 }
@@ -1323,7 +1323,7 @@ ni_ifworker_add_child(ni_ifworker_t *parent, ni_ifworker_t *child, xml_node_t *d
 		if (parent->children.data[i] == child)
 			return TRUE;
 	}
-	ni_ifworker_array_append(&parent->children, child);
+	ni_ifworker_array_append_ref(&parent->children, child);
 	return TRUE;
 }
 
@@ -3249,7 +3249,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	if (!ni_ifworker_references_ok(guard, w))
 		return FALSE;
 
-	ni_ifworker_array_append(guard, w);
+	ni_ifworker_array_append_ref(guard, w);
 
 	if (lower && !ni_fsm_ifmatch_pull_up_lower(fsm, match, &pulled,
 			guard, logit, w, TRUE, TRUE, ports, FALSE, &changed)) {
@@ -3294,7 +3294,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		ni_ifworker_t *dep = pulled.data[i];
 
 		if (ni_ifworker_array_index(matching, dep) == -1)
-			ni_ifworker_array_append(matching, dep);
+			ni_ifworker_array_append_ref(matching, dep);
 	}
 	ni_ifworker_array_destroy(&pulled);
 
@@ -3302,7 +3302,7 @@ ni_fsm_ifmatch_pull_up(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		return TRUE; /* skip unchanged */
 
 	if (ni_ifworker_array_index(matching, w) == -1)
-		ni_ifworker_array_append(matching, w);
+		ni_ifworker_array_append_ref(matching, w);
 
 	return TRUE;
 }
@@ -3461,7 +3461,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 	if (!ni_ifworker_references_ok(guard, w))
 		return FALSE;
 
-	ni_ifworker_array_append(guard, w);
+	ni_ifworker_array_append_ref(guard, w);
 
 	/*
 	 * There is no reason to trigger master or lower shutdown
@@ -3503,7 +3503,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		ni_ifworker_t *dep = pulled.data[i];
 
 		if (ni_ifworker_array_index(matching, dep) == -1)
-			ni_ifworker_array_append(matching, dep);
+			ni_ifworker_array_append_ref(matching, dep);
 	}
 	ni_ifworker_array_destroy(&pulled);
 
@@ -3511,7 +3511,7 @@ ni_fsm_ifmatch_pull_down(ni_fsm_t *fsm, ni_ifmatcher_t *match,
 		return TRUE; /* skip unchanged */
 
 	if (ni_ifworker_array_index(matching, w) == -1)
-		ni_ifworker_array_append(matching, w);
+		ni_ifworker_array_append_ref(matching, w);
 
 	return TRUE;
 }
@@ -3667,7 +3667,7 @@ ni_ifworker_break_loops(ni_ifworker_array_t *guard, ni_ifworker_t *w, unsigned i
 
 	if (!ni_ifworker_references_ok(guard, w))
 		return FALSE;
-	ni_ifworker_array_append(guard, w);
+	ni_ifworker_array_append_ref(guard, w);
 
 	for (i = 0; i < w->children.count; i++) {
 		ni_ifworker_t *c = w->children.data[i];
@@ -4528,7 +4528,7 @@ ni_fsm_print_config_device_worker_hierarchy(const ni_fsm_t *fsm,
 		ni_stringbuf_destroy(&buf);
 		return;
 	}
-	ni_ifworker_array_append(guard, w);
+	ni_ifworker_array_append_ref(guard, w);
 
 	ni_fsm_print_hierarchy(logfn, "%s%*s%s",
 		ni_fsm_config_hierarchy_mark(marked, w),
@@ -4624,7 +4624,7 @@ ni_fsm_print_system_device_worker_hierarchy(const ni_fsm_t *fsm,
 		ni_stringbuf_destroy(&buf);
 		return;
 	}
-	ni_ifworker_array_append(guard, w);
+	ni_ifworker_array_append_ref(guard, w);
 
 	ni_fsm_print_hierarchy(logfn, "%s%*s%s",
 			ni_fsm_system_hierarchy_mark(marked, w),
@@ -5894,7 +5894,7 @@ ni_ifworker_get_ports_by_name(ni_fsm_t *fsm, const char *name, ni_ifworker_array
 			continue;
 
 		if (ports)
-			ni_ifworker_array_append(ports, w);
+			ni_ifworker_array_append_ref(ports, w);
 		else
 			count++;
 	}


### PR DESCRIPTION
Refactored and cleaned up to use our common refcounting and array macros
so the worker and policy are using the same function prototypes, e.g. same
names and meaning of array remove vs. delete.