### PR TITLE
spec: guard the sle_version macro

### DIFF
--- a/wicked.spec.in
+++ b/wicked.spec.in
@@ -48,10 +48,16 @@ Provides:       libwicked@LIBWICKED_PACKAGE_SUFFIX@ = %{version}-%{release}
 Provides:       libwicked-0-6 = %{version}
 Obsoletes:      libwicked-0-6 < %{version}
 
-%if 0%{?suse_version} > 1500 || 0%{?sle_version} >= 150500
+%if 0%{?suse_version} > 1500
+%bcond_without  nbft
+%else
+# boo#1238724: guard the sle_version check inside a suse_version block as
+#              workaround for broken recursive sle_version on leap-16.0 …
+%if 0%{?sle_version} >= 150500
 %bcond_without  nbft
 %else
 %bcond_with     nbft
+%endif
 %endif
 %if 0%{?suse_version} >= 1500
 %bcond_without  rfc4361_cid


### PR DESCRIPTION
Guard the `sle_version` check inside a `suse_version` block as workaround for broken recursive `sle_version` declaration
on LEAP-16.0 in `/etc/rpm/macros.leap`:
```
%sle_version %sle_version
```
causing `rpmbuild` to fail with `Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.` error. See also https://bugzilla.opensuse.org/show_bug.cgi?id=1238724

**Note:** build-system or local builds using `osc build` are not affected, because the `Leap-release` package providing the broken `/etc/rpm/macros.leap` file is not installed by default in the build-root. It affects only local builds using `rpmbuild` e.g. in wicked's `make rpmbuild` as `Leap-release` is  available by default on an installed Leap-16.0 system.