### PR TITLE
netlink: remove libnl-route dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,7 +268,7 @@ AM_PATH_LIBGCRYPT([$REQUIRE_LIBGCRYPT],,[
 AC_SUBST(REQUIRE_LIBGCRYPT)
 
 # Checks for pkg-config modules.
-PKG_CHECK_MODULES(LIBNL, [libnl-3.0 libnl-route-3.0])
+PKG_CHECK_MODULES(LIBNL, [libnl-3.0])
 PKG_CHECK_MODULES(LIBDBUS, [dbus-1])
 
 # Check for systemd modules.

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -22,10 +22,6 @@
 #define aligned_u64 uint64_t
 #include <linux/if_ppp.h>
 #include <netlink/msg.h>
-#include <netlink/route/rtnl.h>
-#include <netlink/genl/genl.h>
-#include <netlink/genl/ctrl.h>
-#include <netlink/genl/family.h>
 
 #include "netinfo_priv.h"
 #include "util_priv.h"

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -482,6 +482,9 @@ ni_nl_dump_store(int af, int type, struct ni_nlmsg_list *list)
 		.msg_type = -1,
 		.list = list,
 	};
+	struct rtgenmsg gmsg = {
+		.rtgen_family = af,
+	};
 	struct nl_cb *cb;
 	const char *name;
 	int rv;
@@ -492,7 +495,7 @@ ni_nl_dump_store(int af, int type, struct ni_nlmsg_list *list)
 		return -NLE_BAD_SOCK;
 	}
 
-	if ((rv = nl_rtgen_request(nl_sock, type, af, NLM_F_DUMP)) < 0) {
+	if ((rv = nl_send_simple(nl_sock, type, NLM_F_DUMP, &gmsg, sizeof(gmsg))) < 0) {
 		ni_error("%s: failed to send request", name);
 		return rv;
 	}


### PR DESCRIPTION
Remove the (only/remaining) `libnl-route` function call of `nl_rtgen_request` to avoid automatic cache (de-)registrations at start and exit of all binaries.