### PR TITLE
policy: cleanup fsm-policy match and transform processing

### DIFF
--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -310,7 +310,6 @@ extern				ni_declare_refcounted_hold(ni_fsm_policy);
 extern				ni_declare_refcounted_drop(ni_fsm_policy);
 extern				ni_declare_refcounted_move(ni_fsm_policy);
 
-extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
 extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
 extern const xml_node_t *	ni_fsm_policy_node(const ni_fsm_policy_t *);
 extern const xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -297,6 +297,10 @@ extern ni_bool_t		ni_fsm_delete_policy(ni_fsm_t *, ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_ref(const ni_fsm_t *, const ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_name(const ni_fsm_t *, const char *);
 
+extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_ifworker_t *);
+extern ni_bool_t		ni_fsm_transform_policies_to_config(xml_node_t *,
+						ni_fsm_policy_t * const *, unsigned int);
+
 extern				ni_declare_refcounted_ref(ni_fsm_policy);
 extern				ni_declare_refcounted_free(ni_fsm_policy);
 extern				ni_declare_refcounted_hold(ni_fsm_policy);
@@ -307,9 +311,6 @@ extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
 extern int			ni_fsm_policy_compare_weight(const ni_fsm_policy_t *, const ni_fsm_policy_t *);
 extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
 						const ni_fsm_policy_t **, unsigned int);
-extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_fsm_policy_t *, ni_ifworker_t *);
-extern ni_bool_t		ni_fsm_transform_policies_to_config(xml_node_t *,
-						ni_fsm_policy_t * const *, unsigned int);
 extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
 extern const xml_node_t *	ni_fsm_policy_node(const ni_fsm_policy_t *);
 extern const xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -294,6 +294,8 @@ extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
 extern ni_fsm_policy_t *	ni_fsm_create_policy(ni_fsm_t *, xml_node_t *);
 extern ni_bool_t		ni_fsm_delete_policy(ni_fsm_t *, ni_fsm_policy_t *);
+extern ni_fsm_policy_t *	ni_fsm_get_policy_by_ref(const ni_fsm_t *, const ni_fsm_policy_t *);
+extern ni_fsm_policy_t *	ni_fsm_get_policy_by_name(const ni_fsm_t *, const char *);
 
 extern				ni_declare_refcounted_ref(ni_fsm_policy);
 extern				ni_declare_refcounted_free(ni_fsm_policy);
@@ -302,7 +304,6 @@ extern				ni_declare_refcounted_drop(ni_fsm_policy);
 extern				ni_declare_refcounted_move(ni_fsm_policy);
 
 extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
-extern ni_fsm_policy_t *	ni_fsm_policy_by_name(const ni_fsm_t *, const char *);
 extern int			ni_fsm_policy_compare_weight(const ni_fsm_policy_t *, const ni_fsm_policy_t *);
 extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
 						const ni_fsm_policy_t **, unsigned int);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -307,7 +307,8 @@ extern int			ni_fsm_policy_compare_weight(const ni_fsm_policy_t *, const ni_fsm_
 extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
 						const ni_fsm_policy_t **, unsigned int);
 extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_fsm_policy_t *, ni_ifworker_t *);
-extern xml_node_t *		ni_fsm_policy_transform_document(xml_node_t *, ni_fsm_policy_t * const *, unsigned int);
+extern ni_bool_t		ni_fsm_transform_policies_to_config(xml_node_t *,
+						ni_fsm_policy_t * const *, unsigned int);
 extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
 extern const xml_node_t *	ni_fsm_policy_node(const ni_fsm_policy_t *);
 extern const xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -316,6 +316,9 @@ extern const ni_uuid_t *	ni_fsm_policy_uuid(const ni_fsm_policy_t *);
 extern uid_t			ni_fsm_policy_owner(const ni_fsm_policy_t *);
 extern const char *		ni_fsm_policy_origin(const ni_fsm_policy_t *);
 extern unsigned int		ni_fsm_policy_weight(const ni_fsm_policy_t *);
+extern ni_ifworker_type_t	ni_fsm_policy_config_type(const ni_fsm_policy_t *);
+extern const ni_dbus_class_t *	ni_fsm_policy_config_class(const ni_fsm_policy_t *);
+
 extern ni_bool_t		ni_fsm_policies_changed_since(const ni_fsm_t *, unsigned int *tstamp);
 
 extern				ni_declare_ptr_array_init(ni_fsm_policy);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -292,8 +292,7 @@ extern void			ni_fsm_events_block(ni_fsm_t *);
 extern void			ni_fsm_process_events(ni_fsm_t *);
 extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
-extern				ni_declare_refcounted_new(ni_fsm_policy,
-						ni_fsm_t *, const char *, xml_node_t *);
+extern				ni_declare_refcounted_new(ni_fsm_policy, ni_fsm_t *, xml_node_t *);
 extern				ni_declare_refcounted_ref(ni_fsm_policy);
 extern				ni_declare_refcounted_free(ni_fsm_policy);
 extern				ni_declare_refcounted_hold(ni_fsm_policy);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -293,6 +293,7 @@ extern void			ni_fsm_process_events(ni_fsm_t *);
 extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
 extern ni_fsm_policy_t *	ni_fsm_create_policy(ni_fsm_t *, xml_node_t *);
+extern ni_bool_t		ni_fsm_delete_policy(ni_fsm_t *, ni_fsm_policy_t *);
 
 extern				ni_declare_refcounted_ref(ni_fsm_policy);
 extern				ni_declare_refcounted_free(ni_fsm_policy);
@@ -301,7 +302,6 @@ extern				ni_declare_refcounted_drop(ni_fsm_policy);
 extern				ni_declare_refcounted_move(ni_fsm_policy);
 
 extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
-extern ni_bool_t		ni_fsm_policy_remove(ni_fsm_t *, ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_policy_by_name(const ni_fsm_t *, const char *);
 extern int			ni_fsm_policy_compare_weight(const ni_fsm_policy_t *, const ni_fsm_policy_t *);
 extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -293,6 +293,7 @@ extern void			ni_fsm_process_events(ni_fsm_t *);
 extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
 extern ni_fsm_policy_t *	ni_fsm_create_policy(ni_fsm_t *, xml_node_t *);
+extern ni_fsm_policy_t *	ni_fsm_replace_policy(ni_fsm_policy_t *, xml_node_t *);
 extern ni_bool_t		ni_fsm_delete_policy(ni_fsm_t *, ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_ref(const ni_fsm_t *, const ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_name(const ni_fsm_t *, const char *);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -292,7 +292,8 @@ extern void			ni_fsm_events_block(ni_fsm_t *);
 extern void			ni_fsm_process_events(ni_fsm_t *);
 extern void			ni_fsm_events_unblock(ni_fsm_t *);
 
-extern				ni_declare_refcounted_new(ni_fsm_policy, ni_fsm_t *, xml_node_t *);
+extern ni_fsm_policy_t *	ni_fsm_create_policy(ni_fsm_t *, xml_node_t *);
+
 extern				ni_declare_refcounted_ref(ni_fsm_policy);
 extern				ni_declare_refcounted_free(ni_fsm_policy);
 extern				ni_declare_refcounted_hold(ni_fsm_policy);

--- a/include/wicked/fsm.h
+++ b/include/wicked/fsm.h
@@ -297,6 +297,8 @@ extern ni_bool_t		ni_fsm_delete_policy(ni_fsm_t *, ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_ref(const ni_fsm_t *, const ni_fsm_policy_t *);
 extern ni_fsm_policy_t *	ni_fsm_get_policy_by_name(const ni_fsm_t *, const char *);
 
+extern unsigned int		ni_fsm_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
+						ni_fsm_policy_array_t *, unsigned int);
 extern ni_bool_t		ni_fsm_exists_applicable_policy(const ni_fsm_t *, ni_ifworker_t *);
 extern ni_bool_t		ni_fsm_transform_policies_to_config(xml_node_t *,
 						ni_fsm_policy_t * const *, unsigned int);
@@ -308,9 +310,6 @@ extern				ni_declare_refcounted_drop(ni_fsm_policy);
 extern				ni_declare_refcounted_move(ni_fsm_policy);
 
 extern ni_bool_t		ni_fsm_policy_update(ni_fsm_policy_t *, xml_node_t *);
-extern int			ni_fsm_policy_compare_weight(const ni_fsm_policy_t *, const ni_fsm_policy_t *);
-extern unsigned int		ni_fsm_policy_get_applicable_policies(const ni_fsm_t *, ni_ifworker_t *,
-						const ni_fsm_policy_t **, unsigned int);
 extern const char *		ni_fsm_policy_name(const ni_fsm_policy_t *);
 extern const xml_node_t *	ni_fsm_policy_node(const ni_fsm_policy_t *);
 extern const xml_location_t *	ni_fsm_policy_location(const ni_fsm_policy_t *);

--- a/include/wicked/xml.h
+++ b/include/wicked/xml.h
@@ -184,6 +184,7 @@ extern				ni_declare_ptr_array_index(xml_document);
 extern				ni_declare_ptr_array_init(xml_node);
 extern				ni_declare_ptr_array_destroy(xml_node);
 extern				ni_declare_ptr_array_append(xml_node);
+extern				ni_declare_ptr_array_append_ref(xml_node);
 
 extern xml_node_array_t *	xml_node_array_new(void);
 extern void			xml_node_array_free(xml_node_array_t *);

--- a/include/wicked/xml.h
+++ b/include/wicked/xml.h
@@ -183,7 +183,6 @@ extern				ni_declare_ptr_array_index(xml_document);
 
 extern				ni_declare_ptr_array_init(xml_node);
 extern				ni_declare_ptr_array_destroy(xml_node);
-extern				ni_declare_ptr_array_append(xml_node);
 extern				ni_declare_ptr_array_append_ref(xml_node);
 
 extern xml_node_array_t *	xml_node_array_new(void);

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -196,13 +196,14 @@ ni_factory_device_apply_policy(ni_fsm_t *fsm, ni_ifworker_t *w, ni_managed_polic
 	/* This returns "modem" or "interface" */
 	type_name = ni_ifworker_type_to_string(w->type);
 
-	config = xml_node_new(type_name, NULL);
-	xml_node_new_element("name", config, w->name);
+	if (type_name && (config = xml_node_new(type_name, NULL)))
+		xml_node_new_element("name", config, w->name);
 
-	config = ni_fsm_policy_transform_document(config, &policy, 1);
-	if (config == NULL) {
-		ni_error("%s: error when applying policy to %s document",
-			w->name, type_name);
+	if (!ni_fsm_transform_policies_to_config(config, &policy, 1)) {
+		xml_node_free(config);
+		ni_error("%s: unable to transform policy %s into config [%s]",
+				w->name, ni_fsm_policy_name(policy),
+				ni_fsm_policy_origin(policy));
 		return -1;
 	}
 
@@ -261,14 +262,17 @@ ni_managed_device_apply_policy(ni_managed_device_t *mdev, ni_managed_policy_t *m
 	/* This returns "modem" or "interface" */
 	type_name = ni_ifworker_type_to_string(w->type);
 
-	config = xml_node_new(type_name, NULL);
-	xml_node_new_element("name", config, w->name);
+	if (type_name && (config = xml_node_new(type_name, NULL)))
+		xml_node_new_element("name", config, w->name);
 
-	config = ni_fsm_policy_transform_document(config, &policy, 1);
-	if (config == NULL) {
-		ni_error("%s: error when applying policy to %s document", w->name, type_name);
+	if (!ni_fsm_transform_policies_to_config(config, &policy, 1)) {
+		xml_node_free(config);
+		ni_error("%s: unable to transform policy %s into config [%s]",
+				w->name, ni_fsm_policy_name(policy),
+				ni_fsm_policy_origin(policy));
 		return -1;
 	}
+
 	ni_debug_config_xml(config, NI_LOG_DEBUG, "%s: using device config", w->name);
 
 	ni_managed_device_set_policy(mdev, mpolicy, config);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -992,7 +992,7 @@ ni_objectmodel_nanny_delete_policy(ni_dbus_object_t *object, const ni_dbus_metho
 			ni_dbus_server_t *server;
 			ni_ifworker_t *w = NULL;
 
-			if (!ni_fsm_policy_remove(mgr->fsm, policy))
+			if (!ni_fsm_delete_policy(mgr->fsm, policy))
 				return FALSE;
 
 			ni_nanny_policy_drop(name);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -517,7 +517,7 @@ ni_nanny_register_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 			mdev->allowed? ", user control allowed" : "",
 			mdev->monitor? ", monitored (auto-enabled)" : "");
 
-	if (ni_fsm_exists_applicable_policy(mgr->fsm, mgr->fsm->policies, w))
+	if (ni_fsm_exists_applicable_policy(mgr->fsm, w))
 		ni_nanny_schedule_recheck(&mgr->recheck, w);
 
 	ni_ifworker_set_progress_callback(w, ni_managed_device_progress, mdev);
@@ -543,7 +543,7 @@ ni_nanny_unregister_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 	ni_ifworker_set_completion_callback(w, NULL, NULL);
 
 	if (!ni_ifworker_is_factory_device(w) ||
-	    !ni_fsm_exists_applicable_policy(mgr->fsm, mgr->fsm->policies, w)) {
+	    !ni_fsm_exists_applicable_policy(mgr->fsm, w)) {
 		ni_nanny_unschedule(&mgr->recheck, w);
 	}
 }
@@ -799,7 +799,7 @@ ni_nanny_process_rename_event(ni_nanny_t *mgr, ni_ifworker_t *w)
 	}
 
 	/* apply matching policies and rearm */
-	if (ni_fsm_exists_applicable_policy(mgr->fsm, mgr->fsm->policies, w)) {
+	if (ni_fsm_exists_applicable_policy(mgr->fsm, w)) {
 		ni_debug_application("%s: schedule recheck for renamed device (%s)",
 				w->name, w->old_name);
 		ni_nanny_schedule_recheck(&mgr->recheck, w);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -1071,8 +1071,8 @@ ni_nanny_recheck_policy(ni_nanny_t *mgr, ni_fsm_policy_t *policy)
 		const char *origin = ni_fsm_policy_origin(policy);
 
 		config = xml_node_new(NI_CLIENT_IFCONFIG, NULL);
-		config = ni_fsm_policy_transform_document(config, &policy, 1);
-		if (!config) {
+		if (!ni_fsm_transform_policies_to_config(config, &policy, 1)) {
+			xml_node_free(config);
 			ni_error("Unable to transform policy %s into config [%s]",
 					ni_fsm_policy_name(policy), origin);
 			return FALSE;

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -387,7 +387,7 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, xml_do
 		ni_string_free(&location);
 	}
 
-	if (!(policy = ni_fsm_policy_new(mgr->fsm, pname, pnode))) {
+	if (!(policy = ni_fsm_policy_new(mgr->fsm, pnode))) {
 		ni_error("Unable to create policy object for %s", pname);
 		goto error;
 	}

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -1062,16 +1062,21 @@ static ni_bool_t
 ni_nanny_recheck_policy(ni_nanny_t *mgr, ni_fsm_policy_t *policy)
 {
 	ni_managed_device_t *mdev;
-	xml_node_t *config;
+	xml_node_t *config = NULL;
 	ni_ifworker_t *w;
 
 	w = ni_fsm_ifworker_by_policy_name(mgr->fsm, NI_IFWORKER_TYPE_NETDEV,
 							ni_fsm_policy_name(policy));
 	if (w == NULL || !w->config.node) {
 		const char *origin = ni_fsm_policy_origin(policy);
+		const char *type_name;
 
-		config = xml_node_new(NI_CLIENT_IFCONFIG, NULL);
-		if (!ni_fsm_transform_policies_to_config(config, &policy, 1)) {
+		type_name = ni_ifworker_type_to_string(ni_fsm_policy_config_type(policy));
+
+		if (type_name && (config = xml_node_new(type_name, NULL)))
+			xml_node_location_relocate(config, ni_fsm_policy_name(policy));
+
+		if (!config || !ni_fsm_transform_policies_to_config(config, &policy, 1)) {
 			xml_node_free(config);
 			ni_error("Unable to transform policy %s into config [%s]",
 					ni_fsm_policy_name(policy), origin);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -387,7 +387,7 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, xml_do
 		ni_string_free(&location);
 	}
 
-	if (!(policy = ni_fsm_policy_new(mgr->fsm, pnode))) {
+	if (!(policy = ni_fsm_create_policy(mgr->fsm, pnode))) {
 		ni_error("Unable to create policy object for %s", pname);
 		goto error;
 	}

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -372,7 +372,7 @@ ni_nanny_create_policy(ni_dbus_object_t **policy_object, ni_nanny_t *mgr, xml_do
 		goto error;
 	}
 
-	policy = ni_fsm_policy_by_name(mgr->fsm, pname);
+	policy = ni_fsm_get_policy_by_name(mgr->fsm, pname);
 	if (policy) {
 		ni_debug_nanny("Policy \"%s\" already exists", pname);
 		rv = 0;
@@ -985,7 +985,7 @@ ni_objectmodel_nanny_delete_policy(ni_dbus_object_t *object, const ni_dbus_metho
 	ni_debug_nanny("Attempting to delete policy %s", name);
 
 	/* Unregistering Policy dbus object */
-	if ((policy = ni_fsm_policy_by_name(mgr->fsm, name))) {
+	if ((policy = ni_fsm_get_policy_by_name(mgr->fsm, name))) {
 		ni_managed_policy_t *mpolicy;
 
 		if ((mpolicy = ni_nanny_get_policy(mgr, policy))) {
@@ -1134,7 +1134,7 @@ ni_nanny_recheck_policies(ni_nanny_t *mgr, const ni_string_array_t *ifnames)
 			char *name = ni_ifpolicy_name_from_ifname(ifname);
 
 			/* TODO: get rid of this using a policy applicable match */
-			if (!name || !(policy = ni_fsm_policy_by_name(mgr->fsm, name))) {
+			if (!name || !(policy = ni_fsm_get_policy_by_name(mgr->fsm, name))) {
 				ni_string_free(&name);
 				ni_debug_application("Not scheduled any recheck for %s: no policy", ifname);
 				continue;

--- a/src/client/ifxml.h
+++ b/src/client/ifxml.h
@@ -61,6 +61,7 @@
 #define NI_NANNY_IFPOLICY_OWNER			NI_CONFIG_OWNER
 #define NI_NANNY_IFPOLICY_UUID			NI_CONFIG_UUID
 #define NI_NANNY_IFPOLICY_WEIGHT		"weight"
+#define NI_NANNY_IFPOLICY_CLASS			"class"
 #define NI_NANNY_IFPOLICY_NAME			"name"
 
 extern ni_bool_t		ni_ifpolicy_match_add_min_state(xml_node_t *, ni_fsm_state_t);
@@ -107,6 +108,12 @@ static inline const char *
 ni_ifconfig_get_origin(const xml_node_t *ifnode)
 {
 	return xml_node_get_attr(ifnode, NI_CLIENT_IFCONFIG_ORIGIN);
+}
+
+static inline const char *
+ni_ifpolicy_get_class(const xml_node_t *pnode)
+{
+	return xml_node_get_attr(pnode, NI_NANNY_IFPOLICY_CLASS);
 }
 
 static inline const char *

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -556,7 +556,7 @@ ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
 }
 
 ni_bool_t
-ni_fsm_policy_remove(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
+ni_fsm_delete_policy(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
 {
 	ni_fsm_policy_t *cur;
 

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -488,19 +488,15 @@ ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 }
 
 static ni_bool_t
-ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, const char *name, xml_node_t *node)
+ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, xml_node_t *node)
 {
-	if (!policy || !fsm || !ni_ifxml_is_policy(node))
-		return FALSE;
-
-	if (ni_string_empty(name) && !(name = ni_ifpolicy_get_name(node)))
+	if (!policy || !fsm || !node || !node->children)
 		return FALSE;
 
 	memset(policy, 0, sizeof(*policy));
 
 	policy->owner = -1U;
-	if (!ni_string_dup(&policy->name, name) ||
-	    !ni_fsm_policy_from_xml(policy, node)) {
+	if (!ni_fsm_policy_from_xml(policy, node)) {
 		ni_fsm_policy_destroy(policy);
 		return FALSE;
 	}
@@ -509,7 +505,7 @@ ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, const char *name, xml
 	return TRUE;
 }
 
-extern ni_define_refcounted_new(ni_fsm_policy, ni_fsm_t *, const char *, xml_node_t *);
+extern ni_define_refcounted_new(ni_fsm_policy, ni_fsm_t *, xml_node_t *);
 extern ni_define_refcounted_ref(ni_fsm_policy);
 extern ni_define_refcounted_free(ni_fsm_policy);
 extern ni_define_refcounted_hold(ni_fsm_policy);

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -825,16 +825,22 @@ ni_fsm_policy_get_applicable_policies(const ni_fsm_t *fsm, ni_ifworker_t *w,
 }
 
 ni_bool_t
-ni_fsm_exists_applicable_policy(const ni_fsm_t *fsm, ni_fsm_policy_t *list, ni_ifworker_t *w)
+ni_fsm_exists_applicable_policy(const ni_fsm_t *fsm, ni_ifworker_t *w)
 {
 	ni_fsm_policy_t *policy;
 
-	if (!list || !w)
+	if (!fsm || !w)
 		return FALSE;
 
-	for (policy = list; policy; policy = policy->next) {
-		if (ni_fsm_policy_applicable(fsm, policy, w))
-			return TRUE;
+	for (policy = fsm->policies; policy; policy = policy->next) {
+		if (policy->type == NI_FSM_POLICY_TYPE_CONFIG) {
+
+			if (policy->config.type != w->type)
+				continue;
+
+			if (ni_fsm_policy_applicable(fsm, policy, w))
+				return TRUE;
+		}
 	}
 
 	return FALSE;

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -523,6 +523,30 @@ ni_fsm_create_policy(ni_fsm_t *fsm, xml_node_t *node)
 	return policy;
 }
 
+ni_fsm_policy_t *
+ni_fsm_replace_policy(ni_fsm_policy_t *policy, xml_node_t *node)
+{
+	ni_fsm_policy_t *update;
+
+	if (!policy || !policy->pprev)
+		return NULL;
+
+	if (!(update = ni_fsm_policy_new(node)))
+		return NULL;
+
+	if (!ni_string_eq(policy->name, update->name)) {
+		ni_error("Cannot replace policy '%s' with policy '%s'",
+				policy->name, update->name);
+		ni_fsm_policy_free(update);
+		return NULL;
+	}
+
+	ni_fsm_policy_list_insert(&policy->next, update);
+	ni_fsm_policy_list_unlink(policy);
+	ni_fsm_policy_free(policy);
+	return update;
+}
+
 ni_bool_t
 ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
 {

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -488,9 +488,9 @@ ni_fsm_policy_from_xml(ni_fsm_policy_t *policy, xml_node_t *node)
 }
 
 static ni_bool_t
-ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, xml_node_t *node)
+ni_fsm_policy_init(ni_fsm_policy_t *policy, xml_node_t *node)
 {
-	if (!policy || !fsm || !node || !node->children)
+	if (!policy || !node || !node->children)
 		return FALSE;
 
 	memset(policy, 0, sizeof(*policy));
@@ -501,16 +501,27 @@ ni_fsm_policy_init(ni_fsm_policy_t *policy, ni_fsm_t *fsm, xml_node_t *node)
 		return FALSE;
 	}
 
-	ni_fsm_policy_list_insert(&fsm->policies, policy);
 	return TRUE;
 }
 
-extern ni_define_refcounted_new(ni_fsm_policy, ni_fsm_t *, xml_node_t *);
+static ni_define_refcounted_new(ni_fsm_policy, xml_node_t *);
 extern ni_define_refcounted_ref(ni_fsm_policy);
 extern ni_define_refcounted_free(ni_fsm_policy);
 extern ni_define_refcounted_hold(ni_fsm_policy);
 extern ni_define_refcounted_drop(ni_fsm_policy);
 extern ni_define_refcounted_move(ni_fsm_policy);
+
+ni_fsm_policy_t *
+ni_fsm_create_policy(ni_fsm_t *fsm, xml_node_t *node)
+{
+	ni_fsm_policy_t *policy;
+
+	if (!fsm || !(policy = ni_fsm_policy_new(node)))
+		return NULL;
+
+	ni_fsm_policy_list_insert(&fsm->policies, policy);
+	return policy;
+}
 
 ni_bool_t
 ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -594,12 +594,30 @@ ni_fsm_policies_changed_since(const ni_fsm_t *fsm, unsigned int *tstamp)
 }
 
 ni_fsm_policy_t *
-ni_fsm_policy_by_name(const ni_fsm_t *fsm, const char *name)
+ni_fsm_get_policy_by_ref(const ni_fsm_t *fsm, const ni_fsm_policy_t *ref)
 {
 	ni_fsm_policy_t *policy;
 
+	if (!fsm || !ref)
+		return NULL;
+
 	for (policy = fsm->policies; policy; policy = policy->next) {
-		if (policy->name && ni_string_eq(policy->name, name))
+		if (policy == ref)
+			return policy;
+	}
+	return NULL;
+}
+
+ni_fsm_policy_t *
+ni_fsm_get_policy_by_name(const ni_fsm_t *fsm, const char *name)
+{
+	ni_fsm_policy_t *policy;
+
+	if (!fsm || ni_string_empty(name))
+		return NULL;
+
+	for (policy = fsm->policies; policy; policy = policy->next) {
+		if (ni_string_eq(policy->name, name))
 			return policy;
 	}
 	return NULL;

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -794,8 +794,11 @@ ni_fsm_policy_transform_document(xml_node_t *node, ni_fsm_policy_t * const *poli
 {
 	unsigned int i = 0;
 
-	/* Apply policies in order of decreasing weight */
-	for (i = count; i--; ) {
+	/*
+	 * Apply policies in order of increasing weight,
+	 * see e) in the transform description above.
+	 */
+	for (i = 0; i < count; ++i) {
 		const ni_fsm_policy_t *policy = policies[i];
 		ni_fsm_policy_action_t *action;
 

--- a/src/fsm-policy.c
+++ b/src/fsm-policy.c
@@ -548,38 +548,6 @@ ni_fsm_replace_policy(ni_fsm_policy_t *policy, xml_node_t *node)
 }
 
 ni_bool_t
-ni_fsm_policy_update(ni_fsm_policy_t *policy, xml_node_t *node)
-{
-	ni_fsm_policy_t temp;
-
-	if (!policy || !ni_ifxml_is_policy(node)
-	||  !ni_string_eq(ni_ifpolicy_get_name(node), policy->name))
-		return FALSE;
-
-	memset(&temp, 0, sizeof(temp));
-	temp.owner = -1U;
-
-	if (!ni_fsm_policy_from_xml(&temp, node)) {
-		ni_fsm_policy_destroy(&temp);
-		return FALSE;
-	}
-
-	ni_fsm_policy_reset(policy);
-	policy->type = temp.type;
-	policy->seq = temp.seq;
-	policy->uuid = temp.uuid;
-	policy->owner = temp.owner;
-	policy->weight = temp.weight;
-	policy->create_action = temp.create_action;
-	policy->actions = temp.actions;
-	policy->match = temp.match;
-
-	xml_node_free(policy->node);
-	policy->node = temp.node;
-	return TRUE;
-}
-
-ni_bool_t
 ni_fsm_delete_policy(ni_fsm_t *fsm, ni_fsm_policy_t *policy)
 {
 	ni_fsm_policy_t *cur;

--- a/src/xml.c
+++ b/src/xml.c
@@ -787,6 +787,7 @@ extern ni_define_ptr_array_init(xml_node);
 extern ni_define_ptr_array_destroy(xml_node);
 static ni_define_ptr_array_realloc(xml_node, XML_NODE_ARRAY_CHUNK)
 extern ni_define_ptr_array_append(xml_node);
+extern ni_define_ptr_array_append_ref(xml_node);
 
 xml_node_array_t *
 xml_node_array_new(void)

--- a/src/xml.c
+++ b/src/xml.c
@@ -786,7 +786,6 @@ extern ni_define_ptr_array_index(xml_document);
 extern ni_define_ptr_array_init(xml_node);
 extern ni_define_ptr_array_destroy(xml_node);
 static ni_define_ptr_array_realloc(xml_node, XML_NODE_ARRAY_CHUNK)
-extern ni_define_ptr_array_append(xml_node);
 extern ni_define_ptr_array_append_ref(xml_node);
 
 xml_node_array_t *


### PR DESCRIPTION
- Fix crash and leak on error in policy action processing when transforming
  them to effective config (not triggered by policies generated from ifcfg).
- Cleanup applicable fsm policy matching to use fsm_policy_array in recheck
- Adjust fsm function names acting on policies vs fsm-policy functions.
- Changed to replace the inner fsm-policy in managed policy update instead
  to tweak it's content, to not require content changed compare later.