### PR TITLE
fsm: remove children reference array from worker 

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -212,8 +212,6 @@ struct ni_ifworker {
 
 	ni_ifworker_t *		masterdev;
 	ni_ifworker_t * 	lowerdev;
-
-	ni_ifworker_array_t	children;
 };
 
 /*
@@ -339,6 +337,7 @@ extern unsigned int		ni_fsm_get_matching_workers(ni_fsm_t *, ni_ifmatcher_t *, n
 extern unsigned int		ni_fsm_mark_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, const ni_ifmarker_t *);
 extern unsigned int		ni_fsm_start_matching_workers(ni_fsm_t *, ni_ifworker_array_t *);
 extern void			ni_fsm_reset_matching_workers(ni_fsm_t *, ni_ifworker_array_t *, const ni_uint_range_t *, ni_bool_t);
+extern void			ni_fsm_reset_worker(ni_fsm_t *, ni_ifworker_t *);
 extern void			ni_fsm_print_config_hierarchy(const ni_fsm_t *,
 						const ni_ifworker_array_t *, ni_log_fn_t *);
 extern void			ni_fsm_print_system_hierarchy(const ni_fsm_t *,

--- a/nanny/interface.c
+++ b/nanny/interface.c
@@ -88,7 +88,7 @@ ni_managed_netdev_disable(ni_managed_device_t *mdev)
 
 	ni_nanny_schedule_recheck(&mgr->down, w);
 	ni_nanny_unschedule(&mgr->recheck, w);
-	ni_ifworker_reset(w);
+	ni_fsm_reset_worker(mgr->fsm, w);
 
 	mdev->monitor = FALSE;
 	return TRUE;

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -1391,8 +1391,11 @@ ni_fsm_policy_match_and_children_check(const ni_ifcondition_t *cond, const ni_fs
 	unsigned int i;
 	ni_bool_t rv = FALSE;
 
-	for (i = 0; i < w->children.count; i++) {
-		ni_ifworker_t *child = w->children.data[i];
+	for (i = 0; i < fsm->workers.count; i++) {
+		ni_ifworker_t *child = fsm->workers.data[i];
+
+		if (w->lowerdev != child && child->masterdev != w)
+			continue;
 
 		if (ni_ifworker_is_device_created(child)) {
 			if (!ni_netdev_device_is_ready(child->device))


### PR DESCRIPTION
The fsm worker is a structure that contains config and/or device.
Use the master/lowerdev worker config interface references only
and remove the confusing children array causing complex cleanup.