### PR TITLE
xpath: fix gcc-15.x assignment discards 'const' warning

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -248,7 +248,11 @@ handle_name_or_axis:
 
 			if (ops != NULL) {
 				/* Okay, we've been using a shorthand identifier */;
-			} else if ((colons = strstr(ident, "::")) != NULL) {
+			} else if ((colons = (char *)strstr(ident, "::")) != NULL) {
+				/*
+				 * Note: colons points directly into the writable
+				 *       static char identbuf[...] passed via ident.
+				 */
 				*colons = '\0';
 				ops = xpath_get_axis_ops(ident);
 				if (!ops) {


### PR DESCRIPTION
Fix a discarded-qualifiers warning when assigning `strstr(ident, ...)`
to a mutable `char *colons`, where `ident` is const.
    
Explicitly cast to `(char *)` since the underlying buffer is writable.

See also:
- https://github.com/openSUSE/wicked/pull/1073
- https://github.com/openSUSE/wicked/pull/1072