### PR TITLE
teamd: fix TEAM_LACP_ACTIVE default to true

### DIFF
--- a/client/suse/compat-suse.c
+++ b/client/suse/compat-suse.c
@@ -2881,7 +2881,6 @@ try_team(ni_suse_ifcfg_array_t *ifcfgs, ni_suse_ifcfg_t *ifcfg)
 				}
 			}
 
-			lacp->config.sys_prio = 255;
 			if ((value = ni_sysconfig_get_value(sc, "TEAM_LACP_SYS_PRIO")) != NULL) {
 				if (ni_parse_uint(value, &lacp->config.sys_prio, 0) < 0) {
 					ni_error("ifcfg-%s: Cannot parse TEAM_LACP_SYS_PRIO='%s'",
@@ -2914,7 +2913,6 @@ try_team(ni_suse_ifcfg_array_t *ifcfgs, ni_suse_ifcfg_t *ifcfg)
 				}
 			}
 
-			lacp->config.tx_hash = NI_TEAM_TX_HASH_NONE;
 			if ((value = ni_sysconfig_get_value(sc, "TEAM_LACP_TX_HASH")) != NULL) {
 				ni_string_array_t flags = NI_STRING_ARRAY_INIT;
 				unsigned int i;
@@ -2943,7 +2941,6 @@ try_team(ni_suse_ifcfg_array_t *ifcfgs, ni_suse_ifcfg_t *ifcfg)
 				}
 			}
 
-			lacp->config.tx_balancer.interval = 50;
 			if ((value = ni_sysconfig_get_value(sc, "TEAM_LACP_TX_BALANCER_INTERVAL")) != NULL) {
 				if (ni_parse_uint(value, &lacp->config.tx_balancer.interval, 0) < 0) {
 					ni_error("ifcfg-%s: Cannot parse TEAM_LACP_TX_BALANCER_INTERVAL='%s'",

--- a/man/ifcfg-team.5.in
+++ b/man/ifcfg-team.5.in
@@ -148,7 +148,7 @@ Fast rate asks link partner to transmit LACPDU frames once per second.
 Otherwise they are sent every 30 seconds.
 .RS
 .PP
-Default: \f[B]true\f[R]
+Default: \f[B]false\f[R]
 .RE
 .TP
 \f[CR]TEAM_LACP_MIN_PORTS\f[R]

--- a/man/src/ifcfg-team.5.md
+++ b/man/src/ifcfg-team.5.md
@@ -131,7 +131,7 @@ the usual network settings. But you must add additional variables
 :   Fast rate asks link partner to transmit LACPDU frames once per second.
     Otherwise they are sent every 30 seconds.
 
-    Default: **true**
+    Default: **false**
 
 `TEAM_LACP_MIN_PORTS`
 :   Minimum number of active ports required to assert carrier in master device.

--- a/src/team.c
+++ b/src/team.c
@@ -216,6 +216,15 @@ ni_team_ab_hwaddr_policy_name_to_type(const char *name, ni_team_ab_hwaddr_policy
 	return TRUE;
 }
 
+static void
+ni_team_runner_lacp_init(ni_team_runner_lacp_t *lacp)
+{
+	lacp->config.active = TRUE;
+	lacp->config.sys_prio = 255;
+	lacp->config.tx_hash = NI_TEAM_TX_HASH_NONE;
+	lacp->config.tx_balancer.interval = 50;
+}
+
 void
 ni_team_runner_init(ni_team_runner_t *runner, ni_team_runner_type_t type)
 {
@@ -229,7 +238,10 @@ ni_team_runner_init(ni_team_runner_t *runner, ni_team_runner_type_t type)
 	case NI_TEAM_RUNNER_LOAD_BALANCE:
 	case NI_TEAM_RUNNER_BROADCAST:
 	case NI_TEAM_RUNNER_RANDOM:
+		break;
 	case NI_TEAM_RUNNER_LACP:
+		ni_team_runner_lacp_init(&runner->lacp);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
* Fix default of TEAM_LACP_ACTIVE to true.
* Fix default of TEAM_LACP_FAST_RATE in manpage ifcfg-team.5
* Set all none zero defaults in ni_team_runner_init()

