### PR TITLE
policy: cleanup ifxml utils and fsm policy parsing

### DIFF
--- a/client/compat.c
+++ b/client/compat.c
@@ -56,7 +56,7 @@
 #include <sys/param.h>
 #include <arpa/inet.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "client/client_state.h"
 #include "appconfig.h"
 #include "util_priv.h"

--- a/client/convert.c
+++ b/client/convert.c
@@ -81,7 +81,7 @@ ni_wicked_convert_match(xml_node_t *node, ni_string_array_t *filter)
 	const char *match;
 	unsigned int i;
 
-	if (ni_ifconfig_is_config(node)) {
+	if (ni_ifxml_is_config(node)) {
 		if (!filter || !filter->count)
 			return TRUE;
 
@@ -90,8 +90,10 @@ ni_wicked_convert_match(xml_node_t *node, ni_string_array_t *filter)
 			if (ni_wicked_convert_match_config(node, match))
 				return TRUE;
 		}
-	} else
-	if (ni_ifconfig_is_policy(node)) {
+		return FALSE;
+	}
+
+	if (ni_ifxml_is_policy(node)) {
 		if (!filter || !filter->count)
 			return TRUE;
 
@@ -100,9 +102,10 @@ ni_wicked_convert_match(xml_node_t *node, ni_string_array_t *filter)
 			if (ni_wicked_convert_match_policy(node, match))
 				return TRUE;
 		}
+		return FALSE;
 	}
 
-	return FALSE; /* omit any non-ifconfig nodes */
+	return FALSE; /* omit any non-ifxml nodes */
 }
 
 static ni_bool_t
@@ -138,13 +141,13 @@ ni_wicked_convert_config_filename(char **filename, xml_node_t *node, const char 
 static ni_bool_t
 ni_wicked_convert_node_filename(char **filename, xml_node_t *node, const char *dirname)
 {
-	if (ni_ifconfig_is_config(node))
+	if (ni_ifxml_is_config(node))
 		return ni_wicked_convert_config_filename(filename, node, dirname);
-	else
-	if (ni_ifconfig_is_policy(node))
+
+	if (ni_ifxml_is_policy(node))
 		return ni_wicked_convert_policy_filename(filename, node, dirname);
-	else
-		return FALSE;
+
+	return FALSE;
 }
 
 static ni_bool_t

--- a/client/convert.c
+++ b/client/convert.c
@@ -41,7 +41,7 @@
 #include "appconfig.h"
 #include "read-config.h"
 #include "wicked-client.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 
 static ni_bool_t

--- a/client/dracut/cmdline.c
+++ b/client/dracut/cmdline.c
@@ -48,7 +48,7 @@
 
 #include "client/wicked-client.h"
 #include "client/read-config.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "client/dracut/cmdline.h"
 #include "buffer.h"
 

--- a/client/ifdown.c
+++ b/client/ifdown.c
@@ -35,7 +35,7 @@
 #include <wicked/logging.h>
 #include <wicked/fsm.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 #include "wicked-client.h"
 #include "appconfig.h"

--- a/client/ifup.c
+++ b/client/ifup.c
@@ -40,7 +40,7 @@
 #include <wicked/socket.h>
 #include <wicked/fsm.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 #include "wicked-client.h"
 #include "appconfig.h"

--- a/client/nanny.c
+++ b/client/nanny.c
@@ -48,7 +48,7 @@
 
 #include "read-config.h"
 #include "wicked-client.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 /*
  * Enable the given user interface

--- a/client/nanny.c
+++ b/client/nanny.c
@@ -124,7 +124,7 @@ do_nanny_addpolicy(int argc, char **argv)
 		/*
 		 * just empty or backend options documents
 		 */
-		if (!ni_ifconfig_is_policy(root) && !ni_ifconfig_is_config(root))
+		if (!ni_ifxml_is_policy(root) && !ni_ifxml_is_config(root))
 			continue;
 
 		rv = ni_nanny_addpolicy(doc);
@@ -305,7 +305,7 @@ ni_nanny_addpolicy_node(const xml_node_t *pnode, const char *origin)
 	if (ni_string_empty(origin))
 		origin = ni_ifpolicy_get_origin(pnode);
 
-	if (!ni_ifconfig_is_policy(pnode)) {
+	if (!ni_ifxml_is_policy(pnode)) {
 		ni_debug_ifconfig("Rejecting to add invalid policy from %s",
 			ni_string_empty(origin) ? "unspecified origin" : origin);
 		return -1;

--- a/client/read-config.c
+++ b/client/read-config.c
@@ -426,7 +426,7 @@ ni_ifconfig_validate_adding_doc(xml_document_t *config_doc, ni_bool_t check_prio
 	for ( ; src_child; src_child = src_child->next) {
 		int rv;
 
-		if (ni_ifconfig_is_policy(src_child)) {
+		if (ni_ifxml_is_policy(src_child)) {
 			ni_debug_ifconfig("ignoring validation on policy nodes");
 			continue;
 		}

--- a/client/read-config.c
+++ b/client/read-config.c
@@ -44,7 +44,7 @@
 
 #include "appconfig.h"
 #include "wicked-client.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "client/read-config.h"
 #include "dracut/dracut.h"
 #include "firmware.h"

--- a/nanny/main.c
+++ b/nanny/main.c
@@ -31,7 +31,7 @@
 #include <wicked/wireless.h>
 #include <wicked/fsm.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "util_priv.h"
 #include "nanny.h"
 

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -358,7 +358,7 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, xml_do
 		pnode = root;
 	}
 
-	if (!ni_ifconfig_is_policy(pnode)) {
+	if (!ni_ifxml_is_policy(pnode)) {
 		pname = pnode->name;
 		ni_error("Not a valid policy document node \"%s\"",
 				ni_print_suspect(pname, ni_string_len(pname)));

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -29,7 +29,7 @@
 #include <wicked/dbus-errors.h>
 #include <wicked/fsm.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "util_priv.h"
 #include "nanny.h"
 

--- a/nanny/policy.c
+++ b/nanny/policy.c
@@ -20,7 +20,7 @@
 
 #include "nanny.h"
 #include "util_priv.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 #include <stdio.h>
 #include <errno.h>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -177,7 +177,7 @@ libwicked_dhcp6_la_SOURCES		= \
 libwicked_client_la_CFLAGS		= $(libwicked_la_CFLAGS)
 libwicked_client_la_SOURCES		= \
 	client/client_state.c	\
-	client/policy.c
+	client/ifxml.c
 
 noinst_HEADERS			= \
 	$(wicked_headers)	\
@@ -196,7 +196,7 @@ wicked_headers			= \
 	array_priv.h		\
 	buffer.h		\
 	client/client_state.h	\
-	client/ifconfig.h	\
+	client/ifxml.h		\
 	dbus-common.h		\
 	dbus-connection.h	\
 	dbus-dict.h		\

--- a/src/client/ifxml.c
+++ b/src/client/ifxml.c
@@ -1,8 +1,8 @@
 /*
- *	wicked client related policy functions
+ *	wicked xml interface config and policy utilities
  *
  *	Copyright (C) 2010-2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
- *	Copyright (C) 2014-2023 SUSE LLC
+ *	Copyright (C) 2014-2025 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 #include <wicked/logging.h>
 #include <wicked/xml.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 
 /*
  * Given the configuration for a device, generate a UUID that uniquely

--- a/src/client/ifxml.c
+++ b/src/client/ifxml.c
@@ -319,13 +319,14 @@ ni_convert_cfg_into_policy_doc(xml_document_t *doc)
 		ni_debug_ifconfig("Ignoring already existing %s named %s from %s",
 				NI_NANNY_IFPOLICY, name, origin);
 		return doc;
-	} else if (ni_ifconfig_is_policy(root)) {
+	}
+	if (ni_ifxml_is_policy(root)) {
 		ni_debug_ifconfig("Ignoring already existing, noname %s from %s",
 				NI_NANNY_IFPOLICY, origin);
 		return doc;
 	}
 
-	if (!ni_ifconfig_is_config(root)) {
+	if (!ni_ifxml_is_config(root)) {
 		ni_error("Unknown document node '%s' found in file %s: neither an %s nor %s",
 				root->name, origin, NI_CLIENT_IFCONFIG, NI_NANNY_IFPOLICY);
 		return NULL;
@@ -354,6 +355,27 @@ ni_convert_cfg_into_policy_doc(xml_document_t *doc)
 	}
 	xml_node_free(match);
 	return NULL;
+}
+
+/*
+ * ifxml utilities
+ */
+ni_bool_t
+ni_ifxml_is_config(const xml_node_t *node)
+{
+	return node && node->children && ni_string_eq(node->name, NI_CLIENT_IFCONFIG);
+}
+
+ni_bool_t
+ni_ifxml_is_policy(const xml_node_t *node)
+{
+	if (node && node->children) {
+		if (ni_string_eq(node->name, NI_NANNY_IFPOLICY))
+			return TRUE;
+		if (ni_string_eq(node->name, NI_NANNY_IFTEMPLATE))
+			return TRUE;
+	}
+	return FALSE;
 }
 
 /*
@@ -625,10 +647,10 @@ ni_ifxml_get_ifconfig_node(xml_document_t *doc)
 	if (!(root = xml_document_root(doc)))
 		return NULL;
 
-	if (ni_ifconfig_is_config(root))
+	if (ni_ifxml_is_config(root))
 		return root;
 
-	if (ni_ifconfig_is_policy(root)) {
+	if (ni_ifxml_is_policy(root)) {
 		if ((node = xml_node_get_child(root, NI_NANNY_IFPOLICY_MERGE)))
 			return node;
 		if ((node = xml_node_get_child(root, NI_NANNY_IFPOLICY_REPLACE)))
@@ -705,7 +727,7 @@ ni_ifxml_find_ifname_by_ifindex(xml_document_array_t *docs, const char *ifindex)
 	if (!(config = ni_ifxml_find_config_by_ifindex(docs, ifindex)))
 		return NULL;
 
-	if (!(policy = ni_ifconfig_is_config(config) ? NULL : config->parent))
+	if (!(policy = ni_ifxml_is_config(config) ? NULL : config->parent))
 		return NULL;
 
 	if (!(match = xml_node_get_child(policy, NI_NANNY_IFPOLICY_MATCH)))
@@ -754,7 +776,7 @@ ni_ifpolicy_match_remove_child_ref(xml_node_t *policy, const char *name)
 	 * We remove the obsolete reference to the port inclusive of
 	 * the <or> and <child> nodes once they're empty.
 	 */
-	if (!ni_ifconfig_is_policy(policy) || ni_string_empty(name))
+	if (!ni_ifxml_is_policy(policy) || ni_string_empty(name))
 		return modified;
 
 	if (!(match = xml_node_get_child(policy, NI_NANNY_IFPOLICY_MATCH)))
@@ -796,7 +818,7 @@ ni_ifpolicy_add_match_device_ref(xml_node_t *policy, const char *device)
 	ni_bool_t modified = FALSE;
 	xml_node_t *match, *ref, *dev;
 
-	if (!ni_ifconfig_is_policy(policy) || ni_string_empty(device))
+	if (!ni_ifxml_is_policy(policy) || ni_string_empty(device))
 		return modified;
 
 	if (!(match = xml_node_create(policy, NI_NANNY_IFPOLICY_MATCH)))
@@ -1085,7 +1107,7 @@ ni_ifconfig_migrate_link_node(xml_document_array_t *docs,
 	if (ni_ifconfig_migrate_link_port(migrate))
 		modified = TRUE;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	if (!policy || !(master = xml_node_get_child_cdata(migrate, "master")))
 		return modified;
 
@@ -1548,7 +1570,7 @@ ni_ifconfig_migrate_bond_node(xml_document_array_t *docs,
 	if (!(bond = ni_ifconfig_get_ifname(config)))
 		return modified;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	origin = ni_ifpolicy_get_origin(policy ?: config);
 	owner = ni_ifpolicy_get_owner(policy ?: config);
 
@@ -1628,7 +1650,7 @@ ni_ifconfig_migrate_team_node(xml_document_array_t *docs,
 	if (!(team = ni_ifconfig_get_ifname(config)))
 		return modified;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	origin = ni_ifpolicy_get_origin(policy ?: config);
 	owner = ni_ifpolicy_get_owner(policy ?: config);
 
@@ -1678,7 +1700,7 @@ ni_ifconfig_migrate_bridge_node(xml_document_array_t *docs,
 	if (!(bridge = ni_ifconfig_get_ifname(config)))
 		return modified;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	origin = ni_ifpolicy_get_origin(policy ?: config);
 	owner = ni_ifpolicy_get_owner(policy ?: config);
 
@@ -1745,7 +1767,7 @@ ni_ifconfig_migrate_ovsbr_node(xml_document_array_t *docs,
 	const char *owner;
 	const char *ovsbr;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	origin = ni_ifpolicy_get_origin(policy ?: config);
 	owner = ni_ifpolicy_get_owner(policy ?: config);
 
@@ -1864,7 +1886,7 @@ ni_ifxml_migrate_lower_device(xml_document_array_t *docs,
 	if (!(lower = ni_ifxml_resolve_ifname_node(docs, device, &index)))
 		return modified;
 
-	policy = ni_ifconfig_is_config(config) ? NULL : config->parent;
+	policy = ni_ifxml_is_config(config) ? NULL : config->parent;
 	if (ni_ifpolicy_match_remove_child_ref(policy, lower))
 		modified = TRUE;
 
@@ -2055,13 +2077,13 @@ ni_ifxml_migrate_ifconfig_node(xml_document_array_t *docs, const char *name,
 		doc = docs->data[i];
 		root = xml_document_root(doc);
 
-		if (ni_ifconfig_is_config(root)) {
+		if (ni_ifxml_is_config(root)) {
 			if (ni_ifconfig_migrate_node(docs, func, name, root))
 				modified = TRUE;
 			continue;
 		}
 
-		if (ni_ifconfig_is_policy(root)) {
+		if (ni_ifxml_is_policy(root)) {
 			if (ni_ifpolicy_migrate_node(docs, func, name, root))
 				modified = TRUE;
 			continue;

--- a/src/client/ifxml.c
+++ b/src/client/ifxml.c
@@ -372,8 +372,10 @@ ni_ifxml_is_policy(const xml_node_t *node)
 	if (node && node->children) {
 		if (ni_string_eq(node->name, NI_NANNY_IFPOLICY))
 			return TRUE;
+#ifdef NI_ENABLE_NANNY_TEMPLATE
 		if (ni_string_eq(node->name, NI_NANNY_IFTEMPLATE))
 			return TRUE;
+#endif
 	}
 	return FALSE;
 }

--- a/src/client/ifxml.c
+++ b/src/client/ifxml.c
@@ -183,8 +183,7 @@ ni_ifpolicy_set_owner_uid(xml_node_t *node, uid_t uid)
 	while (xml_node_del_attr(node, NI_NANNY_IFPOLICY_OWNER))
 		;
 
-	xml_node_add_attr_uint(node, NI_NANNY_IFPOLICY_OWNER, uid);
-	return TRUE;
+	return xml_node_add_attr_uint(node, NI_NANNY_IFPOLICY_OWNER, uid);
 }
 
 ni_bool_t
@@ -203,16 +202,14 @@ ni_ifpolicy_set_uuid(xml_node_t *node, const ni_uuid_t *uuid)
 {
 	const char *ptr;
 
-	if (!node)
+	ptr = ni_uuid_print(uuid);
+	if (!node || ni_string_empty(ptr))
 		return FALSE;
 
 	while (xml_node_del_attr(node, NI_NANNY_IFPOLICY_UUID))
 		;
 
-	ptr = ni_uuid_print(uuid);
-	if (!ni_string_empty(ptr))
-		xml_node_add_attr(node, NI_NANNY_IFPOLICY_UUID, ptr);
-	return TRUE;
+	return xml_node_add_attr(node, NI_NANNY_IFPOLICY_UUID, ptr);
 }
 
 /*

--- a/src/client/ifxml.h
+++ b/src/client/ifxml.h
@@ -1,8 +1,8 @@
 /*
- *	wicked client ifconfig structures and objects
+ *	wicked xml interface config and policy utilities
  *
  *	Copyright (C) 2010-2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
- *	Copyright (C) 2014-2024 SUSE LLC
+ *	Copyright (C) 2014-2025 SUSE LLC
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by

--- a/src/client/ifxml.h
+++ b/src/client/ifxml.h
@@ -94,11 +94,8 @@ extern ni_bool_t		ni_ifxml_node_is_migrated(const xml_node_t *);
 extern ni_bool_t		ni_ifxml_node_set_migrated(xml_node_t *, ni_bool_t);
 extern ni_bool_t		ni_ifxml_migrate_docs(xml_document_array_t *);
 
-static inline ni_bool_t
-ni_ifconfig_is_config(const xml_node_t *ifnode)
-{
-	return !xml_node_is_empty(ifnode) && ni_string_eq(ifnode->name, NI_CLIENT_IFCONFIG);
-}
+extern ni_bool_t		ni_ifxml_is_config(const xml_node_t *);
+extern ni_bool_t		ni_ifxml_is_policy(const xml_node_t *);
 
 static inline const char *
 ni_ifconfig_get_uuid(const xml_node_t *ifnode)
@@ -110,20 +107,6 @@ static inline const char *
 ni_ifconfig_get_origin(const xml_node_t *ifnode)
 {
 	return xml_node_get_attr(ifnode, NI_CLIENT_IFCONFIG_ORIGIN);
-}
-
-static inline ni_bool_t
-ni_ifconfig_is_policy(const xml_node_t *pnode)
-{
-	return !xml_node_is_empty(pnode) &&
-		(ni_string_eq(pnode->name, NI_NANNY_IFPOLICY) ||
-		 ni_string_eq(pnode->name, NI_NANNY_IFTEMPLATE));
-}
-
-static inline ni_bool_t
-ni_ifconfig_is_template(const xml_node_t *pnode)
-{
-	return !xml_node_is_empty(pnode) && ni_string_eq(pnode->name, NI_NANNY_IFTEMPLATE);
 }
 
 static inline const char *
@@ -159,7 +142,7 @@ ni_ifpolicy_get_weight(const xml_node_t *pnode)
 static inline ni_bool_t
 ni_ifpolicy_is_valid(const xml_node_t *pnode)
 {
-	if (!ni_ifconfig_is_policy(pnode))
+	if (!ni_ifxml_is_policy(pnode))
 		return FALSE;
 
 	return ni_ifpolicy_name_is_valid(ni_ifpolicy_get_name(pnode));

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -398,7 +398,7 @@ ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 static ni_bool_t
 ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, const char *name, xml_node_t *node)
 {
-	if (!policy || !fsm || xml_node_is_empty(node))
+	if (!policy || !fsm || !ni_ifxml_is_policy(node))
 		return FALSE;
 
 	if (ni_string_empty(name) && !(name = ni_ifpolicy_get_name(node)))
@@ -429,7 +429,7 @@ ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
 {
 	ni_fsm_policy_t temp;
 
-	if (!policy || !ni_ifconfig_is_policy(node)
+	if (!policy || !ni_ifxml_is_policy(node)
 	||  !ni_string_eq(ni_ifpolicy_get_name(node), policy->name))
 		return FALSE;
 

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -14,7 +14,7 @@
 #include <wicked/fsm.h>
 #include <limits.h>
 
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "util_priv.h"
 #include "refcount_priv.h"
 #include "array_priv.h"

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -275,8 +275,7 @@ ni_fsm_policy_uuid_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 				xml_node_location(node),
 				NI_NANNY_IFPOLICY_UUID, old, new);
 
-		ni_ifpolicy_set_uuid(node, &policy->uuid);
-		return FALSE;
+		return ni_ifpolicy_set_uuid(node, &policy->uuid);
 	}
 
 	if (!ni_uuid_equal(&policy->uuid, &uuid)) {
@@ -285,8 +284,7 @@ ni_fsm_policy_uuid_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 				xml_node_location(node),
 				NI_NANNY_IFPOLICY_UUID, old, new);
 
-		ni_ifpolicy_set_uuid(node, &policy->uuid);
-		return FALSE;
+		return ni_ifpolicy_set_uuid(node, &policy->uuid);
 	}
 
 	return TRUE;
@@ -313,7 +311,8 @@ ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 	if (!ni_fsm_policy_weight_from_xml(policy, node))
 		return FALSE;
 
-	(void)ni_fsm_policy_uuid_from_xml(policy, node);
+	if (!ni_fsm_policy_uuid_from_xml(policy, node))
+		return FALSE;
 
 	for (item = node->children; item; item = item->next) {
 		ni_fsm_policy_action_t *action = NULL;

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -206,17 +206,18 @@ ni_fsm_policy_type_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 {
 	if (ni_string_eq(node->name, NI_NANNY_IFPOLICY)) {
 		policy->type = NI_IFPOLICY_TYPE_CONFIG;
-	} else
+		return TRUE;
+	}
+#ifdef NI_ENABLE_NANNY_TEMPLATE
 	if (ni_string_eq(node->name, NI_NANNY_IFTEMPLATE)) {
 		policy->type = NI_IFPOLICY_TYPE_TEMPLATE;
-	} else {
-		ni_error("%s: invalid policy, node must be either <%s> or <%s>",
-				xml_node_location(node),
-				NI_NANNY_IFPOLICY,
-				NI_NANNY_IFTEMPLATE);
-		return FALSE;
+		return TRUE;
 	}
-	return TRUE;
+#endif
+	ni_error("%s: invalid policy, node must be either <%s> or <%s>",
+			xml_node_location(node),
+			NI_NANNY_IFPOLICY, NI_NANNY_IFTEMPLATE);
+	return FALSE;
 }
 
 static ni_bool_t

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -221,6 +221,21 @@ ni_fsm_policy_type_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 }
 
 static ni_bool_t
+ni_fsm_policy_name_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
+{
+	const char *name = ni_ifpolicy_get_name(node);
+
+	if (!ni_ifpolicy_name_is_valid(name)) {
+		ni_error("%s: invalid %s name \"%s\"",
+				xml_node_location(node), node->name,
+				ni_print_suspect(name, ni_string_len(name)));
+		return FALSE;
+	}
+
+	return ni_string_dup(&policy->name, name);
+}
+
+static ni_bool_t
 ni_fsm_policy_owner_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 {
 	const char *attr;
@@ -303,6 +318,9 @@ ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 		return TRUE;
 
 	if (!ni_fsm_policy_type_from_xml(policy, node))
+		return FALSE;
+
+	if (!ni_fsm_policy_name_from_xml(policy, node))
 		return FALSE;
 
 	if (!ni_fsm_policy_owner_from_xml(policy, node))

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -30,7 +30,7 @@
 #include <xml-schema.h>
 
 #include "dbus-objects/model.h"
-#include "client/ifconfig.h"
+#include "client/ifxml.h"
 #include "appconfig.h"
 #include "refcount_priv.h"
 #include "array_priv.h"


### PR DESCRIPTION
- Cleanup `is_config` and `is_policy` utilities to use `ni_ifxml` prefix,
  the interface related xml configuration in the `wicked:xml` scheme.
- Fix return status and in set owner and uuid utils and use the status
  when parsing `ifpolicy` xml node into an `fsm-policy` object.
- Disable the experimental and never used `template` policy type.
- Ensure the `fsm-policy` parsed from xml is complete or fail to parse.