### PR TITLE
nanny: use opaque id for managed-netif dbus path

### DIFF
--- a/nanny/device.c
+++ b/nanny/device.c
@@ -73,13 +73,18 @@ ni_managed_device_list_unlink(ni_managed_device_t *mdev)
  * create a new managed_device object
  */
 ni_managed_device_t *
-ni_managed_device_new(ni_nanny_t *mgr, unsigned int ifindex, ni_managed_device_t **list)
+ni_managed_device_new(ni_nanny_t *mgr, ni_ifworker_t *w, ni_managed_device_t **list)
 {
 	ni_managed_device_t *mdev;
 
-	mdev = xcalloc(1, sizeof(*mdev));
+	if (!mgr || !w)
+		return NULL;
+
+	if (!(mdev = calloc(1, sizeof(*mdev))))
+		return NULL;
+
 	mdev->nanny = mgr;
-	mdev->ifindex = ifindex;
+	mdev->worker = ni_ifworker_ref(w);
 
 	if (list)
 		ni_managed_device_list_append(list, mdev);
@@ -90,10 +95,15 @@ ni_managed_device_new(ni_nanny_t *mgr, unsigned int ifindex, ni_managed_device_t
 void
 ni_managed_device_free(ni_managed_device_t *mdev)
 {
-	ni_ifworker_t *w = ni_managed_device_get_worker(mdev);
+	ni_assert(mdev);
 
-	ni_debug_nanny("%s(%s): obj=%p", __func__, w ? w->name : "anon", mdev->object);
+	ni_debug_nanny("%s(%p): object=%p/%s, worker=%p/%s", __func__, mdev,
+			mdev->object, mdev->object ? mdev->object->path : NULL,
+			mdev->worker, mdev->worker ? mdev->worker->name : NULL);
+
 	ni_assert(mdev->object == NULL);
+
+	ni_ifworker_drop(&mdev->worker);
 
 	ni_secret_array_destroy(&mdev->secrets);
 	free(mdev);
@@ -134,16 +144,7 @@ ni_managed_device_set_security_id(ni_managed_device_t *mdev, const ni_security_i
 ni_ifworker_t *
 ni_managed_device_get_worker(const ni_managed_device_t *mdev)
 {
-	ni_fsm_t *fsm;
-	ni_ifworker_t *w;
-
-	if (!mdev || !mdev->nanny || !(fsm = mdev->nanny->fsm))
-		return NULL;
-
-	if (!(w = ni_fsm_ifworker_by_ifindex(fsm, mdev->ifindex)))
-		ni_debug_nanny("%s: no corresponding worker for ifindex %d", __func__, mdev->ifindex);
-
-	return w;
+	return mdev ? mdev->worker : NULL;
 }
 
 char *
@@ -522,15 +523,15 @@ ni_managed_state_to_string(ni_managed_state_t state)
 }
 
 /*
- * Look up managed device for a given ifindex
+ * Look up managed device for a given worker
  */
 ni_managed_device_t *
-ni_nanny_get_device_by_ifindex(ni_nanny_t *mgr, unsigned int ifindex)
+ni_nanny_get_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 {
 	ni_managed_device_t *mdev;
 
 	for (mdev = mgr->device_list; mdev; mdev = mdev->next) {
-		if (mdev->ifindex == ifindex)
+		if (mdev->worker == w)
 			return mdev;
 	}
 

--- a/nanny/device.c
+++ b/nanny/device.c
@@ -85,6 +85,7 @@ ni_managed_device_new(ni_nanny_t *mgr, ni_ifworker_t *w, ni_managed_device_t **l
 
 	mdev->nanny = mgr;
 	mdev->worker = ni_ifworker_ref(w);
+	ni_uuid_generate(&mdev->uuid);
 
 	if (list)
 		ni_managed_device_list_append(list, mdev);

--- a/nanny/interface.c
+++ b/nanny/interface.c
@@ -93,6 +93,26 @@ ni_managed_netif_disable(ni_managed_device_t *mdev)
 	mdev->monitor = FALSE;
 	return TRUE;
 }
+/*
+ * Create a dbus object path representing the managed netif.
+ */
+const char *
+ni_objectmodel_create_managed_netif_path(const ni_managed_device_t *mdev, char **path)
+{
+	const char *list = NI_OBJECTMODEL_MANAGED_NETIF_LIST_PATH;
+	ni_ifworker_t *w = ni_managed_device_get_worker(mdev);
+	char uuid[64] = {'\0'};
+
+	if (!path || !w || w->type != NI_IFWORKER_TYPE_NETDEV)
+		return NULL;
+
+	/* dbus path does not support '-' characters used in uuid string */
+	if (ni_format_hex_data(&mdev->uuid.octets[0], sizeof(mdev->uuid),
+			uuid, sizeof(uuid), "", FALSE) != 0)
+		return NULL;
+
+	return ni_string_printf(path, "%s/%s", list, uuid);
+}
 
 /*
  * Create a dbus object representing the managed netdev
@@ -100,19 +120,14 @@ ni_managed_netif_disable(ni_managed_device_t *mdev)
 ni_dbus_object_t *
 ni_objectmodel_register_managed_netif(ni_dbus_server_t *server, ni_managed_device_t *mdev)
 {
-	ni_netdev_t *dev;
-	char relative_path[128];
 	ni_dbus_object_t *object;
-	ni_ifworker_t *w;
+	char *path = NULL;
 
-	if (!(w = ni_managed_device_get_worker(mdev)))
+	if (!ni_objectmodel_create_managed_netif_path(mdev, &path))
 		return NULL;
 
-	if (!(dev = ni_ifworker_get_netdev(w)))
-		return NULL;
-
-	snprintf(relative_path, sizeof(relative_path), "Interface/%u", dev->link.ifindex);
-	object = ni_dbus_server_register_object(server, relative_path, &ni_objectmodel_managed_netif_class, mdev);
+	object = ni_dbus_server_register_object(server, path, &ni_objectmodel_managed_netif_class, mdev);
+	ni_string_free(&path);
 
 	if (object)
 		ni_objectmodel_bind_compatible_interfaces(object);

--- a/nanny/modem.c
+++ b/nanny/modem.c
@@ -47,22 +47,38 @@ ni_objectmodel_managed_modem_init(ni_dbus_server_t *server)
 #endif
 
 /*
+ * Create a dbus object path representing the managed modem
+ */
+const char *
+ni_objectmodel_create_managed_modem_path(const ni_managed_device_t *mdev, char **path)
+{
+	const char *list = NI_OBJECTMODEL_MANAGED_MODEM_LIST_PATH;
+	ni_ifworker_t *w = ni_managed_device_get_worker(mdev);
+	ni_modem_t *modem;
+
+	if (!path || !w || w->type != NI_IFWORKER_TYPE_MODEM)
+		return NULL;
+
+	if (!(modem = ni_ifworker_get_modem(w)))
+		return NULL;
+
+	return ni_string_printf(path, "%s/%s", list, modem->device);
+}
+
+/*
  * Create a dbus object representing the managed modem
  */
 ni_dbus_object_t *
 ni_objectmodel_register_managed_modem(ni_dbus_server_t *server, ni_managed_device_t *mdev)
 {
-	ni_modem_t *modem;
-	char relative_path[128];
 	ni_dbus_object_t *object;
-	ni_ifworker_t *w;
+	char *path = NULL;
 
-	if (!(w = ni_managed_device_get_worker(mdev)))
+	if (!ni_objectmodel_create_managed_modem_path(mdev, &path))
 		return NULL;
 
-	modem = ni_ifworker_get_modem(w);
-	snprintf(relative_path, sizeof(relative_path), "Modem/%s", modem->device);
-	object = ni_dbus_server_register_object(server, relative_path, &ni_objectmodel_managed_modem_class, mdev);
+	object = ni_dbus_server_register_object(server, path, &ni_objectmodel_managed_modem_class, mdev);
+	ni_string_free(&path);
 
 	if (object)
 		ni_objectmodel_bind_compatible_interfaces(object);

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -480,7 +480,7 @@ ni_nanny_register_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 	if (ni_nanny_get_device(mgr, w) != NULL)
 		return;
 
-	if (!(mdev = ni_managed_device_new(mgr, w->ifindex, &mgr->device_list)))
+	if (!(mdev = ni_managed_device_new(mgr, w, &mgr->device_list)))
 		return;
 
 	if (w->type == NI_IFWORKER_TYPE_NETDEV) {

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -470,29 +470,32 @@ ni_managed_device_progress(ni_ifworker_t *w, ni_fsm_state_t new_state)
 /*
  * Register a device
  */
-void
+ni_managed_device_t *
 ni_nanny_register_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 {
 	ni_managed_device_t *mdev;
 	const ni_dbus_class_t *dev_class = NULL;
 	ni_nanny_devmatch_t *match;
 
-	if (ni_nanny_get_device(mgr, w) != NULL)
-		return;
+	if ((mdev = ni_nanny_get_device(mgr, w)))
+		return mdev;
 
 	if (!(mdev = ni_managed_device_new(mgr, w, &mgr->device_list)))
-		return;
+		return NULL;
 
 	if (w->type == NI_IFWORKER_TYPE_NETDEV) {
 		if ((mdev->object = ni_objectmodel_register_managed_netif(mgr->server, mdev)))
-			dev_class = ni_objectmodel_link_class(w->device->link.type);
+			dev_class = w->device ? ni_objectmodel_link_class(w->device->link.type) : NULL;
 	} else
 	if (w->type == NI_IFWORKER_TYPE_MODEM) {
 		if ((mdev->object = ni_objectmodel_register_managed_modem(mgr->server, mdev)))
-			dev_class = ni_objectmodel_modem_get_class(w->modem->type);
+			dev_class = w->modem ? ni_objectmodel_modem_get_class(w->modem->type) : NULL;
 	}
-	if (!mdev->object || !dev_class)
-		return;
+	if (!mdev->object) {
+		ni_nanny_remove_device(mgr, mdev);
+		ni_managed_device_free(mdev);
+		return NULL;
+	}
 
 	for (match = mgr->enable; match; match = match->next) {
 		switch (match->type) {
@@ -523,6 +526,7 @@ ni_nanny_register_device(ni_nanny_t *mgr, ni_ifworker_t *w)
 		ni_nanny_schedule_recheck(&mgr->recheck, w);
 
 	ni_ifworker_set_progress_callback(w, ni_managed_device_progress, mdev);
+	return mdev;
 }
 
 /*

--- a/nanny/nanny.c
+++ b/nanny/nanny.c
@@ -876,7 +876,8 @@ ni_objectmodel_nanny_get_device(ni_dbus_object_t *object, const ni_dbus_method_t
 	ni_nanny_t *mgr;
 	const char *ifname;
 	ni_ifworker_t *w;
-	ni_managed_device_t *mdev = NULL;
+	ni_managed_device_t *mdev;
+	char *path = NULL;
 
 	if ((mgr = ni_objectmodel_nanny_unwrap(object, error)) == NULL)
 		return FALSE;
@@ -887,22 +888,20 @@ ni_objectmodel_nanny_get_device(ni_dbus_object_t *object, const ni_dbus_method_t
 	/* XXX: scalability. Use ni_call_identify_device() */
 	w = ni_fsm_ifworker_by_name(mgr->fsm, NI_IFWORKER_TYPE_NETDEV, ifname);
 
-	if (w)
-		mdev = ni_nanny_get_device(mgr, w);
-
-	if (mdev == NULL) {
+	mdev = ni_nanny_get_device(mgr, w);
+	if (!w || !mdev) {
 		dbus_set_error(error, NI_DBUS_ERROR_DEVICE_NOT_KNOWN, "No such device: %s", ifname);
 		return FALSE;
-	} else {
-		ni_netdev_t *dev = ni_ifworker_get_netdev(w);
-		char object_path[128];
-
-		snprintf(object_path, sizeof(object_path),
-				NI_OBJECTMODEL_MANAGED_NETIF_LIST_PATH "/%u",
-				dev->link.ifindex);
-
-		ni_dbus_message_append_object_path(reply, object_path);
 	}
+
+	if (!ni_objectmodel_create_managed_netif_path(mdev, &path)) {
+		dbus_set_error(error, DBUS_ERROR_FAILED, "Unable to create path for %s", ifname);
+		return FALSE;
+	}
+
+	ni_dbus_message_append_object_path(reply, path);
+	ni_string_free(&path);
+
 	return TRUE;
 }
 

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -135,7 +135,7 @@ extern void			ni_nanny_schedule_recheck(ni_ifworker_array_t *, ni_ifworker_t *);
 extern void			ni_nanny_unschedule(ni_ifworker_array_t *, ni_ifworker_t *);
 extern unsigned int		ni_nanny_recheck_do(ni_nanny_t *mgr);
 extern unsigned int		ni_nanny_down_do(ni_nanny_t *mgr);
-extern void			ni_nanny_register_device(ni_nanny_t *, ni_ifworker_t *);
+extern ni_managed_device_t *	ni_nanny_register_device(ni_nanny_t *, ni_ifworker_t *);
 extern void			ni_nanny_unregister_device(ni_nanny_t *, ni_ifworker_t *);
 extern ni_managed_device_t *	ni_nanny_get_device(ni_nanny_t *, ni_ifworker_t *);
 extern void			ni_nanny_remove_device(ni_nanny_t *, ni_managed_device_t *);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -22,9 +22,9 @@
 #define NI_NANNY_POLICY_BAK	".bak"
 #endif
 
-typedef struct ni_nanny		ni_nanny_t;
-typedef struct ni_managed_device ni_managed_device_t;
-typedef struct ni_managed_policy ni_managed_policy_t;
+typedef struct ni_nanny			ni_nanny_t;
+typedef struct ni_managed_device	ni_managed_device_t;
+typedef struct ni_managed_policy	ni_managed_policy_t;
 
 typedef enum ni_managed_state {
 	NI_MANAGED_STATE_STOPPED,
@@ -42,7 +42,8 @@ struct ni_managed_device {
 
 	ni_nanny_t *		nanny;		// back pointer at mgr
 	ni_dbus_object_t *	object;		// server object
-	unsigned int		ifindex;
+
+	ni_ifworker_t *		worker;		// managed worker (we have config for)
 
 	ni_bool_t		allowed;	// true iff user is allowed to enable it
 	ni_bool_t		monitor;	// true iff we're monitoring it
@@ -136,7 +137,7 @@ extern unsigned int		ni_nanny_recheck_do(ni_nanny_t *mgr);
 extern unsigned int		ni_nanny_down_do(ni_nanny_t *mgr);
 extern void			ni_nanny_register_device(ni_nanny_t *, ni_ifworker_t *);
 extern void			ni_nanny_unregister_device(ni_nanny_t *, ni_ifworker_t *);
-extern ni_managed_device_t *	ni_nanny_get_device_by_ifindex(ni_nanny_t *, unsigned int);
+extern ni_managed_device_t *	ni_nanny_get_device(ni_nanny_t *, ni_ifworker_t *);
 extern void			ni_nanny_remove_device(ni_nanny_t *, ni_managed_device_t *);
 extern ni_managed_policy_t *	ni_nanny_get_policy(ni_nanny_t *, const ni_fsm_policy_t *);
 extern ni_nanny_user_t *	ni_nanny_get_user(ni_nanny_t *, uid_t);
@@ -155,7 +156,7 @@ extern void			ni_managed_netif_up(ni_managed_device_t *, unsigned int);
 extern void			ni_managed_modem_apply_policy(ni_managed_device_t *, ni_managed_policy_t *, ni_fsm_t *);
 extern void			ni_managed_modem_up(ni_managed_device_t *, unsigned int);
 
-extern ni_managed_device_t *	ni_managed_device_new(ni_nanny_t *, unsigned int, ni_managed_device_t **list);
+extern ni_managed_device_t *	ni_managed_device_new(ni_nanny_t *,  ni_ifworker_t *, ni_managed_device_t **list);
 extern void			ni_managed_device_free(ni_managed_device_t *);
 extern ni_ifworker_t *		ni_managed_device_get_worker(const ni_managed_device_t *);
 extern char *			ni_managed_device_get_name(ni_managed_device_t *);
@@ -187,18 +188,5 @@ extern void			ni_objectmodel_managed_netif_init(ni_dbus_server_t *);
 extern void			ni_objectmodel_managed_modem_init(ni_dbus_server_t *);
 #endif
 extern void			ni_objectmodel_managed_policy_init(ni_dbus_server_t *);
-
-/*
- * Look up managed device for a given worker
- */
-
-/*
- * Look up managed device for a given worker
- */
-static inline ni_managed_device_t *
-ni_nanny_get_device(ni_nanny_t *mgr, ni_ifworker_t *w)
-{
-	return w ? ni_nanny_get_device_by_ifindex(mgr, w->ifindex) : NULL;
-}
 
 #endif /* __WICKED_MANAGER_H__ */

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -43,6 +43,7 @@ struct ni_managed_device {
 	ni_nanny_t *		nanny;		// back pointer at mgr
 	ni_dbus_object_t *	object;		// server object
 
+	ni_uuid_t		uuid;		// opaque dbus object id stored in uuid
 	ni_ifworker_t *		worker;		// managed worker (we have config for)
 
 	ni_bool_t		allowed;	// true iff user is allowed to enable it
@@ -174,6 +175,7 @@ extern uid_t			ni_managed_policy_owner(const ni_managed_policy_t *);
 
 extern const char *		ni_managed_state_to_string(ni_managed_state_t);
 
+extern const char *		ni_objectmodel_create_managed_netif_path(const ni_managed_device_t *, char **);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_netif(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_modem(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_policy(ni_dbus_server_t *, ni_managed_policy_t *);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -176,6 +176,7 @@ extern uid_t			ni_managed_policy_owner(const ni_managed_policy_t *);
 extern const char *		ni_managed_state_to_string(ni_managed_state_t);
 
 extern const char *		ni_objectmodel_create_managed_netif_path(const ni_managed_device_t *, char **);
+extern const char *		ni_objectmodel_create_managed_modem_path(const ni_managed_device_t *, char **);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_netif(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_modem(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_policy(ni_dbus_server_t *, ni_managed_policy_t *);

--- a/nanny/nanny.h
+++ b/nanny/nanny.h
@@ -177,6 +177,7 @@ extern const char *		ni_managed_state_to_string(ni_managed_state_t);
 
 extern const char *		ni_objectmodel_create_managed_netif_path(const ni_managed_device_t *, char **);
 extern const char *		ni_objectmodel_create_managed_modem_path(const ni_managed_device_t *, char **);
+extern const char *		ni_objectmodel_create_managed_policy_path(const ni_managed_policy_t *, char **);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_netif(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_modem(ni_dbus_server_t *, ni_managed_device_t *);
 extern ni_dbus_object_t *	ni_objectmodel_register_managed_policy(ni_dbus_server_t *, ni_managed_policy_t *);

--- a/nanny/policy.c
+++ b/nanny/policy.c
@@ -269,17 +269,42 @@ ni_managed_policy_register(ni_nanny_t *mgr, ni_fsm_policy_t *policy)
 }
 
 /*
- * Create a dbus object representing the managed netdev
+ * Create a dbus object path representing the managed policy
+ */
+const char *
+ni_objectmodel_create_managed_policy_path(const ni_managed_policy_t *mpolicy, char **path)
+{
+	const char *list = NI_OBJECTMODEL_MANAGED_POLICY_LIST_PATH;
+	const char *name;
+
+	if (!mpolicy || !mpolicy->fsm_policy || !path)
+		return NULL;
+
+	/*
+	 * Note: **currently**, the name is already encoded for dbus path;
+	 *       -> we should add e.g. a ni_fsm_policy_path function ...
+	 */
+	if (!(name = ni_fsm_policy_name(mpolicy->fsm_policy)))
+		return NULL;
+
+	return ni_string_printf(path, "%s/%s", list, name);
+}
+
+/*
+ * Create a dbus object representing the managed policy
  */
 ni_dbus_object_t *
 ni_objectmodel_register_managed_policy(ni_dbus_server_t *server, ni_managed_policy_t *mpolicy)
 {
-	char relative_path[128];
 	ni_dbus_object_t *object;
+	char *path = NULL;
 
-	snprintf(relative_path, sizeof(relative_path), "Policy/%s",
-					ni_fsm_policy_name(mpolicy->fsm_policy));
-	object = ni_dbus_server_register_object(server, relative_path, &ni_objectmodel_managed_policy_class, mpolicy);
+	if (!ni_objectmodel_create_managed_policy_path(mpolicy, &path))
+		return NULL;
+
+	object = ni_dbus_server_register_object(server, path, &ni_objectmodel_managed_policy_class, mpolicy);
+	ni_string_free(&path);
+
 	if (object)
 		ni_objectmodel_bind_compatible_interfaces(object);
 	return object;


### PR DESCRIPTION
The network interface (and ifindex) referenced by the managed-netif
object may not exist yet or any more, but we have config for and we
wait until it (re-)appears or until we can (re-)create it.
Use an "opaque" id instead of ifindex for dbus path to managed-netif.